### PR TITLE
fix(vscode): Update extension recommendation for tslint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,9 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["esbenp.prettier-vscode", "eg2.tslint", "stkb.rewrap"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "ms-vscode.vscode-typescript-tslint-plugin",
+    "stkb.rewrap"
+  ]
 }


### PR DESCRIPTION
We currently recommend [this version](https://marketplace.visualstudio.com/items?itemName=eg2.tslint), which has been deprecated in favor of [this one](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin).