### PR TITLE
ref(config): Create environment utils module

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -35,7 +35,7 @@ describe('compile-json-schema-to-typescript', () => {
 });
 
 describe('validateConfiguration', () => {
-  test('parses minimal configuration', async () => {
+  test('parses minimal configuration', () => {
     const data = { github: { owner: 'getsentry', repo: 'craft' } };
 
     const projectConfig = validateConfiguration(data);
@@ -43,7 +43,8 @@ describe('validateConfiguration', () => {
     expect(projectConfig).toEqual(data);
   });
 
-  test('fails with empty configuration', async () => {
+  test('fails with empty configuration', () => {
+    // this ensures that we do actually run the expect line in the catch block
     expect.assertions(1);
 
     try {
@@ -55,10 +56,9 @@ describe('validateConfiguration', () => {
 });
 
 describe('getProjectConfigSchema', () => {
-  test('returns non-empty object', async () => {
+  test('returns non-empty object', () => {
     const projectConfigSchema = getProjectConfigSchema();
 
-    expect(projectConfigSchema).toBeTruthy();
     expect(projectConfigSchema).toHaveProperty('title');
     expect(projectConfigSchema).toHaveProperty('properties');
   });

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -16,12 +16,7 @@ import { GithubGlobalConfig } from '../schemas/project_config';
 import { getAllTargetNames, getTargetByName, SpecialTarget } from '../targets';
 import { BaseTarget } from '../targets/base';
 import { checkEnvForPrerequisites } from '../utils/env';
-import {
-  coerceType,
-  // ConfigurationError,
-  handleGlobalError,
-  reportError,
-} from '../utils/errors';
+import { coerceType, handleGlobalError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import { stringToRegexp } from '../utils/filters';
 import { getGithubClient, mergeReleaseBranch } from '../utils/githubApi';
@@ -97,26 +92,6 @@ export interface PublishOptions {
   /** Do not remove release branch after publishing */
   keepBranch: boolean;
 }
-
-/**
- * Checks Zeus prerequisites
- */
-// function checkPrerequisites(): void {
-//   if (!process.env.ZEUS_TOKEN && !process.env.ZEUS_API_TOKEN) {
-//     throw new ConfigurationError(
-//       'ZEUS_API_TOKEN not found in the environment. See the documentation for more details.'
-//     );
-//   }
-//   if (process.env.ZEUS_TOKEN) {
-//     logger.warn(
-//       'Usage of ZEUS_TOKEN is deprecated, and will be removed in later versions. ' +
-//         'Please use ZEUS_API_TOKEN instead.'
-//     );
-//   } else {
-//     // We currently need ZEUS_TOKEN set for zeus-sdk to work properly
-//     process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;
-//   }
-// }
 
 /**
  * Checks that the passed version is a valid version string
@@ -400,13 +375,15 @@ async function handleReleaseBranch(
 export async function publishMain(argv: PublishOptions): Promise<any> {
   logger.debug('Argv:', JSON.stringify(argv));
   checkMinimalConfigVersion();
+  // TODO (kmclb): pull the names of the necessary env vars out of config once
+  // there are more options than just Zeus
   checkEnvForPrerequisites([['ZEUS_API_TOKEN', 'ZEUS_TOKEN']]);
   // We currently need ZEUS_TOKEN set for zeus-sdk to work properly
   if (!process.env.ZEUS_TOKEN) {
     process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;
   }
 
-  // Get repo configuration
+  // Get publishing configuration
   const config = getConfiguration() || {};
   const githubConfig = config.github;
   const githubClient = getGithubClient();

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -400,7 +400,11 @@ async function handleReleaseBranch(
 export async function publishMain(argv: PublishOptions): Promise<any> {
   logger.debug('Argv:', JSON.stringify(argv));
   checkMinimalConfigVersion();
-  checkEnvForPrerequisites(['ZEUS_API_TOKEN', 'ZEUS_TOKEN']);
+  checkEnvForPrerequisites([['ZEUS_API_TOKEN', 'ZEUS_TOKEN']]);
+  // We currently need ZEUS_TOKEN set for zeus-sdk to work properly
+  if (!process.env.ZEUS_TOKEN) {
+    process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;
+  }
 
   // Get repo configuration
   const config = getConfiguration() || {};

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -15,9 +15,10 @@ import { formatTable, logger } from '../logger';
 import { GithubGlobalConfig } from '../schemas/project_config';
 import { getAllTargetNames, getTargetByName, SpecialTarget } from '../targets';
 import { BaseTarget } from '../targets/base';
+import { checkEnvForPrerequisites } from '../utils/env';
 import {
   coerceType,
-  ConfigurationError,
+  // ConfigurationError,
   handleGlobalError,
   reportError,
 } from '../utils/errors';
@@ -100,22 +101,22 @@ export interface PublishOptions {
 /**
  * Checks Zeus prerequisites
  */
-function checkPrerequisites(): void {
-  if (!process.env.ZEUS_TOKEN && !process.env.ZEUS_API_TOKEN) {
-    throw new ConfigurationError(
-      'ZEUS_API_TOKEN not found in the environment. See the documentation for more details.'
-    );
-  }
-  if (process.env.ZEUS_TOKEN) {
-    logger.warn(
-      'Usage of ZEUS_TOKEN is deprecated, and will be removed in later versions. ' +
-        'Please use ZEUS_API_TOKEN instead.'
-    );
-  } else {
-    // We currently need ZEUS_TOKEN set for zeus-sdk to work properly
-    process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;
-  }
-}
+// function checkPrerequisites(): void {
+//   if (!process.env.ZEUS_TOKEN && !process.env.ZEUS_API_TOKEN) {
+//     throw new ConfigurationError(
+//       'ZEUS_API_TOKEN not found in the environment. See the documentation for more details.'
+//     );
+//   }
+//   if (process.env.ZEUS_TOKEN) {
+//     logger.warn(
+//       'Usage of ZEUS_TOKEN is deprecated, and will be removed in later versions. ' +
+//         'Please use ZEUS_API_TOKEN instead.'
+//     );
+//   } else {
+//     // We currently need ZEUS_TOKEN set for zeus-sdk to work properly
+//     process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;
+//   }
+// }
 
 /**
  * Checks that the passed version is a valid version string
@@ -175,7 +176,7 @@ async function publishToTargets(
       }
     }
 
-    // Publish all the targets
+    // Publish to all targets
     for (const target of targetList) {
       const publishMessage = `=== Publishing to target: ${chalk.bold(
         chalk.cyan(target.name)
@@ -399,7 +400,7 @@ async function handleReleaseBranch(
 export async function publishMain(argv: PublishOptions): Promise<any> {
   logger.debug('Argv:', JSON.stringify(argv));
   checkMinimalConfigVersion();
-  checkPrerequisites();
+  checkEnvForPrerequisites(['ZEUS_API_TOKEN', 'ZEUS_TOKEN']);
 
   // Get repo configuration
   const config = getConfiguration() || {};

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -15,7 +15,7 @@ import { formatTable, logger } from '../logger';
 import { GithubGlobalConfig } from '../schemas/project_config';
 import { getAllTargetNames, getTargetByName, SpecialTarget } from '../targets';
 import { BaseTarget } from '../targets/base';
-import { checkEnvForPrerequisites } from '../utils/env';
+import { checkEnvForPrerequisite } from '../utils/env';
 import { coerceType, handleGlobalError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import { stringToRegexp } from '../utils/filters';
@@ -377,7 +377,7 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
   checkMinimalConfigVersion();
   // TODO (kmclb): pull the names of the necessary env vars out of config once
   // there are more options than just Zeus
-  checkEnvForPrerequisites([['ZEUS_API_TOKEN', 'ZEUS_TOKEN']]);
+  checkEnvForPrerequisite({ name: 'ZEUS_API_TOKEN', legacyName: 'ZEUS_TOKEN' });
   // We currently need ZEUS_TOKEN set for zeus-sdk to work properly
   if (!process.env.ZEUS_TOKEN) {
     process.env.ZEUS_TOKEN = process.env.ZEUS_API_TOKEN;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,8 @@
-import { existsSync, lstatSync, readFileSync, statSync } from 'fs';
-import { homedir } from 'os';
+import { existsSync, lstatSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 import * as Ajv from 'ajv';
 import { safeLoad } from 'js-yaml';
-import * as nvar from 'nvar';
 
 import { logger } from './logger';
 import {
@@ -28,9 +26,6 @@ import { BaseStatusProvider } from './status_providers/base';
 
 // TODO support multiple configuration files (one per configuration)
 export const CONFIG_FILE_NAME = '.craft.yml';
-
-/** File name where additional environment variables are stored */
-export const ENV_FILE_NAME = '.craft.env';
 
 /**
  * Cached path to the configuration file
@@ -219,99 +214,6 @@ export function getGitTagPrefix(): string {
   const targets = getConfiguration().targets || [];
   const githubTarget = targets.find(target => target.name === 'github') || {};
   return githubTarget.tagPrefix || '';
-}
-
-/**
- * Checks that the file is only readable for the owner
- *
- * It is assumed that the file already exists
- * @param path File path
- */
-function checkFileIsPrivate(path: string): boolean {
-  const FULL_MODE_MASK = 0o777;
-  const GROUP_MODE_MASK = 0o070;
-  const OTHER_MODE_MASK = 0o007;
-  const mode = statSync(path).mode;
-  // tslint:disable-next-line:no-bitwise
-  if (mode & GROUP_MODE_MASK || mode & OTHER_MODE_MASK) {
-    // tslint:disable-next-line:no-bitwise
-    const perms = (mode & FULL_MODE_MASK).toString(8);
-    logger.warn(
-      `Permissions 0${perms} for file "${path}" are too open. Consider making it readable only for the user.\n`
-    );
-    return false;
-  }
-  return true;
-}
-
-/**
- * Loads environment variables from ".craft.env" files in certain locations
- *
- * The following two places are checked:
- * - The user's home directory
- * - The configuration file directory
- *
- * @param overwriteExisting If set to true, overwrite the existing environment variables
- */
-export function readEnvironmentConfig(
-  overwriteExisting: boolean = false
-): void {
-  let newEnv = {} as any;
-
-  // Read from home dir
-  const homedirEnvFile = join(homedir(), ENV_FILE_NAME);
-  if (existsSync(homedirEnvFile)) {
-    logger.debug(
-      `Found environment file in the home directory: ${homedirEnvFile}`
-    );
-    checkFileIsPrivate(homedirEnvFile);
-    const homedirEnv = {};
-    nvar({ path: homedirEnvFile, target: homedirEnv });
-    newEnv = { ...newEnv, ...homedirEnv };
-    logger.debug(
-      `Read the following variables from ${homedirEnvFile}: ${Object.keys(
-        homedirEnv
-      ).toString()}`
-    );
-  } else {
-    logger.debug(
-      `No environment file found in the home directory: ${homedirEnvFile}`
-    );
-  }
-
-  // Read from the directory where the configuration file is located
-
-  // Apparently this is the best we can do to make getConfigFileDir mockable ;(
-  // See https://github.com/facebook/jest/issues/936 for more info
-  const configFileDir = exports.getConfigFileDir() as string | undefined;
-  const configDirEnvFile = configFileDir && join(configFileDir, ENV_FILE_NAME);
-  if (!configDirEnvFile) {
-    logger.debug(`No configuration file (${CONFIG_FILE_NAME}) found!`);
-  } else if (configDirEnvFile && existsSync(configDirEnvFile)) {
-    logger.debug(
-      `Found environment file in the configuration directory: ${configDirEnvFile}`
-    );
-    checkFileIsPrivate(configDirEnvFile);
-    const configDirEnv = {};
-    nvar({ path: configDirEnvFile, target: configDirEnv });
-    newEnv = { ...newEnv, ...configDirEnv };
-    logger.debug(
-      `Read the following variables from ${configDirEnvFile}: ${Object.keys(
-        configDirEnv
-      ).toString()}`
-    );
-  } else {
-    logger.debug(
-      `No environment file found in the configuration directory: ${configDirEnvFile}`
-    );
-  }
-
-  // Add non-existing values to env
-  for (const key of Object.keys(newEnv)) {
-    if (overwriteExisting || process.env[key] === undefined) {
-      process.env[key] = newEnv[key];
-    }
-  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { isDryRun, setDryRun } from 'dryrun';
 import * as once from 'once';
 import * as yargs from 'yargs';
 
-import { readEnvironmentConfig } from './config';
+import { readEnvironmentConfig } from './utils/env';
 import { logger } from './logger';
 import { hasNoInput, setNoInput } from './utils/noInput';
 import { initSentrySdk } from './utils/sentry';

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -1,136 +1,259 @@
-import { checkEnvForPrerequisite } from '../env';
-import { logger } from '../../logger';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import * as os from 'os';
+
+import * as config from '../../config';
+import {
+  checkEnvForPrerequisite,
+  readEnvironmentConfig,
+  ENV_FILE_NAME,
+} from '../env';
 import { ConfigurationError } from '../errors';
+import { logger } from '../../logger';
+import { withTempDir } from '../files';
 
 jest.mock('../../logger');
+const homedirMock = jest.spyOn(os, 'homedir');
+const getConfigFileDirMock = jest.spyOn(config, 'getConfigFileDir');
 
-describe('checkEnvForPrerequisite', () => {
+describe('env utils functions', () => {
   const cleanEnv = { ...process.env };
+
   beforeEach(() => {
     process.env = { ...cleanEnv };
     jest.resetAllMocks();
   });
 
-  it('runs', () => {
-    process.env.DOGS = 'RULE'; // just to prevent the function erroring
-    checkEnvForPrerequisite({ name: 'DOGS' });
-    expect(logger.debug).toHaveBeenCalledWith(
-      `\tChecking for environment variable DOGS`
-    );
-  });
-
-  describe('no legacy name', () => {
-    it('finds correctly set var', () => {
-      process.env.DOGS = 'RULE';
+  describe('checkEnvForPrerequisite', () => {
+    it('runs', () => {
+      process.env.DOGS = 'RULE'; // just to prevent the function erroring
       checkEnvForPrerequisite({ name: 'DOGS' });
-      expect(logger.debug).toHaveBeenCalledWith(`Found DOGS`);
-    });
-
-    it('errors if var not set', () => {
-      expect(() => checkEnvForPrerequisite({ name: 'DOGS' })).toThrowError(
-        ConfigurationError
-      );
-    });
-  }); // end describe('no legacy name')
-
-  describe('with legacy name', () => {
-    it('handles both new and legacy variable being set', () => {
-      process.env.DOGS = 'RULE';
-      process.env.CATS = 'DROOL';
-      checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
-      expect(logger.warn).toHaveBeenCalledWith(
-        `When searching configuration files and your environment, found DOGS ` +
-          `but also found legacy CATS. Do you mean to be using both?`
-      );
-    });
-
-    it('handles only new variable being set', () => {
-      process.env.DOGS = 'RULE';
-      checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
-      expect(logger.debug).toHaveBeenCalledWith('Found DOGS');
-    });
-
-    it('handles only legacy variable being set, and copies value to new variable', () => {
-      process.env.CATS = 'DROOL';
-      checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
-      expect(logger.warn).toHaveBeenCalledWith(
-        `Usage of CATS is deprecated, and will be removed in later versions. ` +
-          `Please use DOGS instead.`
-      );
-      expect(process.env.DOGS).toEqual('DROOL');
-    });
-
-    it('errors if neither is set', () => {
-      expect(() =>
-        checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' })
-      ).toThrowError(ConfigurationError);
-    });
-  }); // end describe('with legacy name')
-
-  describe('multiple options', () => {
-    it('checks for multiple variables', () => {
-      // don't set either variable to force it to look for both (but that makes
-      // it error, so `expect` the error to catch it so it doesn't break the
-      // test)
-      expect(() =>
-        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
-      ).toThrowError(ConfigurationError);
       expect(logger.debug).toHaveBeenCalledWith(
-        `Checking for environment variable(s) MAISEY or CHARLIE`
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        `\tChecking for environment variable MAISEY`
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        `\tChecking for environment variable CHARLIE`
+        `\tChecking for environment variable DOGS`
       );
     });
 
-    it('is happy if either option is defined', () => {
-      process.env.MAISEY = 'GOOD DOG';
-      expect(() =>
-        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
-      ).not.toThrowError(ConfigurationError);
-      expect(logger.debug).toHaveBeenCalledWith('Found MAISEY');
+    describe('no legacy name', () => {
+      it('finds correctly set var', () => {
+        process.env.DOGS = 'RULE';
+        checkEnvForPrerequisite({ name: 'DOGS' });
+        expect(logger.debug).toHaveBeenCalledWith(`Found DOGS`);
+      });
 
-      delete process.env.MAISEY;
-      process.env.CHARLIE = 'ALSO GOOD DOG';
-      expect(() =>
-        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
-      ).not.toThrowError(ConfigurationError);
-      expect(logger.debug).toHaveBeenCalledWith('Found CHARLIE');
+      it('errors if var not set', () => {
+        expect(() => checkEnvForPrerequisite({ name: 'DOGS' })).toThrowError(
+          ConfigurationError
+        );
+      });
+    }); // end describe('no legacy name')
+
+    describe('with legacy name', () => {
+      it('handles both new and legacy variable being set', () => {
+        process.env.DOGS = 'RULE';
+        process.env.CATS = 'DROOL';
+        checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
+        expect(logger.warn).toHaveBeenCalledWith(
+          `When searching configuration files and your environment, found DOGS ` +
+            `but also found legacy CATS. Do you mean to be using both?`
+        );
+      });
+
+      it('handles only new variable being set', () => {
+        process.env.DOGS = 'RULE';
+        checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
+        expect(logger.debug).toHaveBeenCalledWith('Found DOGS');
+      });
+
+      it('handles only legacy variable being set, and copies value to new variable', () => {
+        process.env.CATS = 'DROOL';
+        checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
+        expect(logger.warn).toHaveBeenCalledWith(
+          `Usage of CATS is deprecated, and will be removed in later versions. ` +
+            `Please use DOGS instead.`
+        );
+        expect(process.env.DOGS).toEqual('DROOL');
+      });
+
+      it('errors if neither is set', () => {
+        expect(() =>
+          checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' })
+        ).toThrowError(ConfigurationError);
+      });
+    }); // end describe('with legacy name')
+
+    describe('multiple options', () => {
+      it('checks for multiple variables', () => {
+        // don't set either variable to force it to look for both (but that makes
+        // it error, so `expect` the error to catch it so it doesn't break the
+        // test)
+        expect(() =>
+          checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+        ).toThrowError(ConfigurationError);
+        expect(logger.debug).toHaveBeenCalledWith(
+          `Checking for environment variable(s) MAISEY or CHARLIE`
+        );
+        expect(logger.debug).toHaveBeenCalledWith(
+          `\tChecking for environment variable MAISEY`
+        );
+        expect(logger.debug).toHaveBeenCalledWith(
+          `\tChecking for environment variable CHARLIE`
+        );
+      });
+
+      it('is happy if either option is defined', () => {
+        process.env.MAISEY = 'GOOD DOG';
+        expect(() =>
+          checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+        ).not.toThrowError(ConfigurationError);
+        expect(logger.debug).toHaveBeenCalledWith('Found MAISEY');
+
+        delete process.env.MAISEY;
+        process.env.CHARLIE = 'ALSO GOOD DOG';
+        expect(() =>
+          checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+        ).not.toThrowError(ConfigurationError);
+        expect(logger.debug).toHaveBeenCalledWith('Found CHARLIE');
+      });
+
+      it('throws if neither one is defined', () => {
+        // skip defining vars here
+        expect(() =>
+          checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+        ).toThrowError(ConfigurationError);
+      });
+
+      it('handles a mix of variables with and without legacy names', () => {
+        process.env.MAISEY = 'GOOD DOG';
+        expect(() =>
+          checkEnvForPrerequisite(
+            { name: 'MAISEY' },
+            { name: 'CHARLIE', legacyName: 'OPAL' }
+          )
+        ).not.toThrowError(ConfigurationError);
+        expect(logger.debug).toHaveBeenCalledWith('Found MAISEY');
+
+        delete process.env.MAISEY;
+        process.env.OPAL = 'GOOD PUPPY';
+        expect(() =>
+          checkEnvForPrerequisite(
+            { name: 'MAISEY' },
+            { name: 'CHARLIE', legacyName: 'OPAL' }
+          )
+        ).not.toThrowError(ConfigurationError);
+        expect(logger.warn).toHaveBeenCalledWith(
+          `Usage of OPAL is deprecated, and will be removed in later versions. ` +
+            `Please use CHARLIE instead.`
+        );
+        expect(process.env.CHARLIE).toEqual('GOOD PUPPY');
+      });
+    }); // end describe('multiple variables')
+  }); // end describe('checkEnvForPrerequisites')
+
+  describe('readEnvironmentConfig', () => {
+    const invalidDir = '/invalid/invalid';
+
+    function writeConfigFile(directory: string): void {
+      const outConfigFile = join(directory, config.CONFIG_FILE_NAME);
+      writeFileSync(outConfigFile, '');
+    }
+
+    test('calls homedir/findConfigFile', async () => {
+      process.env.TEST_BLA = '123';
+
+      homedirMock.mockReturnValue(invalidDir);
+      getConfigFileDirMock.mockReturnValue(invalidDir);
+
+      readEnvironmentConfig();
+
+      expect(getConfigFileDirMock).toHaveBeenCalledTimes(1);
+      expect(homedirMock).toHaveBeenCalledTimes(1);
+      expect(process.env.TEST_BLA).toBe('123');
+      expect(ENV_FILE_NAME.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('throws if neither one is defined', () => {
-      // skip defining vars here
-      expect(() =>
-        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
-      ).toThrowError(ConfigurationError);
+    test('checks the config directory', async () => {
+      homedirMock.mockReturnValue(invalidDir);
+
+      await withTempDir(async directory => {
+        getConfigFileDirMock.mockReturnValue(directory);
+
+        writeConfigFile(directory);
+
+        const outFile = join(directory, ENV_FILE_NAME);
+        writeFileSync(outFile, 'export TEST_BLA=234\nexport TEST_ANOTHER=345');
+
+        readEnvironmentConfig();
+
+        expect(process.env.TEST_BLA).toBe('234');
+      });
+    });
+    test('checks home directory', async () => {
+      getConfigFileDirMock.mockReturnValue(invalidDir);
+
+      await withTempDir(async directory => {
+        homedirMock.mockReturnValue(directory);
+        const outFile = join(directory, ENV_FILE_NAME);
+        writeFileSync(outFile, 'export TEST_BLA=234\n');
+
+        readEnvironmentConfig();
+
+        expect(process.env.TEST_BLA).toBe('234');
+      });
     });
 
-    it('handles a mix of variables with and without legacy names', () => {
-      process.env.MAISEY = 'GOOD DOG';
-      expect(() =>
-        checkEnvForPrerequisite(
-          { name: 'MAISEY' },
-          { name: 'CHARLIE', legacyName: 'OPAL' }
-        )
-      ).not.toThrowError(ConfigurationError);
-      expect(logger.debug).toHaveBeenCalledWith('Found MAISEY');
+    test('checks home directory first, and then the config directory', async () => {
+      await withTempDir(async dir1 => {
+        await withTempDir(async dir2 => {
+          homedirMock.mockReturnValue(dir1);
 
-      delete process.env.MAISEY;
-      process.env.OPAL = 'GOOD PUPPY';
-      expect(() =>
-        checkEnvForPrerequisite(
-          { name: 'MAISEY' },
-          { name: 'CHARLIE', legacyName: 'OPAL' }
-        )
-      ).not.toThrowError(ConfigurationError);
-      expect(logger.warn).toHaveBeenCalledWith(
-        `Usage of OPAL is deprecated, and will be removed in later versions. ` +
-          `Please use CHARLIE instead.`
-      );
-      expect(process.env.CHARLIE).toEqual('GOOD PUPPY');
+          const outHome = join(dir1, ENV_FILE_NAME);
+          writeFileSync(outHome, 'export TEST_BLA=from_home');
+
+          getConfigFileDirMock.mockReturnValue(dir2);
+          writeConfigFile(dir2);
+          const configDirFile = join(dir2, ENV_FILE_NAME);
+          writeFileSync(configDirFile, 'export TEST_BLA=from_config_dir');
+
+          readEnvironmentConfig();
+
+          expect(process.env.TEST_BLA).toBe('from_config_dir');
+        });
+      });
     });
-  }); // end describe('multiple variables')
-}); // end describe('checkEnvForPrerequisites')
+
+    test('does not overwrite existing variables by default', async () => {
+      homedirMock.mockReturnValue(invalidDir);
+
+      process.env.TEST_BLA = 'existing';
+
+      await withTempDir(async directory => {
+        getConfigFileDirMock.mockReturnValue(directory);
+        const outFile = join(directory, ENV_FILE_NAME);
+        writeFileSync(outFile, 'export TEST_BLA=new_value');
+
+        readEnvironmentConfig();
+
+        expect(process.env.TEST_BLA).toBe('existing');
+      });
+    });
+
+    test('overwrites existing variables if explicitly stated', async () => {
+      homedirMock.mockReturnValue(invalidDir);
+
+      process.env.TEST_BLA = 'existing';
+
+      await withTempDir(async directory => {
+        getConfigFileDirMock.mockReturnValue(directory);
+
+        writeConfigFile(directory);
+
+        const outFile = join(directory, ENV_FILE_NAME);
+        writeFileSync(outFile, 'export TEST_BLA=new_value');
+
+        readEnvironmentConfig(true);
+
+        expect(process.env.TEST_BLA).toBe('new_value');
+      });
+    });
+  }); // end describe('readEnvironmentConfig')
+}); // end describe('env utils functions')

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -33,13 +33,14 @@ describe('checkEnvForPrerequisites', () => {
     });
   }); // end describe('no legacy name')
 
-  describe('legacy name', () => {
+  describe('with legacy name', () => {
     it('handles both new and legacy variable being set', () => {
       process.env.DOGS = 'RULE';
       process.env.CATS = 'DROOL';
       checkEnvForPrerequisites([['DOGS', 'CATS']]);
       expect(logger.warn).toHaveBeenCalledWith(
-        `Found DOGS in your environment but also found legacy CATS. Do you mean to be using both?`
+        `When searching configuration files and your environment, found DOGS ` +
+          `but also found legacy CATS. Do you mean to be using both?`
       );
     });
 
@@ -64,7 +65,7 @@ describe('checkEnvForPrerequisites', () => {
         ConfigurationError
       );
     });
-  }); // end describe('legacy name')
+  }); // end describe('with legacy name')
 
   describe('multiple variables', () => {
     it('checks for multiple variables', () => {
@@ -77,7 +78,7 @@ describe('checkEnvForPrerequisites', () => {
       expect(logger.debug).toHaveBeenCalledWith(
         `Checking for environment variable CHARLIE`
       );
-    }); // end it('checks for multiple variables')
+    });
 
     it('handles a mix of variables with and without legacy names', () => {
       process.env.MAISEY = 'GOOD DOG';

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -1,10 +1,10 @@
-import { checkEnvForPrerequisites } from '../env';
+import { checkEnvForPrerequisite } from '../env';
 import { logger } from '../../logger';
 import { ConfigurationError } from '../errors';
 
 jest.mock('../../logger');
 
-describe('checkEnvForPrerequisites', () => {
+describe('checkEnvForPrerequisite', () => {
   const cleanEnv = { ...process.env };
   beforeEach(() => {
     process.env = { ...cleanEnv };
@@ -13,21 +13,21 @@ describe('checkEnvForPrerequisites', () => {
 
   it('runs', () => {
     process.env.DOGS = 'RULE'; // just to prevent the function erroring
-    checkEnvForPrerequisites(['DOGS']);
+    checkEnvForPrerequisite({ name: 'DOGS' });
     expect(logger.debug).toHaveBeenCalledWith(
-      `Checking for environment variable DOGS`
+      `\tChecking for environment variable DOGS`
     );
   });
 
   describe('no legacy name', () => {
     it('finds correctly set var', () => {
       process.env.DOGS = 'RULE';
-      checkEnvForPrerequisites(['DOGS']);
+      checkEnvForPrerequisite({ name: 'DOGS' });
       expect(logger.debug).toHaveBeenCalledWith(`Found DOGS`);
     });
 
     it('errors if var not set', () => {
-      expect(() => checkEnvForPrerequisites(['DOGS'])).toThrowError(
+      expect(() => checkEnvForPrerequisite({ name: 'DOGS' })).toThrowError(
         ConfigurationError
       );
     });
@@ -37,7 +37,7 @@ describe('checkEnvForPrerequisites', () => {
     it('handles both new and legacy variable being set', () => {
       process.env.DOGS = 'RULE';
       process.env.CATS = 'DROOL';
-      checkEnvForPrerequisites([['DOGS', 'CATS']]);
+      checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
       expect(logger.warn).toHaveBeenCalledWith(
         `When searching configuration files and your environment, found DOGS ` +
           `but also found legacy CATS. Do you mean to be using both?`
@@ -46,13 +46,13 @@ describe('checkEnvForPrerequisites', () => {
 
     it('handles only new variable being set', () => {
       process.env.DOGS = 'RULE';
-      checkEnvForPrerequisites([['DOGS', 'CATS']]);
+      checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
       expect(logger.debug).toHaveBeenCalledWith('Found DOGS');
     });
 
-    it('handles only legacy variable being set', () => {
+    it('handles only legacy variable being set, and copies value to new variable', () => {
       process.env.CATS = 'DROOL';
-      checkEnvForPrerequisites([['DOGS', 'CATS']]);
+      checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' });
       expect(logger.warn).toHaveBeenCalledWith(
         `Usage of CATS is deprecated, and will be removed in later versions. ` +
           `Please use DOGS instead.`
@@ -61,34 +61,76 @@ describe('checkEnvForPrerequisites', () => {
     });
 
     it('errors if neither is set', () => {
-      expect(() => checkEnvForPrerequisites([['DOGS', 'CATS']])).toThrowError(
-        ConfigurationError
-      );
+      expect(() =>
+        checkEnvForPrerequisite({ name: 'DOGS', legacyName: 'CATS' })
+      ).toThrowError(ConfigurationError);
     });
   }); // end describe('with legacy name')
 
-  describe('multiple variables', () => {
+  describe('multiple options', () => {
     it('checks for multiple variables', () => {
+      // don't set either variable to force it to look for both (but that makes
+      // it error, so `expect` the error to catch it so it doesn't break the
+      // test)
+      expect(() =>
+        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+      ).toThrowError(ConfigurationError);
+      expect(logger.debug).toHaveBeenCalledWith(
+        `Checking for environment variable(s) MAISEY or CHARLIE`
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        `\tChecking for environment variable MAISEY`
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        `\tChecking for environment variable CHARLIE`
+      );
+    });
+
+    it('is happy if either option is defined', () => {
       process.env.MAISEY = 'GOOD DOG';
+      expect(() =>
+        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+      ).not.toThrowError(ConfigurationError);
+      expect(logger.debug).toHaveBeenCalledWith('Found MAISEY');
+
+      delete process.env.MAISEY;
       process.env.CHARLIE = 'ALSO GOOD DOG';
-      checkEnvForPrerequisites(['MAISEY', 'CHARLIE']);
-      expect(logger.debug).toHaveBeenCalledWith(
-        `Checking for environment variable MAISEY`
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        `Checking for environment variable CHARLIE`
-      );
+      expect(() =>
+        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+      ).not.toThrowError(ConfigurationError);
+      expect(logger.debug).toHaveBeenCalledWith('Found CHARLIE');
+    });
+
+    it('throws if neither one is defined', () => {
+      // skip defining vars here
+      expect(() =>
+        checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
+      ).toThrowError(ConfigurationError);
     });
 
     it('handles a mix of variables with and without legacy names', () => {
       process.env.MAISEY = 'GOOD DOG';
-      process.env.OPAL = 'GOOD PUPPY';
-      checkEnvForPrerequisites(['MAISEY', ['CHARLIE', 'OPAL']]);
+      expect(() =>
+        checkEnvForPrerequisite(
+          { name: 'MAISEY' },
+          { name: 'CHARLIE', legacyName: 'OPAL' }
+        )
+      ).not.toThrowError(ConfigurationError);
       expect(logger.debug).toHaveBeenCalledWith('Found MAISEY');
+
+      delete process.env.MAISEY;
+      process.env.OPAL = 'GOOD PUPPY';
+      expect(() =>
+        checkEnvForPrerequisite(
+          { name: 'MAISEY' },
+          { name: 'CHARLIE', legacyName: 'OPAL' }
+        )
+      ).not.toThrowError(ConfigurationError);
       expect(logger.warn).toHaveBeenCalledWith(
         `Usage of OPAL is deprecated, and will be removed in later versions. ` +
           `Please use CHARLIE instead.`
       );
+      expect(process.env.CHARLIE).toEqual('GOOD PUPPY');
     });
   }); // end describe('multiple variables')
 }); // end describe('checkEnvForPrerequisites')

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -1,0 +1,93 @@
+import { checkEnvForPrerequisites } from '../env';
+import { logger } from '../../logger';
+import { ConfigurationError } from '../errors';
+
+jest.mock('../../logger');
+
+describe('checkEnvForPrerequisites', () => {
+  const cleanEnv = { ...process.env };
+  beforeEach(() => {
+    process.env = { ...cleanEnv };
+    jest.resetAllMocks();
+  });
+
+  it('runs', () => {
+    process.env.DOGS = 'RULE'; // just to prevent the function erroring
+    checkEnvForPrerequisites(['DOGS']);
+    expect(logger.debug).toHaveBeenCalledWith(
+      `Checking for environment variable DOGS`
+    );
+  });
+
+  describe('no legacy name', () => {
+    it('finds correctly set var', () => {
+      process.env.DOGS = 'RULE';
+      checkEnvForPrerequisites(['DOGS']);
+      expect(logger.debug).toHaveBeenCalledWith(`Found DOGS`);
+    });
+
+    it('errors if var not set', () => {
+      expect(() => checkEnvForPrerequisites(['DOGS'])).toThrowError(
+        ConfigurationError
+      );
+    });
+  }); // end describe('no legacy name')
+
+  describe('legacy name', () => {
+    it('handles both new and legacy variable being set', () => {
+      process.env.DOGS = 'RULE';
+      process.env.CATS = 'DROOL';
+      checkEnvForPrerequisites([['DOGS', 'CATS']]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Found DOGS in your environment but also found legacy CATS. Do you mean to be using both?`
+      );
+    });
+
+    it('handles only new variable being set', () => {
+      process.env.DOGS = 'RULE';
+      checkEnvForPrerequisites([['DOGS', 'CATS']]);
+      expect(logger.debug).toHaveBeenCalledWith('Found DOGS');
+    });
+
+    it('handles only legacy variable being set', () => {
+      process.env.CATS = 'DROOL';
+      checkEnvForPrerequisites([['DOGS', 'CATS']]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Usage of CATS is deprecated, and will be removed in later versions. ` +
+          `Please use DOGS instead.`
+      );
+      expect(process.env.DOGS).toEqual('DROOL');
+    });
+
+    it('errors if neither is set', () => {
+      expect(() => checkEnvForPrerequisites([['DOGS', 'CATS']])).toThrowError(
+        ConfigurationError
+      );
+    });
+  }); // end describe('legacy name')
+
+  describe('multiple variables', () => {
+    it('checks for multiple variables', () => {
+      process.env.MAISEY = 'GOOD DOG';
+      process.env.CHARLIE = 'ALSO GOOD DOG';
+      checkEnvForPrerequisites(['MAISEY', 'CHARLIE']);
+      expect(logger.debug).toHaveBeenCalledWith(
+        `Checking for environment variable MAISEY`
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        `Checking for environment variable CHARLIE`
+      );
+    }); // end it('checks for multiple variables')
+
+    it('handles a mix of variables with and without legacy names', () => {
+      process.env.MAISEY = 'GOOD DOG';
+      process.env.OPAL = 'GOOD PUPPY';
+      checkEnvForPrerequisites(['MAISEY', ['CHARLIE', 'OPAL']]);
+      expect(logger.debug).toHaveBeenCalledWith('Found MAISEY');
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Usage of OPAL is deprecated, and will be removed in later versions. ` +
+          `Please use CHARLIE instead.`
+      );
+    });
+  }); // end describe('multiple variables')
+}); // end describe('checkEnvForPrerequisites')

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -21,8 +21,14 @@ export function checkEnvForPrerequisites(
 
     // not found, under either the current or legacy names
     if (!process.env[varName] && !process.env[legacyVarName]) {
+      // note: Technically this function only checks the environment, not any
+      // config files, but that's only because on app startup we move all config
+      // variables into the environment, so we can have one central place to
+      // look for them. So, when communicating with the user, we need to address
+      // all of the places they might have stuck these variables.
       throw new ConfigurationError(
-        `${varName} not found in the environment. See the documentation for more details.`
+        `Required value ${varName} not found in configuration files or the ` +
+          `environment. See the documentation for more details.`
       );
     }
 
@@ -44,8 +50,9 @@ export function checkEnvForPrerequisites(
       // they have both the legacy and the new name in the environment
       else {
         logger.warn(
-          `Found ${varName} in your environment but also found legacy ${legacyVarName}. ` +
-            `Do you mean to be using both?`
+          `When searching configuration files and your environment, found ` +
+            `${varName} but also found legacy ${legacyVarName}. Do you mean ` +
+            `to be using both?`
         );
       }
       logger.info();

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -28,8 +28,9 @@ export function checkEnvForPrerequisites(
     if (legacyVarName && process.env[legacyVarName]) {
       process.env[varName] = process.env[legacyVarName];
       logger.warn(
+        // tslint:disable-next-line: prefer-template
         `Usage of ${legacyVarName} is deprecated, and will be removed in later versions. ` +
-          `Please use ${varName} instead.`
+          `Please use ${varName} instead.\n`
       );
     }
   }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -19,7 +19,7 @@ export interface RequiredConfigVar {
  * @returns true if variable was found, under either current or legacy name,
  * false otherwise
  */
-const envHasVar = (envVar: RequiredConfigVar): boolean => {
+function envHasVar(envVar: RequiredConfigVar): boolean {
   const { name, legacyName } = envVar;
 
   logger.debug(`\tChecking for environment variable ${name}`);
@@ -54,7 +54,7 @@ const envHasVar = (envVar: RequiredConfigVar): boolean => {
 
   // regardless, we've found it
   return true;
-};
+}
 
 /**
  * Checks the environment for the presence of the given variable(s).

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,36 @@
+import { ConfigurationError } from './errors';
+import { logger } from '../logger';
+
+/**
+ * Checks the environment for the presence of the given variables.
+ *
+ * Variables can be specified either as strings or as tuples of [currentName,
+ * legacyName], in which case a deprecation warning will be issued.
+ */
+export function checkEnvForPrerequisites(
+  varList: Array<string | [string, string]>
+): void {
+  // ensure that every variable has a corresponding legacy name, even if it's
+  // null, to make processing easier
+  const vars = varList.map(
+    item => (item instanceof String ? [item, null] : item) //
+  ) as Array<[string, string]>;
+
+  for (const [varName, legacyVarName] of vars) {
+    if (!process.env[varName] && !process.env[legacyVarName]) {
+      throw new ConfigurationError(
+        `${varName} not found in the environment. See the documentation for more details.`
+      );
+    }
+
+    // if we used to use a different name for the env variable, move it to the
+    // new name and warn the user
+    if (legacyVarName && process.env[legacyVarName]) {
+      process.env[varName] = process.env[legacyVarName];
+      logger.warn(
+        `Usage of ${legacyVarName} is deprecated, and will be removed in later versions. ` +
+          `Please use ${varName} instead.`
+      );
+    }
+  }
+}


### PR DESCRIPTION
With the introduction of the CGS artifact provider, we now have need for a function like [this](https://github.com/getsentry/craft/blob/2f623facdf151fde646e7746e93a8f6b3e902a60/src/commands/publish.ts#L100-L118) in multiple places, so this PR factors it out into its own module and makes it more generic. (It also moves all other env-related stuff to the new module.)

~I've marked this WIP until I can resolve two outstanding questions:~

~1) I've included unit tests for the function itself, but not any integration/acceptance/etc tests. So, in particular, though I've manually tested the fact that this doesn't break publishing (in other words, that that the generic function with specific parameters correctly mimics the behavior of the single-use function it's replacing), I have not written tests which confirm this. Not sure if these should live in a new `craft/src/commands/__tests__/publish.test.ts ` file or elsewhere. (I didn't find integration-y tests anywhere else, but please point me to them if I missed them.)~

~2) The line between what's env and what's config feels pretty blurry, but I wonder if there's anything else that ought to live under the heading of "env," now that I've separated them.~