### PR TITLE
feat/fix: Add tag next for npm prereleases

### DIFF
--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -9,7 +9,7 @@ import { TargetConfig } from '../schemas/project_config';
 import { ZeusStore } from '../stores/zeus';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { hasExecutable, spawnProcess } from '../utils/system';
-import { parseVersion } from '../utils/version';
+import { isPreviewRelease, parseVersion } from '../utils/version';
 import { BaseTarget } from './base';
 
 const logger = loggerRaw.withScope('[npm]');
@@ -180,6 +180,14 @@ export class NpmTarget extends BaseTarget {
         // it can be left blank
         args.push(`--access=${this.npmConfig.access}`);
       }
+    }
+
+    // In case we have a prerelease, there should never be a reason to publish
+    // it with the latest tag in npm.
+    if (isPreviewRelease(options.version)) {
+      logger.warn('Detected pre-release version for npm package!');
+      logger.warn('Adding tag "next" to not make it "latest" default install.');
+      args.push(`--tag=next`);
     }
 
     // Pass OTP if configured

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -186,8 +186,8 @@ export class NpmTarget extends BaseTarget {
     // it with the latest tag in npm.
     if (isPreviewRelease(options.version)) {
       logger.warn('Detected pre-release version for npm package!');
-      logger.warn('Adding tag "next" to not make it "latest" default install.');
-      args.push(`--tag=next`);
+      logger.warn('Adding tag "next" to not make it "latest" in registry.');
+      args.push('--tag=next');
     }
 
     // Pass OTP if configured


### PR DESCRIPTION
We published `@sentry/*` with `5.0.0-beta1` & `5.0.0-beta.2` to the npm registry.
Apparently, npm needs a tag with `--tag=next` to not make it `latest` which means it will be the default when doing `npm install @sentry/browser` for example.

Without `--tag=next` you would get the highest version, in our case `5.0.0-beta.2`.
We actually never ever want this to happen (imho) that's why I added this check to make sure we always add `--tag=next` in case it's a pre-release version.

We had to unpublish both version from npm 😞 