### PR TITLE
feat(crates): Clone with submodules before publishing

### DIFF
--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -205,9 +205,13 @@ export class CratesTarget extends BaseTarget {
     version: string,
     directory: string
   ): Promise<any> {
+    const { owner, repo } = config;
     const git = simpleGit(directory).silent(true);
-    const url = `https://github.com/${config.owner}/${config.repo}.git`;
-    const opts = [`-b`, `release/${version}`, '--depth=1', '--recurse'];
+    const url = `https://github.com/${owner}/${repo}.git`;
+    const branch = `release/${version}`;
+    const opts = [`-b`, branch, '--depth=1', '--recurse'];
+
+    logger.info(`Downloading sources for ${owner}/${repo}:${branch}`);
     return git.clone(url, directory, opts);
   }
 


### PR DESCRIPTION
Instead of downloading a source tarball from GitHub, clone the release branch with submodules instead. This allows to publish crates like `symbolic` that depend on shipping code from submodules.

Noteworthy points:
 - This performs a **shallow clone** (`--depth=1`) to reduce the time this takes.
 - There is no straight-forward option to directly shallow clone an arbitrary commit SHA, so instead this clones the release branch. Since the branch is checked against Zeus immediately beforehand, we can assume that the branch head revision matches.
 - The clone is performed with `--recurse`, which initializes submodules. If the repository does not specify shallow submodules, this might take quite a while, but that is out of scope of this PR. We could pass `--shalllow-submodules`, but that comes with a bunch of other implications, so I'd rather keep that simple. `symbolic` only has shallow references, for instance. 
