### PR TITLE
feat: Show link to diff after `craft release`

### DIFF
--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -438,6 +438,12 @@ export const handler = async (argv: ReleaseOptions) => {
     if (argv.publish) {
       await execPublish(newVersion);
     } else {
+      logger.info(
+        `View diff at: https://github.com/${githubConfig.owner}/${
+          githubConfig.repo
+        }/compare/${branchName}`
+      );
+
       logger.success(
         'Done. Do not forget to run "craft publish" to publish the artifacts:',
         `  $ craft publish ${newVersion}`


### PR DESCRIPTION
Adds a link to the GitHub compare interface to make it easier to visually
compare changes performed by craft.

```
 $ craft release --no-changelog 5.1.1
...
ℹ info Pushing the release branch "release/5.1.1"...
ℹ info View diff at: https://github.com/getsentry/symbolic/compare/release/5.1.1
✔ success Done. Do not forget to run "craft publish" to publish the artifacts:
    $ craft publish 5.1.1
```