### PR TITLE
ref(artifact providers): Refactor CraftArtifact interface

### DIFF
--- a/src/commands/artifacts_cmds/download.ts
+++ b/src/commands/artifacts_cmds/download.ts
@@ -97,8 +97,10 @@ async function handlerMain(argv: ArtifactsDownloadOptions): Promise<any> {
     return undefined;
   }
 
-  const filesToDownload = argv.all ? artifacts.map(ar => ar.name) : argv.names;
-  const nameToArtifact = _.fromPairs(artifacts.map(ar => [ar.name, ar]));
+  const filesToDownload = argv.all
+    ? artifacts.map(ar => ar.filename)
+    : argv.names;
+  const nameToArtifact = _.fromPairs(artifacts.map(ar => [ar.filename, ar]));
 
   logger.info(`Fetching artifacts for revision: ${revision}`);
   for (const name of filesToDownload) {

--- a/src/commands/artifacts_cmds/list.ts
+++ b/src/commands/artifacts_cmds/list.ts
@@ -37,9 +37,9 @@ async function handlerMain(argv: ArtifactsOptions): Promise<any> {
   }
 
   const artifactData = artifacts.map(ar => [
-    ar.name,
-    formatSize(ar.file.size),
-    ar.updated_at || '',
+    ar.filename,
+    formatSize(ar.storedFile.size),
+    ar.storedFile.lastUpdated || '',
   ]);
 
   const table = formatTable(

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -186,9 +186,9 @@ async function printRevisionSummary(
   const artifacts = await artifactProvider.listArtifactsForRevision(revision);
   if (artifacts && artifacts.length > 0) {
     const artifactData = artifacts.map(ar => [
-      ar.name,
-      formatSize(ar.file.size),
-      ar.updated_at || '',
+      ar.filename,
+      formatSize(ar.storedFile.size),
+      ar.storedFile.lastUpdated || '',
     ]);
     artifactData.sort((a1, a2) => (a1[0] < a2[0] ? -1 : a1[0] > a2[0] ? 1 : 0));
     const table = formatTable(
@@ -260,7 +260,7 @@ async function checkRequiredArtifacts(
   for (const nameRegexString of requiredNames) {
     const nameRegex = stringToRegexp(nameRegexString);
     const matchedArtifacts = artifacts.filter(artifact =>
-      nameRegex.test(artifact.name)
+      nameRegex.test(artifact.filename)
     );
     if (matchedArtifacts.length === 0) {
       reportError(
@@ -268,7 +268,7 @@ async function checkRequiredArtifacts(
       );
     } else {
       logger.debug(
-        `Artifact "${matchedArtifacts[0].name}" matches pattern ${nameRegexString}`
+        `Artifact "${matchedArtifacts[0].filename}" matches pattern ${nameRegexString}`
       );
     }
   }

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -157,14 +157,14 @@ export class BrewTarget extends BaseTarget {
     const filesList = await this.getArtifactsForRevision(revision);
     logger.debug(
       'Downloading artifacts for the revision:',
-      JSON.stringify(filesList.map(file => file.name))
+      JSON.stringify(filesList.map(file => file.filename))
     );
 
     const checksums: any = {};
 
     // tslint:disable-next-line:await-promise
     await mapLimit(filesList, MAX_DOWNLOAD_CONCURRENCY, async file => {
-      checksums[file.name] = await this.artifactProvider.getChecksum(
+      checksums[file.filename] = await this.artifactProvider.getChecksum(
         file,
         HashAlgorithm.SHA256,
         HashOutputFormat.Hex

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -183,7 +183,7 @@ export class GcsTarget extends BaseTarget {
    * @param artifact Artifact to check
    */
   private detectContentType(artifact: CraftArtifact): string | undefined {
-    const name = artifact.name;
+    const name = artifact.filename;
     for (const entry of CONTENT_TYPES_EXT) {
       const [regex, contentType] = entry;
       if (name.match(regex)) {

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -370,7 +370,7 @@ export class GithubTarget extends BaseTarget {
     await Promise.all(
       artifacts.map(async artifact => {
         const path = await this.artifactProvider.downloadArtifact(artifact);
-        return this.uploadAsset(release, path, artifact.type);
+        return this.uploadAsset(release, path, artifact.mimeType);
       })
     );
   }

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -226,7 +226,7 @@ export class NpmTarget extends BaseTarget {
     await Promise.all(
       packageFiles.map(async (file: CraftArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
-        logger.info(`Releasing ${file.name} to NPM`);
+        logger.info(`Releasing ${file.filename} to NPM`);
         return this.publishPackage(path, publishOptions);
       })
     );

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -97,7 +97,7 @@ export class NugetTarget extends BaseTarget {
     await Promise.all(
       packageFiles.map(async (file: CraftArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
-        logger.info(`Uploading file "${file.name}" via "dotnet nuget"`);
+        logger.info(`Uploading file "${file.filename}" via "dotnet nuget"`);
         return this.uploadAsset(path);
       })
     );

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -98,7 +98,7 @@ export class PypiTarget extends BaseTarget {
     await Promise.all(
       packageFiles.map(async (file: CraftArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
-        logger.info(`Uploading file "${file.name}" via twine`);
+        logger.info(`Uploading file "${file.filename}" via twine`);
         return this.uploadAsset(path);
       })
     );

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -337,10 +337,10 @@ export class RegistryTarget extends BaseTarget {
 
     const fileUrls: { [_: string]: string } = {};
     for (const artifact of artifacts) {
-      fileUrls[artifact.name] = renderTemplateSafe(
+      fileUrls[artifact.filename] = renderTemplateSafe(
         this.registryConfig.urlTemplate,
         {
-          file: artifact.name,
+          file: artifact.filename,
           revision,
           version,
         }
@@ -371,7 +371,7 @@ export class RegistryTarget extends BaseTarget {
 
     if (this.registryConfig.urlTemplate) {
       artifactData.url = renderTemplateSafe(this.registryConfig.urlTemplate, {
-        file: artifact.name,
+        file: artifact.filename,
         revision,
         version,
       });
@@ -423,7 +423,7 @@ export class RegistryTarget extends BaseTarget {
     await mapLimit(artifacts, MAX_DOWNLOAD_CONCURRENCY, async artifact => {
       const fileData = await this.getArtifactData(artifact, version, revision);
       if (!_.isEmpty(fileData)) {
-        files[artifact.name] = fileData;
+        files[artifact.filename] = fileData;
       }
     });
 


### PR DESCRIPTION
Our current `CraftArtifact` interface is based on `zeus`'s `Artifact` interface. However, since we're working to include options besides `zeus` (and eventually move away from it all together), there's no reason we have to be tied to that format.

This refactors the interface so that property names are
- a little more explicit, 
- all in camel case, 
- consistent with the way things are named in the upcoming `GCSArtifactProvider`, and
- organized in such a way that it's clear what information is about the file in general, and what information is specifically about the copy of the file which lives on the artifact store.