### PR TITLE
feat: Ignore date for gh release title in changelog

### DIFF
--- a/src/utils/__tests__/changes.test.ts
+++ b/src/utils/__tests__/changes.test.ts
@@ -10,6 +10,25 @@ test('extracts a single change', () => {
   expect(changes).toEqual({ name, body });
 });
 
+test('ignore date in parentheses', () => {
+  const name = 'Version 1.0.0';
+  const body = 'this is a test';
+
+  const markdown = `# Changelog
+  ## 1.0.1
+  newer
+
+  ## ${name} (2019-02-02)
+  ${body}
+
+  ## 0.9.0
+  older
+  `;
+
+  const changes = findChangeset(markdown, 'v1.0.0');
+  expect(changes).toEqual({ name, body });
+});
+
 test('extracts a change between headings', () => {
   const name = 'Version 1.0.0';
   const body = 'this is a test';

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -36,7 +36,7 @@ export function extractChangeset(
   const start = header.index + header[0].length;
   const end = nextHeader ? nextHeader.index : undefined;
   const body = markdown.substring(start, end).trim();
-  const name = (header[1] || header[2]).trim();
+  const name = (header[1] || header[2]).replace(/(\(.*\))$/, '').trim();
   return { name, body };
 }
 

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -36,7 +36,7 @@ export function extractChangeset(
   const start = header.index + header[0].length;
   const end = nextHeader ? nextHeader.index : undefined;
   const body = markdown.substring(start, end).trim();
-  const name = (header[1] || header[2]).replace(/(\(.*\))$/, '').trim();
+  const name = (header[1] || header[2]).replace(/\(.*\)$/, '').trim();
   return { name, body };
 }
 


### PR DESCRIPTION
We have the date in the changelog file in the PHP repo. It makes sense in the file itself but not that it's pasted in the GH title imho.