### PR TITLE
Allow empty preReleaseCommand

### DIFF
--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -206,7 +206,7 @@ export async function runPreReleaseCommand(
 ): Promise<void> {
   let sysCommand: string;
   let args: string[];
-  if (preReleaseCommand === '') {
+  if (preReleaseCommand && preReleaseCommand.length === 0) {
     // Not running pre-release command
     logger.warn('Not running the pre-release command: no command specified');
     return;
@@ -461,6 +461,8 @@ export async function releaseMain(argv: ReleaseOptions): Promise<any> {
   const branchName = await createReleaseBranch(git, newVersion);
 
   // Run a pre-release script (e.g. for version bumping)
+  console.log('ahahahaha');
+  console.log(config.preReleaseCommand);
   await runPreReleaseCommand(newVersion, config.preReleaseCommand);
 
   // Commit the pending changes

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -203,13 +203,13 @@ async function commitNewVersion(
 export async function runPreReleaseCommand(
   newVersion: string,
   preReleaseCommand?: string
-): Promise<void> {
+): Promise<boolean> {
   let sysCommand: string;
   let args: string[];
-  if (preReleaseCommand && preReleaseCommand.length === 0) {
+  if (preReleaseCommand !== undefined && preReleaseCommand.length === 0) {
     // Not running pre-release command
     logger.warn('Not running the pre-release command: no command specified');
-    return;
+    return false;
   } else if (preReleaseCommand) {
     [sysCommand, ...args] = shellQuote.parse(preReleaseCommand);
   } else {
@@ -225,6 +225,7 @@ export async function runPreReleaseCommand(
   await spawnProcess(sysCommand, args, {
     env: { ...process.env, ...additionalEnv },
   });
+  return true;
 }
 
 /**
@@ -461,12 +462,17 @@ export async function releaseMain(argv: ReleaseOptions): Promise<any> {
   const branchName = await createReleaseBranch(git, newVersion);
 
   // Run a pre-release script (e.g. for version bumping)
-  console.log('ahahahaha');
-  console.log(config.preReleaseCommand);
-  await runPreReleaseCommand(newVersion, config.preReleaseCommand);
+  const preReleaseCommandRan = await runPreReleaseCommand(
+    newVersion,
+    config.preReleaseCommand
+  );
 
-  // Commit the pending changes
-  await commitNewVersion(git, newVersion);
+  if (preReleaseCommandRan) {
+    // Commit the pending changes
+    await commitNewVersion(git, newVersion);
+  } else {
+    logger.info('Not commiting anything since preReleaseCommand is empty.');
+  }
 
   // Push the release branch
   await pushReleaseBranch(git, branchName, !argv.noPush);


### PR DESCRIPTION
This will no longer print the error
```
⚠ warn Not running the pre-release command: no command specified
✖ error Error: Nothing to commit: has the pre-release command done its job?
```
if the `preReleaseCommand` is defined as empty string.