### PR TITLE
 feat: Use artifact provider for publishing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ then enforces a specific workflow for managing release branches, changelogs, art
   - [Changelog Policies](#changelog-policies)
   - [Minimal Version](#minimal-version)
   - [Required Files](#required-files)
+- [Status Provider](#status-provider)
+- [Artifact Provider](#artifact-provider)
 - [Target Configurations](#target-configurations)
   - [Per-target options](#per-target-options)
   - [GitHub (`github`)](#github-github)
@@ -166,7 +168,7 @@ Options:
 ### `craft publish`: Publishing the Release
 
 The command will find a release branch for the provided version (tag) and
-publish the existing artifacts from Zeus to configured targets.
+publish the existing artifacts from the configured artifact provider to selected targets.
 
 ```plain
 craft publish NEW-VERSION
@@ -303,6 +305,48 @@ to ensure that we're not trying to do an incomplete release.
 requireNames:
   - /^sentry-craft.*\.tgz$/
   - /^gh-pages.zip$/
+```
+
+## Status Provider
+
+You can configure which status providers `craft` will use to check for your build status.
+By default, it will take Zeus but you can also use GitHub directly.
+This is helpful if you don't want to rely on Zeus for asking if you build is green or not.
+
+**Configuration**
+
+| Option   | Description                                                                                        |
+| -------- | -------------------------------------------------------------------------------------------------- |
+| `name`   | Name of the status provider: either `zeus` (default) or `github`                                   |
+| `config` | In case of `github`: may include `contexts` key that contains a list of required contexts (checks) |
+
+**Example:**
+
+```yaml
+statusProvider:
+  name: github
+  config:
+    contexts:
+      - Travis CI - Branch
+```
+
+## Artifact Provider
+
+You can configure which artifact providers `craft` will use to fetch artifacts from.
+By default, Zeus is used, but in case you don't need use any artifacts in your
+project, you can set it to `none`.
+
+**Configuration**
+
+| Option | Description                                                      |
+| ------ | ---------------------------------------------------------------- |
+| `name` | Name of the artifact provider: can be `zeus` (default) or `none` |
+
+**Example:**
+
+```yaml
+statusProvider:
+  name: none
 ```
 
 ## Target Configurations
@@ -685,25 +729,6 @@ The `cocoapods` gem must be installed on the system.
 targets:
   - name: cocoapods
     specPath: MyProject.podspec
-```
-
-### Status Provider
-
-You can configure which status providers `craft` will to check for your build status.
-By default it will take Zeus but you can also use Github directly.
-This is helpful if you don't want to rely on Zeus for asking if you build is green or not.
-
-**Configuration**
-
-| Option | Description                                                      |
-| ------ | ---------------------------------------------------------------- |
-| `name` | Name of the `statusProvider` either `zeus` (default) or `github` |
-
-**Example:**
-
-```yaml
-statusProvider:
-  name: github
 ```
 
 ## Integrating Your Project with `craft`

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "shell-quote": "1.6.1",
     "simple-git": "1.131.0",
     "split": "1.0.1",
-    "string-length": "3.0.0",
+    "string-length": "3.1.0",
     "tar": "4.4.8",
     "tmp": "0.1.0",
     "unzipper": "0.9.7",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "shell-quote": "1.6.1",
     "simple-git": "1.131.0",
     "split": "1.0.1",
+    "string-length": "3.0.0",
     "tar": "4.4.8",
     "tmp": "0.1.0",
     "unzipper": "0.9.7",

--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -84,6 +84,7 @@ export abstract class BaseArtifactProvider {
     clearObjectProperties(this.fileListCache);
     clearObjectProperties(this.checksumCache);
   }
+
   /**
    * Downloads the given artifact file.
    *
@@ -116,13 +117,17 @@ export abstract class BaseArtifactProvider {
     return promise;
   }
 
-  /** TODO */
+  /**
+   * Downloads the given artifact file (without caching)
+   */
   protected abstract async doDownloadArtifact(
     artifact: CraftArtifact,
     downloadDirectory: string
   ): Promise<string>;
 
-  /** TODO */
+  /**
+   * Downloads multiple artifacts to the given directory
+   */
   public async downloadArtifacts(
     artifacts: CraftArtifact[],
     downloadDirectory?: string
@@ -139,6 +144,7 @@ export abstract class BaseArtifactProvider {
    *
    * If there are several artifacts with the same name, returns the most recent
    * of them.
+   * The results are cached.
    *
    * @param revision Git commit id
    * @returns Filtered list of artifacts, or "undefined" if the revision can not be found
@@ -171,7 +177,9 @@ export abstract class BaseArtifactProvider {
     return dedupedArtifacts;
   }
 
-  /** TODO */
+  /**
+   * List artifacts for the given revision (without caching)
+   */
   protected abstract async doListArtifactsForRevision(
     revision: string
   ): Promise<CraftArtifact[] | undefined>;

--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -7,8 +7,11 @@ import { clearObjectProperties } from '../utils/objects';
 import * as _ from 'lodash';
 import { ConfigurationError } from '../utils/errors';
 
+/** Maximum concurrency for downloads */
+export const MAX_DOWNLOAD_CONCURRENCY = 5;
+
 /**
- * TODO
+ * A generic artifact interface
  */
 export interface CraftArtifact {
   download_url: string;
@@ -31,7 +34,9 @@ export interface FilterOptions {
   excludeNames?: RegExp;
 }
 
-/** TODO */
+/**
+ * Base interface for artifact providers.
+ */
 export abstract class BaseArtifactProvider {
   /** URL cache for downloaded files */
   protected readonly downloadCache: {
@@ -174,7 +179,7 @@ export abstract class BaseArtifactProvider {
   /**
    * Returns the calculated hash digest for the given artifact
    *
-   * The results are cached using the cache object attached to the ZeusStore instance.   *
+   * The results are cached.
    *
    * @param artifact Artifact we want to compute hash for
    * @param algorithm Hash algorithm

--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -1,0 +1,28 @@
+import {
+  BaseArtifactProvider,
+  CraftArtifact,
+} from '../artifact_providers/base';
+
+/**
+ * Empty artifact provider that does nothing.
+ */
+export class NoneArtifactProvider extends BaseArtifactProvider {
+  /**
+   * This method should not be called by user code.
+   */
+  public async doDownloadArtifact(
+    _artifact: CraftArtifact,
+    _downloadDirectory?: string
+  ): Promise<string> {
+    return Promise.reject('NoneProvider does not suuport file downloads!');
+  }
+
+  /**
+   * Empty provider does not have any artifacts.
+   */
+  protected async doListArtifactsForRevision(
+    _revision: string
+  ): Promise<CraftArtifact[] | undefined> {
+    return [];
+  }
+}

--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -12,7 +12,7 @@ export class NoneArtifactProvider extends BaseArtifactProvider {
    */
   public async doDownloadArtifact(
     _artifact: CraftArtifact,
-    _downloadDirectory?: string
+    _downloadDirectory: string
   ): Promise<string> {
     return Promise.reject('NoneProvider does not suuport file downloads!');
   }

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -7,7 +7,9 @@ import {
 import { logger } from '../logger';
 
 /**
- * TODO
+ * Zeus artifact provider
+ *
+ * Artifacts have to be uploaded to Zeus via "zeus-cli" command line tool.
  */
 export class ZeusArtifactProvider extends BaseArtifactProvider {
   /** Zeus API client */
@@ -38,11 +40,12 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
    * file is downloaded only once.
    *
    * @param artifact An artifact object to download
+   * @param downloadDirectory Directory where downloaded artifact is stored
    * @returns Absolute path to the saved file
    */
   public async doDownloadArtifact(
     artifact: CraftArtifact,
-    downloadDirectory?: string
+    downloadDirectory: string
   ): Promise<string> {
     // TODO fix some of these attributes
     return this.client.downloadArtifact(
@@ -57,7 +60,11 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
     );
   }
 
-  /** TODO */
+  /**
+   * List artifacts for the given revision
+   *
+   * @param revision revision id (its SHA)
+   */
   protected async doListArtifactsForRevision(
     revision: string
   ): Promise<CraftArtifact[] | undefined> {

--- a/src/commands/artifacts.ts
+++ b/src/commands/artifacts.ts
@@ -4,7 +4,9 @@ export const command = ['artifacts'];
 export const aliases = ['a', 'artifact'];
 export const description = '📦 Manage artifacts';
 
-/** TODO */
+/**
+ * Common options for `artifacts` commands
+ */
 export interface ArtifactsOptions {
   rev: string;
 }

--- a/src/commands/artifacts_cmds/download.ts
+++ b/src/commands/artifacts_cmds/download.ts
@@ -65,7 +65,9 @@ async function prepareOutputDirectory(
   }
 }
 
-/** TODO */
+/**
+ * Body of 'artifacts download' command
+ */
 async function handlerMain(argv: ArtifactsDownloadOptions): Promise<any> {
   // FIXME move elsewhere
   process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;
@@ -115,7 +117,9 @@ async function handlerMain(argv: ArtifactsDownloadOptions): Promise<any> {
   }
 }
 
-/** TODO */
+/**
+ * Main command handler
+ */
 export async function handler(argv: ArtifactsDownloadOptions): Promise<any> {
   try {
     return await handlerMain(argv);

--- a/src/commands/artifacts_cmds/download.ts
+++ b/src/commands/artifacts_cmds/download.ts
@@ -7,6 +7,7 @@ import { Argv } from 'yargs';
 import { resolve } from 'path';
 import { existsSync, lstatSync } from 'fs';
 import mkdirp = require('mkdirp');
+import { NoneArtifactProvider } from '../../artifact_providers/none';
 
 export const command = ['download [NAME..]'];
 export const aliases = ['d', 'get'];
@@ -76,7 +77,7 @@ async function handlerMain(argv: ArtifactsDownloadOptions): Promise<any> {
   const revision = argv.rev;
 
   const artifactProvider = getArtifactProviderFromConfig();
-  if (!artifactProvider) {
+  if (artifactProvider instanceof NoneArtifactProvider) {
     logger.warn(
       `Artifact provider is disabled in the configuration, nothing to do.`
     );

--- a/src/commands/artifacts_cmds/list.ts
+++ b/src/commands/artifacts_cmds/list.ts
@@ -9,7 +9,9 @@ export const command = ['list'];
 export const aliases = ['l'];
 export const description = 'List artifacts';
 
-/** TODO */
+/**
+ * Body of 'artifacts list' command
+ */
 async function handlerMain(argv: ArtifactsOptions): Promise<any> {
   // FIXME move elsewhere
   process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;
@@ -54,7 +56,7 @@ async function handlerMain(argv: ArtifactsOptions): Promise<any> {
   return argv.rev;
 }
 
-/** TODO */
+/** Main command handler */
 export async function handler(argv: ArtifactsOptions): Promise<any> {
   try {
     return await handlerMain(argv);

--- a/src/commands/artifacts_cmds/list.ts
+++ b/src/commands/artifacts_cmds/list.ts
@@ -3,6 +3,7 @@ import { ArtifactsOptions } from '../artifacts';
 import { getArtifactProviderFromConfig } from '../../config';
 import { handleGlobalError } from '../../utils/errors';
 import { formatSize } from '../../utils/strings';
+import { NoneArtifactProvider } from '../../artifact_providers/none';
 
 export const command = ['list'];
 export const aliases = ['l'];
@@ -16,7 +17,7 @@ async function handlerMain(argv: ArtifactsOptions): Promise<any> {
   const revision = argv.rev;
 
   const artifactProvider = getArtifactProviderFromConfig();
-  if (!artifactProvider) {
+  if (artifactProvider instanceof NoneArtifactProvider) {
     logger.warn(
       `Artifact provider is disabled in the configuration, nothing to do.`
     );

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -2,6 +2,8 @@ import * as Github from '@octokit/rest';
 import { shouldPerform } from 'dryrun';
 import * as inquirer from 'inquirer';
 import { Arguments, Argv } from 'yargs';
+import chalk from 'chalk';
+import stringLength from 'string-length';
 
 import {
   checkMinimalConfigVersion,
@@ -175,8 +177,10 @@ async function publishToTargets(
 
     // Publish all the targets
     for (const target of targetList) {
-      const publishMessage = `=== Publishing to target: "${target.name}" ===`;
-      const delim = Array(publishMessage.length + 1).join('=');
+      const publishMessage = `=== Publishing to target: ${chalk.bold(
+        chalk.cyan(target.name)
+      )} ===`;
+      const delim = Array(stringLength(publishMessage) + 1).join('=');
       logger.info(' ');
       logger.info(delim);
       logger.info(publishMessage);
@@ -434,9 +438,9 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
   logger.debug('Revision to publish: ', revision);
 
   const statusProvider = getStatusProviderFromConfig();
-  const artifactProvider = getArtifactProviderFromConfig();
-
   logger.info(`Using "${statusProvider.constructor.name}" for status checks`);
+  const artifactProvider = getArtifactProviderFromConfig();
+  logger.info(`Using "${artifactProvider.constructor.name}" for artifacts`);
 
   // Check status of all CI builds linked to the revision
   await checkRevisionStatus(statusProvider, revision, argv.noStatusCheck);

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -3,7 +3,7 @@ import { shouldPerform } from 'dryrun';
 import * as inquirer from 'inquirer';
 import { Arguments, Argv } from 'yargs';
 import chalk from 'chalk';
-import stringLength from 'string-length';
+import * as stringLength from 'string-length';
 
 import {
   checkMinimalConfigVersion,

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -7,10 +7,10 @@ import {
   checkMinimalConfigVersion,
   getConfiguration,
   getStatusProviderFromConfig,
+  getArtifactProviderFromConfig,
 } from '../config';
 import { formatTable, logger } from '../logger';
 import { GithubGlobalConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
 import { getAllTargetNames, getTargetByName, SpecialTarget } from '../targets';
 import { BaseTarget } from '../targets/base';
 import {
@@ -27,7 +27,7 @@ import { formatSize, formatJson } from '../utils/strings';
 import { catchKeyboardInterrupt } from '../utils/system';
 import { isValidVersion } from '../utils/version';
 import { BaseStatusProvider } from '../status_providers/base';
-import { ZeusStatusProvider } from '../status_providers/zeus';
+import { BaseArtifactProvider } from '../artifact_providers/base';
 
 export const command = ['publish NEW-VERSION'];
 export const aliases = ['pp', 'publish'];
@@ -140,21 +140,17 @@ function checkVersion(argv: Arguments<any>, _opt: any): any {
  * @param keepDownloads If "true", downloaded files will not be removed
  */
 async function publishToTargets(
-  githubConfig: GithubGlobalConfig,
   version: string,
   revision: string,
   targetConfigList: any[],
+  artifactProvider: BaseArtifactProvider,
   keepDownloads: boolean = false
 ): Promise<void> {
   let downloadDirectoryPath;
 
   await withTempDir(async (downloadDirectory: string) => {
     downloadDirectoryPath = downloadDirectory;
-    const store = new ZeusStore(
-      githubConfig.owner,
-      githubConfig.repo,
-      downloadDirectory
-    );
+    artifactProvider.setDownloadDirectory(downloadDirectoryPath);
     const targetList: BaseTarget[] = [];
 
     // Initialize all targets first
@@ -169,7 +165,7 @@ async function publishToTargets(
         continue;
       }
       try {
-        const target = new targetClass(targetConfig, store);
+        const target = new targetClass(targetConfig, artifactProvider);
         targetList.push(target);
       } catch (e) {
         logger.error('Error creating target instance!');
@@ -200,15 +196,15 @@ async function publishToTargets(
 /**
  * Prints summary for the revision, including available artifacts
  *
- * @param zeus Zeus store object
+ * @param artifactProvider Artifact provider instance
  * @param revision Git revision SHA
  */
 async function printRevisionSummary(
-  zeus: ZeusStore,
+  artifactProvider: BaseArtifactProvider,
   revision: string
 ): Promise<void> {
-  const artifacts = await zeus.listArtifactsForRevision(revision);
-  if (artifacts.length > 0) {
+  const artifacts = await artifactProvider.listArtifactsForRevision(revision);
+  if (artifacts && artifacts.length > 0) {
     const artifactData = artifacts.map(ar => [
       ar.name,
       formatSize(ar.file.size),
@@ -223,8 +219,10 @@ async function printRevisionSummary(
       artifactData
     );
     logger.info(`Available artifacts: \n${table.toString()}\n`);
+  } else if (!artifacts) {
+    throw new Error(`Revision ${revision} not found!`);
   } else {
-    logger.warn('No artifacts found for the release.');
+    logger.warn('No artifacts found for the revision.');
   }
 }
 
@@ -266,7 +264,7 @@ async function promptConfirmation(): Promise<void> {
  * @param requiredNames A list of patterns that all have to match
  */
 async function checkRequiredArtifacts(
-  zeus: ZeusStore,
+  artifactProvider: BaseArtifactProvider,
   revision: string,
   requiredNames?: string[]
 ): Promise<void> {
@@ -274,7 +272,11 @@ async function checkRequiredArtifacts(
     return;
   }
   logger.debug('Checking that the required artifact names are present...');
-  const artifacts = await zeus.listArtifactsForRevision(revision);
+  const artifacts = await artifactProvider.listArtifactsForRevision(revision);
+  if (!artifacts) {
+    throw new Error(`Revision ${revision} not found!`);
+  }
+
   for (const nameRegexString of requiredNames) {
     const nameRegex = stringToRegexp(nameRegexString);
     const matchedArtifacts = artifacts.filter(artifact =>
@@ -431,10 +433,8 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
   }
   logger.debug('Revision to publish: ', revision);
 
-  // TODO: This needs to become optional
-  const zeus = new ZeusStore(githubConfig.owner, githubConfig.repo);
-
   const statusProvider = getStatusProviderFromConfig();
+  const artifactProvider = getArtifactProviderFromConfig();
 
   logger.info(`Using "${statusProvider.constructor.name}" for status checks`);
 
@@ -471,12 +471,12 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
       return undefined;
     }
 
-    // TODO: Handle new Artifacts stores
-    // We only ask Zeus now for artifacts
-    if (statusProvider instanceof ZeusStatusProvider) {
-      await printRevisionSummary(zeus, revision);
-      await checkRequiredArtifacts(zeus, revision, config.requireNames);
-    }
+    await printRevisionSummary(artifactProvider, revision);
+    await checkRequiredArtifacts(
+      artifactProvider,
+      revision,
+      config.requireNames
+    );
 
     logger.info('Publishing to targets:');
 
@@ -489,10 +489,10 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
     await promptConfirmation();
 
     await publishToTargets(
-      githubConfig,
       newVersion,
       revision,
       targetConfigList,
+      artifactProvider,
       argv.keepDownloads
     );
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ import { ZeusArtifactProvider } from './artifact_providers/zeus';
 import { ZeusStatusProvider } from './status_providers/zeus';
 import { GithubStatusProvider } from './status_providers/github';
 import { BaseStatusProvider } from './status_providers/base';
+import { NoneArtifactProvider } from './artifact_providers/none';
 
 // TODO support multiple configuration files (one per configuration)
 export const CONFIG_FILE_NAME = '.craft.yml';
@@ -319,9 +320,7 @@ export function readEnvironmentConfig(
  * @returns An instance of artifact provider, or "undefined" if the artifact
  * provider is disabled.
  */
-export function getArtifactProviderFromConfig():
-  | BaseArtifactProvider
-  | undefined {
+export function getArtifactProviderFromConfig(): BaseArtifactProvider {
   const config = getConfiguration() || {};
   const githubConfig = config.github;
 
@@ -332,11 +331,11 @@ export function getArtifactProviderFromConfig():
   const statusProviderName = rawStatusProvider.name;
 
   switch (statusProviderName) {
-    case ArtifactProviderName.None:
-      return undefined;
-    case undefined: // Zeus is default at the moment
+    case undefined: // Zeus is the default at the moment
     case ArtifactProviderName.Zeus:
       return new ZeusArtifactProvider(githubConfig.owner, githubConfig.repo);
+    case ArtifactProviderName.None:
+      return new NoneArtifactProvider();
     default: {
       throw new ConfigurationError('Invalid artifact provider');
     }

--- a/src/status_providers/base.ts
+++ b/src/status_providers/base.ts
@@ -13,18 +13,22 @@ const BUILD_STATUS_POLLING_MAX = 60 * 60;
 const BUILD_POLLING_INTERVAL = 30;
 
 /**
- * TODO
+ * Allowed commit statuses that status providers may report
  */
 export enum CommitStatus {
-  /** TODO */
+  /** Commit is still being tested/checked/etc. */
   PENDING = 'pending',
-  /** TODO */
+  /** All required commit checks have passed successfully */
   SUCCESS = 'success',
-  /** TODO */
+  /** One or more commit checks failed */
   FAILURE = 'failure',
-  /** TODO */
+  /** Commit could not be found */
   NOT_FOUND = 'not_found',
 }
+
+/** Repository information */
+// tslint:disable-next-line:no-empty-interface
+export interface RepositoryInfo {}
 
 /**
  * Base class for commit status providers
@@ -32,13 +36,17 @@ export enum CommitStatus {
 export abstract class BaseStatusProvider {
   public config: any;
 
-  /** TODO */
+  /**
+   * Gets a status for the given revision
+   *
+   * @param revision Revision SHA
+   */
   public abstract async getRevisionStatus(
     revision: string
   ): Promise<CommitStatus>;
 
   /** TODO */
-  public abstract async getRepositoryInfo(): Promise<any>;
+  public abstract async getRepositoryInfo(): Promise<RepositoryInfo>;
 
   /**
    * Waits for the builds to finish for the revision
@@ -80,7 +88,6 @@ export abstract class BaseStatusProvider {
       }
 
       if (firstIteration) {
-        firstIteration = false;
         if (status !== CommitStatus.NOT_FOUND) {
           logger.info(`Revision ${revision} has been found.`);
         }
@@ -91,6 +98,8 @@ export abstract class BaseStatusProvider {
           `Waited for more than ${BUILD_STATUS_POLLING_MAX} seconds for the build to finish. Aborting.`
         );
       }
+
+      firstIteration = false;
 
       // Update the spinner
       const timeString = new Date().toLocaleString();

--- a/src/status_providers/zeus.ts
+++ b/src/status_providers/zeus.ts
@@ -1,4 +1,4 @@
-import { BaseStatusProvider, CommitStatus } from './base';
+import { BaseStatusProvider, CommitStatus, RepositoryInfo } from './base';
 import { ZeusStore } from '../stores/zeus';
 
 /**
@@ -41,7 +41,7 @@ export class ZeusStatusProvider extends BaseStatusProvider {
   }
 
   /** TODO */
-  public async getRepositoryInfo(): Promise<any> {
+  public async getRepositoryInfo(): Promise<RepositoryInfo> {
     return this.store.getRepositoryInfo();
   }
 }

--- a/src/stores/zeus.ts
+++ b/src/stores/zeus.ts
@@ -1,10 +1,10 @@
 import {
   Artifact,
   Client as ZeusClient,
-  RepositoryInfo,
   Result,
   RevisionInfo,
   Status,
+  RepositoryInfo,
 } from '@zeus-ci/sdk';
 import * as _ from 'lodash';
 
@@ -219,6 +219,8 @@ export class ZeusStore {
 
   /**
    * Gets repository information
+   *
+   * TODO: this RepositoryInfo is from zeus-sdk.
    */
   public async getRepositoryInfo(): Promise<RepositoryInfo> {
     return this.client.getRepositoryInfo(this.repoOwner, this.repoName);

--- a/src/targets/__tests__/crates.test.ts
+++ b/src/targets/__tests__/crates.test.ts
@@ -1,5 +1,5 @@
-import { ZeusStore } from '../../stores/zeus';
 import { CrateDependency, CratePackage, CratesTarget } from '../crates';
+import { NoneArtifactProvider } from '../../artifact_providers/none';
 
 jest.mock('../../utils/system');
 
@@ -22,8 +22,7 @@ function cratePackageToDependency(cratePackage: CratePackage): CrateDependency {
 
 describe('getPublishOrder', () => {
   process.env.CRATES_IO_TOKEN = 'xxx';
-  const store = new ZeusStore('craft-test', 'craft-test-repo');
-  const target = new CratesTarget({}, store);
+  const target = new CratesTarget({}, new NoneArtifactProvider());
 
   test('sorts crate packages properly', async () => {
     const packages = ['p1', 'p2', 'p3', 'p4'].map(cratePackageFactory);

--- a/src/targets/base.ts
+++ b/src/targets/base.ts
@@ -1,9 +1,11 @@
-import { Artifact } from '@zeus-ci/sdk';
-
 import { logger } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
-import { FilterOptions, ZeusStore } from '../stores/zeus';
+import { FilterOptions } from '../stores/zeus';
 import { stringToRegexp } from '../utils/filters';
+import {
+  BaseArtifactProvider,
+  CraftArtifact,
+} from '../artifact_providers/base';
 
 // TODO: make abstract?
 /**
@@ -12,15 +14,18 @@ import { stringToRegexp } from '../utils/filters';
 export class BaseTarget {
   /** Target name */
   public readonly name: string = 'base';
-  /** Artifact store */
-  public readonly store: ZeusStore;
+  /** Artifact provider */
+  public readonly artifactProvider: BaseArtifactProvider;
   /** Unparsed target configuration */
   public readonly config: TargetConfig;
   /** Artifact filtering options for the target */
   public readonly filterOptions: FilterOptions;
 
-  public constructor(config: TargetConfig, store: ZeusStore) {
-    this.store = store;
+  public constructor(
+    config: TargetConfig,
+    artifactProvider: BaseArtifactProvider
+  ) {
+    this.artifactProvider = artifactProvider;
     this.config = config;
     this.filterOptions = {};
     if (this.config.includeNames) {
@@ -57,7 +62,7 @@ export class BaseTarget {
   public async getArtifactsForRevision(
     revision: string,
     defaultFilterOptions: FilterOptions = {}
-  ): Promise<Artifact[]> {
+  ): Promise<CraftArtifact[]> {
     const filterOptions = {
       ...defaultFilterOptions,
       ...this.filterOptions,
@@ -73,6 +78,9 @@ export class BaseTarget {
         filterOptions.includeNames
       )}, excludeNames:${String(filterOptions.excludeNames)}}`
     );
-    return this.store.filterArtifactsForRevision(revision, filterOptions);
+    return this.artifactProvider.filterArtifactsForRevision(
+      revision,
+      filterOptions
+    );
   }
 }

--- a/src/targets/base.ts
+++ b/src/targets/base.ts
@@ -67,9 +67,11 @@ export class BaseTarget {
       ...defaultFilterOptions,
       ...this.filterOptions,
     };
+    // This is a hacky legacy way of skipping artifact downloads.
+    // Can be removed when we fully migrate from ZeusStore to artifact providers.
     if (filterOptions.includeNames?.source === 'none') {
       logger.debug(
-        `target.includeNames is 'none', skipping trying to fetch artifacts.`
+        `target.includeNames is 'none', skipping artifacts downloads.`
       );
       return [];
     }

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -6,12 +6,13 @@ import * as _ from 'lodash';
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZeusStore, ZEUS_DOWNLOAD_CONCURRENCY } from '../stores/zeus';
+import { ZEUS_DOWNLOAD_CONCURRENCY } from '../stores/zeus';
 import { ConfigurationError } from '../utils/errors';
 import { getGithubClient } from '../utils/githubApi';
 import { renderTemplateSafe } from '../utils/strings';
 import { HashAlgorithm, HashOutputFormat } from '../utils/system';
 import { BaseTarget } from './base';
+import { BaseArtifactProvider } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[brew]');
 
@@ -53,8 +54,8 @@ export class BrewTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.brewConfig = this.getBrewConfig();
     this.github = getGithubClient();
     this.githubRepo = getGlobalGithubConfig();
@@ -161,7 +162,7 @@ export class BrewTarget extends BaseTarget {
 
     // tslint:disable-next-line:await-promise
     await mapLimit(filesList, ZEUS_DOWNLOAD_CONCURRENCY, async file => {
-      checksums[file.name] = await this.store.getChecksum(
+      checksums[file.name] = await this.artifactProvider.getChecksum(
         file,
         HashAlgorithm.SHA256,
         HashOutputFormat.Hex

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -6,13 +6,15 @@ import * as _ from 'lodash';
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZEUS_DOWNLOAD_CONCURRENCY } from '../stores/zeus';
 import { ConfigurationError } from '../utils/errors';
 import { getGithubClient } from '../utils/githubApi';
 import { renderTemplateSafe } from '../utils/strings';
 import { HashAlgorithm, HashOutputFormat } from '../utils/system';
 import { BaseTarget } from './base';
-import { BaseArtifactProvider } from '../artifact_providers/base';
+import {
+  BaseArtifactProvider,
+  MAX_DOWNLOAD_CONCURRENCY,
+} from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[brew]');
 
@@ -161,7 +163,7 @@ export class BrewTarget extends BaseTarget {
     const checksums: any = {};
 
     // tslint:disable-next-line:await-promise
-    await mapLimit(filesList, ZEUS_DOWNLOAD_CONCURRENCY, async file => {
+    await mapLimit(filesList, MAX_DOWNLOAD_CONCURRENCY, async file => {
       checksums[file.name] = await this.artifactProvider.getChecksum(
         file,
         HashAlgorithm.SHA256,

--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -6,12 +6,12 @@ import { promisify } from 'util';
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import { getFile, getGithubClient } from '../utils/githubApi';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
+import { BaseArtifactProvider } from '../artifact_providers/base';
 const writeFile = promisify(fs.writeFile);
 
 const logger = loggerRaw.withScope('[cocoapods]');
@@ -44,8 +44,8 @@ export class CocoapodsTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.cocoapodsConfig = this.getCocoapodsConfig();
     this.github = getGithubClient();
     this.githubRepo = getGlobalGithubConfig();

--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -8,12 +8,12 @@ import * as simpleGit from 'simple-git/promise';
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
 import { forEachChained } from '../utils/async';
 import { ConfigurationError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
+import { BaseArtifactProvider } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[crates]');
 
@@ -69,8 +69,8 @@ export class CratesTarget extends BaseTarget {
   /** Target options */
   public readonly cratesConfig: CratesTargetOptions;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.cratesConfig = this.getCratesConfig();
     checkExecutableIsPresent(CARGO_BIN);
   }

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -240,6 +240,6 @@ export class GhPagesTarget extends BaseTarget {
       'craft-gh-pages-'
     );
 
-    logger.info('Gh-pages release complete');
+    logger.info('GitHub pages release complete');
   }
 }

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -9,7 +9,6 @@ import * as simpleGit from 'simple-git/promise';
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
@@ -20,6 +19,7 @@ import {
 } from '../utils/githubApi';
 import { extractZipArchive } from '../utils/system';
 import { BaseTarget } from './base';
+import { BaseArtifactProvider } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[gh-pages]');
 
@@ -53,8 +53,8 @@ export class GhPagesTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.github = getGithubClient();
     this.githubRepo = getGlobalGithubConfig();
     this.ghPagesConfig = this.getGhPagesConfig();
@@ -214,7 +214,9 @@ export class GhPagesTarget extends BaseTarget {
       );
       return undefined;
     }
-    const archivePath = await this.store.downloadArtifact(packageFiles[0]);
+    const archivePath = await this.artifactProvider.downloadArtifact(
+      packageFiles[0]
+    );
 
     const username = await getAuthUsername(this.github);
 

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -199,7 +199,7 @@ export class GhPagesTarget extends BaseTarget {
   public async publish(version: string, revision: string): Promise<any> {
     const { githubOwner, githubRepo, branch } = this.ghPagesConfig;
 
-    logger.debug('Fetching artifact list from Zeus...');
+    logger.debug('Fetching artifact list...');
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_DEPLOY_ARCHIVE_REGEX,
     });

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -6,7 +6,6 @@ import { basename } from 'path';
 import { getConfiguration, getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
 import { DEFAULT_CHANGELOG_PATH, findChangeset } from '../utils/changes';
 import {
   getFile,
@@ -17,6 +16,7 @@ import {
 } from '../utils/githubApi';
 import { isPreviewRelease, versionToTag } from '../utils/version';
 import { BaseTarget } from './base';
+import { BaseArtifactProvider } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[github]');
 
@@ -68,8 +68,8 @@ export class GithubTarget extends BaseTarget {
   /** Github client */
   public readonly github: Github;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.githubConfig = {
       ...getGlobalGithubConfig(),
       annotatedTag:
@@ -369,7 +369,7 @@ export class GithubTarget extends BaseTarget {
     const artifacts = await this.getArtifactsForRevision(revision);
     await Promise.all(
       artifacts.map(async artifact => {
-        const path = await this.store.downloadArtifact(artifact);
+        const path = await this.artifactProvider.downloadArtifact(artifact);
         return this.uploadAsset(release, path, artifact.type);
       })
     );

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -208,7 +208,7 @@ export class NpmTarget extends BaseTarget {
    * @param revision Git commit SHA to be published
    */
   public async publish(version: string, revision: string): Promise<any> {
-    logger.debug('Fetching artifact list from Zeus...');
+    logger.debug('Fetching artifact list...');
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_PACKAGE_REGEX,
     });

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -1,16 +1,17 @@
 import { SpawnOptions, spawnSync } from 'child_process';
-
-import { Artifact } from '@zeus-ci/sdk';
 import { shouldPerform } from 'dryrun';
 import * as inquirer from 'inquirer';
 
 import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { hasExecutable, spawnProcess } from '../utils/system';
 import { isPreviewRelease, parseVersion } from '../utils/version';
 import { BaseTarget } from './base';
+import {
+  BaseArtifactProvider,
+  CraftArtifact,
+} from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[npm]');
 
@@ -68,8 +69,8 @@ export class NpmTarget extends BaseTarget {
   /** Target options */
   public readonly npmConfig: NpmTargetOptions;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.checkRequirements();
     this.npmConfig = this.getNpmConfig();
   }
@@ -223,8 +224,8 @@ export class NpmTarget extends BaseTarget {
     }
 
     await Promise.all(
-      packageFiles.map(async (file: Artifact) => {
-        const path = await this.store.downloadArtifact(file);
+      packageFiles.map(async (file: CraftArtifact) => {
+        const path = await this.artifactProvider.downloadArtifact(file);
         logger.info(`Releasing ${file.name} to NPM`);
         return this.publishPackage(path, publishOptions);
       })

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -83,7 +83,7 @@ export class NugetTarget extends BaseTarget {
    * @param revision Git commit SHA to be published
    */
   public async publish(_version: string, revision: string): Promise<any> {
-    logger.debug('Fetching artifact list from Zeus...');
+    logger.debug('Fetching artifact list...');
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_NUGET_REGEX,
     });

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -1,11 +1,12 @@
-import { Artifact } from '@zeus-ci/sdk';
-
 import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
+import {
+  BaseArtifactProvider,
+  CraftArtifact,
+} from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[nuget]');
 
@@ -35,8 +36,8 @@ export class NugetTarget extends BaseTarget {
   /** Target options */
   public readonly nugetConfig: NugetTargetOptions;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.nugetConfig = this.getNugetConfig();
     checkExecutableIsPresent(NUGET_DOTNET_BIN);
   }
@@ -94,8 +95,8 @@ export class NugetTarget extends BaseTarget {
     }
 
     await Promise.all(
-      packageFiles.map(async (file: Artifact) => {
-        const path = await this.store.downloadArtifact(file);
+      packageFiles.map(async (file: CraftArtifact) => {
+        const path = await this.artifactProvider.downloadArtifact(file);
         logger.info(`Uploading file "${file.name}" via "dotnet nuget"`);
         return this.uploadAsset(path);
       })

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -85,7 +85,7 @@ export class PypiTarget extends BaseTarget {
    * @param revision Git commit SHA to be published
    */
   public async publish(_version: string, revision: string): Promise<any> {
-    logger.debug('Fetching artifact list from Zeus...');
+    logger.debug('Fetching artifact list...');
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_PYPI_REGEX,
     });

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -1,8 +1,9 @@
-import { Artifact } from '@zeus-ci/sdk';
-
 import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
-import { ZeusStore } from '../stores/zeus';
+import {
+  BaseArtifactProvider,
+  CraftArtifact,
+} from '../artifact_providers/base';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
@@ -38,8 +39,8 @@ export class PypiTarget extends BaseTarget {
   /** Target options */
   public readonly pypiConfig: PypiTargetOptions;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.pypiConfig = this.getPypiConfig();
     checkExecutableIsPresent(TWINE_BIN);
   }
@@ -95,8 +96,8 @@ export class PypiTarget extends BaseTarget {
     }
 
     await Promise.all(
-      packageFiles.map(async (file: Artifact) => {
-        const path = await this.store.downloadArtifact(file);
+      packageFiles.map(async (file: CraftArtifact) => {
+        const path = await this.artifactProvider.downloadArtifact(file);
         logger.info(`Uploading file "${file.name}" via twine`);
         return this.uploadAsset(path);
       })

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -11,7 +11,6 @@ import * as _ from 'lodash';
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZEUS_DOWNLOAD_CONCURRENCY } from '../stores/zeus';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
@@ -32,6 +31,7 @@ import { BaseTarget } from './base';
 import {
   CraftArtifact,
   BaseArtifactProvider,
+  MAX_DOWNLOAD_CONCURRENCY,
 } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[registry]');
@@ -420,7 +420,7 @@ export class RegistryTarget extends BaseTarget {
     const files: { [key: string]: any } = {};
 
     // tslint:disable-next-line:await-promise
-    await mapLimit(artifacts, ZEUS_DOWNLOAD_CONCURRENCY, async artifact => {
+    await mapLimit(artifacts, MAX_DOWNLOAD_CONCURRENCY, async artifact => {
       const fileData = await this.getArtifactData(artifact, version, revision);
       if (!_.isEmpty(fileData)) {
         files[artifact.name] = fileData;

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 
 import { mapLimit } from 'async';
 import * as Github from '@octokit/rest';
-import { Artifact } from '@zeus-ci/sdk';
 import { shouldPerform } from 'dryrun';
 // tslint:disable-next-line:no-submodule-imports
 import * as simpleGit from 'simple-git/promise';
@@ -12,7 +11,7 @@ import * as _ from 'lodash';
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { ZeusStore, ZEUS_DOWNLOAD_CONCURRENCY } from '../stores/zeus';
+import { ZEUS_DOWNLOAD_CONCURRENCY } from '../stores/zeus';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
@@ -30,6 +29,10 @@ import {
 } from '../utils/version';
 import { stringToRegexp } from '../utils/filters';
 import { BaseTarget } from './base';
+import {
+  CraftArtifact,
+  BaseArtifactProvider,
+} from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[registry]');
 
@@ -85,8 +88,8 @@ export class RegistryTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, store: ZeusStore) {
-    super(config, store);
+  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+    super(config, artifactProvider);
     this.github = getGithubClient();
     this.githubRepo = getGlobalGithubConfig();
     this.registryConfig = this.getRegistryConfig();
@@ -360,7 +363,7 @@ export class RegistryTarget extends BaseTarget {
    *
    */
   public async getArtifactData(
-    artifact: Artifact,
+    artifact: CraftArtifact,
     version: string,
     revision: string
   ): Promise<any> {
@@ -378,7 +381,7 @@ export class RegistryTarget extends BaseTarget {
       const fileChecksums: { [key: string]: string } = {};
       for (const checksumType of this.registryConfig.checksums) {
         const { algorithm, format } = checksumType;
-        const checksum = await this.store.getChecksum(
+        const checksum = await this.artifactProvider.getChecksum(
           artifact,
           algorithm,
           format
@@ -566,9 +569,12 @@ export class RegistryTarget extends BaseTarget {
     // If we have onlyIfPresent specified, check that we have any of matched files
     const onlyIfPresentPattern = this.registryConfig.onlyIfPresent;
     if (onlyIfPresentPattern) {
-      const artifacts = await this.store.filterArtifactsForRevision(revision, {
-        includeNames: onlyIfPresentPattern,
-      });
+      const artifacts = await this.artifactProvider.filterArtifactsForRevision(
+        revision,
+        {
+          includeNames: onlyIfPresentPattern,
+        }
+      );
       if (artifacts.length === 0) {
         logger.warn(
           `No files found that match "${onlyIfPresentPattern.toString()}", skipping the target.`

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,4 +1,5 @@
 import * as updateNotifier from 'update-notifier';
+import chalk from 'chalk';
 
 import { getGitTagPrefix } from '../config';
 
@@ -141,7 +142,6 @@ export function versionToTag(version: string, tagPrefix?: string): string {
  * This wrappers adds a custom update message that mentions "yarn".
  */
 export function checkForUpdates(): void {
-  const chalk = require('chalk');
   const pkg = getPackage();
 
   // Notify if the new version is available

--- a/yarn.lock
+++ b/yarn.lock
@@ -5021,13 +5021,13 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
-string-length@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.0.0.tgz#74ae8d207c716322d4a8fe79736170d3b5a4ed94"
-  integrity sha512-VeZa3u8MpEpDi7NMsZfp6ggk2x6ncBdE+sObPEVlczaUciCc+3ktm46P3HU2KdXArigN4XeEFNaj1Sg9TYAznw==
+string-length@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"
+  integrity sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==
   dependencies:
     astral-regex "^1.0.0"
-    strip-ansi "^5.1.0"
+    strip-ansi "^5.2.0"
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -5107,7 +5107,7 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
-strip-ansi@^5.1.0:
+strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,14 +658,14 @@
     "@types/node" "*"
 
 "@types/node-emoji@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@types/node-emoji/-/node-emoji-1.8.0.tgz#6bc88a880cdcb3c165e2828d056db242e8829a8b"
-  integrity sha512-+LiY4f3HMAgQGjte8Lg4K6xpTR+glwZolVrreU+ShACr6H/IzYN1VQAitHVeQrNKgZeuOegxE3IACh7Jo2qk0w==
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@types/node-emoji/-/node-emoji-1.8.1.tgz#689cb74fdf6e84309bcafce93a135dfecd01de3f"
+  integrity sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==
 
 "@types/node-fetch@^2.1.1":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.1.4.tgz#093d1beae11541aef25999d70aa09286fd025b1a"
-  integrity sha512-tR1ekaXUGpmzOcDXWU9BW73YfA2/VW1DF1FH+wlJ82BbCSnWTbdX+JkqWQXWKIGsFPnPsYadbXfNgz28g+ccWg==
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.4.tgz#5245b6d8841fc3a6208b82291119bc11c4e0ce44"
+  integrity sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==
   dependencies:
     "@types/node" "*"
 
@@ -967,6 +967,11 @@ ansi-regex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
   integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-regex@^5.0.0:
   version "5.0.0"
@@ -5016,6 +5021,14 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
+string-length@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.0.0.tgz#74ae8d207c716322d4a8fe79736170d3b5a4ed94"
+  integrity sha512-VeZa3u8MpEpDi7NMsZfp6ggk2x6ncBdE+sObPEVlczaUciCc+3ktm46P3HU2KdXArigN4XeEFNaj1Sg9TYAznw==
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^5.1.0"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -5093,6 +5106,13 @@ strip-ansi@^5.0.0:
   integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
   dependencies:
     ansi-regex "^4.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This PR replaces all usages of the legacy ZeusStore with BaseArtifactProvider.
Zeus is still used as the default artifact provider, but we can now add new providers, yay.