### PR TITLE
ref(README): Clarify GitHub project parameter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,12 +216,12 @@ located in the project root.
 
 ### GitHub project
 
-One of the required settings you need to specify is GitHub project parameters:
+One of the required settings you need to specify is GitHub project parameters. For example:
 
 ```yaml
 github:
   owner: getsentry
-  repo: craft
+  repo: sentry-javascript
 ```
 
 ### Pre-release Command


### PR DESCRIPTION
As a naive reader of this doc, it wasn't obvious to me that the GitHub params needed to point to the repo for the package you want to release, rather than always pointing to the `craft` repo. This hopefully clarifies that.