### PR TITLE
ref(docs): Clarify artifact provider docstrings

### DIFF
--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -136,7 +136,7 @@ export abstract class BaseArtifactProvider {
   ): Promise<string>;
 
   /**
-   * Given an arry of artifacts, returns an arry of local paths to the those
+   * Given an array of artifacts, returns an array of local paths to those
    * artifacts, downloading (and then caching) each file first if necessary.
    *
    * The cache persists for the lifetime of the ArtifactProvider instance, so

--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -8,9 +8,11 @@ import {
  */
 export class NoneArtifactProvider extends BaseArtifactProvider {
   /**
-   * This method should not be called by user code.
+   * Empty provider cannot download any files.
+   *
+   * @returns A promise rejection with an error message
    */
-  public async doDownloadArtifact(
+  protected async doDownloadArtifact(
     _artifact: CraftArtifact,
     _downloadDirectory: string
   ): Promise<string> {
@@ -19,6 +21,8 @@ export class NoneArtifactProvider extends BaseArtifactProvider {
 
   /**
    * Empty provider does not have any artifacts.
+   *
+   * @returns An empty array
    */
   protected async doListArtifactsForRevision(
     _revision: string

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -34,14 +34,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
   }
 
   /**
-   * Downloads the given artifact file.
-   *
-   * Downloaded URL are cached during the instance's lifetime, so the same
-   * file is downloaded only once.
-   *
-   * @param artifact An artifact object to download
-   * @param downloadDirectory Directory where downloaded artifact is stored
-   * @returns Absolute path to the saved file
+   * @inheritDoc
    */
   public async doDownloadArtifact(
     artifact: CraftArtifact,
@@ -61,9 +54,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
   }
 
   /**
-   * List artifacts for the given revision
-   *
-   * @param revision revision id (its SHA)
+   * @inheritDoc
    */
   protected async doListArtifactsForRevision(
     revision: string


### PR DESCRIPTION
This makes explicit things which weren't obvious to me, as a newcomer to the codebase. Specifically:

1) I tried to differentiate between `XXX` methods, which rely on caching when they can, and `doXXX` methods, which always get their data from the provider.

2) I made sure every docstring included all parameters and the return value (if there was one).

3) Where paths are local, I tried to call them out as such.

4) When possible, I let subclass implementations of abstract methods inherit their docstrings from the base class.