### PR TITLE
ref(targets): Create GCS API module

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,12 +597,14 @@ The bucket paths (`paths`) can be interpolated using Mustache syntax (`{{ variab
 
 Google Cloud credentials can be provided using either of the following two environment variables.
 
-| Name                         | Description                                                              |
-| ---------------------------- | ------------------------------------------------------------------------ |
-| `CRAFT_GCS_CREDENTIALS_PATH` | Local filesystem path to Google Cloud credentials (service account file) |
-| `CRAFT_GCS_CREDENTIALS_JSON` | Full service account file contents, as a JSON string                     |
+| Name                          | Description                                                              |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `CRAFT_GCS_TARGET_CREDS_PATH` | Local filesystem path to Google Cloud credentials (service account file) |
+| `CRAFT_GCS_TARGET_CREDS_JSON` | Full service account file contents, as a JSON string                     |
 
-If defined, `CRAFT_GCS_CREDENTIALS_JSON` will be preferred over `CRAFT_GCS_CREDENTIALS_PATH`.
+If defined, `CRAFT_GCS_TARGET_CREDS_JSON` will be preferred over `CRAFT_GCS_TARGET_CREDS_PATH`.
+
+_Note:_ `CRAFT_GCS_TARGET_CREDS_JSON` and `CRAFT_GCS_TARGET_CREDS_PATH` were formerly called `CRAFT_GCS_CREDENTIALS_JSON` and `CRAFT_GCS_CREDENTIALS_PATH`, respectively. While those names will continue to work for the foreseeable future, you'll receive a warning encouraging you to switch to the new names.
 
 **Configuration**
 

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -10,10 +10,13 @@ import {
 } from '../artifact_providers/base';
 import { logger } from '../logger';
 
+// TODO (kmclb) once `craft upload` is a thing, add an upload method here (and change the docstring below)
+
 /**
  * Zeus artifact provider
  *
- * Artifacts have to be uploaded to Zeus via "zeus-cli" command line tool.
+ * For the moment, artifacts have to be uploaded to Zeus via "zeus-cli" command
+ * line tool.
  */
 export class ZeusArtifactProvider extends BaseArtifactProvider {
   /** Zeus API client */

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -7,6 +7,7 @@ import {
   DestinationPath,
   GCSBucket,
   GCSBucketConfig,
+  getGCSCredsFromEnv,
 } from '../utils/gcsApi';
 import { renderTemplateSafe } from '../utils/strings';
 import { BaseTarget } from './base';
@@ -66,11 +67,9 @@ export class GcsTarget extends BaseTarget {
    * Parses and checks configuration for the GCS target
    */
   protected getGCSTargetConfig(): GCSTargetConfig {
-    const {
-      project_id,
-      client_email,
-      private_key,
-    } = GCSBucket.getGCSCredsFromEnv(TARGET_ROLE_STR);
+    const { project_id, client_email, private_key } = getGCSCredsFromEnv(
+      TARGET_ROLE_STR
+    );
 
     const bucketName = this.config.bucket;
     if (!bucketName && typeof bucketName !== 'string') {

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -34,8 +34,6 @@ interface PathTemplate extends Partial<DestinationPath> {
   template: string;
 }
 
-// TODO (kmclb) Figure out how includeNames and excludeNames (from TargetConfig) are handled
-
 /**
  * Configuration options for the GCS target
  */
@@ -55,7 +53,10 @@ export class GcsTarget extends BaseTarget {
   /** GCS API client */
   private readonly gcsClient: GCSBucket;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: TargetConfig,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.targetConfig = this.getGCSTargetConfig();
     this.gcsClient = new GCSBucket(this.targetConfig);
@@ -66,7 +67,7 @@ export class GcsTarget extends BaseTarget {
    */
   protected getGCSTargetConfig(): GCSTargetConfig {
     const {
-      projectId,
+      project_id,
       client_email,
       private_key,
     } = GCSBucket.getGCSCredsFromEnv(TARGET_ROLE_STR);
@@ -86,7 +87,7 @@ export class GcsTarget extends BaseTarget {
       credentials: { client_email, private_key },
       name: 'GCS target',
       pathTemplates,
-      projectId,
+      projectId: project_id,
     };
   }
 
@@ -195,8 +196,6 @@ export class GcsTarget extends BaseTarget {
     pathTemplate.path = realPath;
   }
 
-  // TODO (kmclb) where else do I need try/catch blocks, if anywhere?
-
   /**
    * Uploads artifacts to Google Cloud Storage
    *
@@ -231,7 +230,7 @@ export class GcsTarget extends BaseTarget {
     await forEachChained(
       this.targetConfig.pathTemplates,
       async (pathTemplate: PathTemplate): Promise<void> => {
-        // this adds a `path` property to the PathTemplate object, will
+        // this adds a `path` property to the PathTemplate object, with
         // `version` and `revision` values filled in
         this.materializePathTemplate(pathTemplate, version, revision);
         await this.gcsClient.uploadArtifacts(

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -4,7 +4,7 @@ import { forEachChained } from '../utils/async';
 import { ConfigurationError, reportError } from '../utils/errors';
 import {
   DestinationPath,
-  GCSBucket,
+  CraftGCSClient,
   GCSBucketConfig,
   getGCSCredsFromEnv,
 } from '../utils/gcsApi';
@@ -49,7 +49,7 @@ export class GcsTarget extends BaseTarget {
   /** Target options */
   public readonly targetConfig: GCSTargetConfig;
   /** GCS API client */
-  private readonly gcsClient: GCSBucket;
+  private readonly gcsClient: CraftGCSClient;
 
   public constructor(
     config: TargetConfig,
@@ -57,7 +57,7 @@ export class GcsTarget extends BaseTarget {
   ) {
     super(config, artifactProvider);
     this.targetConfig = this.getGCSTargetConfig();
-    this.gcsClient = new GCSBucket(this.targetConfig);
+    this.gcsClient = new CraftGCSClient(this.targetConfig);
   }
 
   /**

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -17,8 +17,6 @@ import {
 
 const logger = loggerRaw.withScope(`[gcs target]`);
 
-const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
-
 /**
  * Adds templating to the DestinationPath interface. (Partial so that the
  * required `path` property of that interface can be optional here, since we
@@ -119,7 +117,6 @@ export class GcsTarget extends BaseTarget {
     else if (typeof rawPathConfig === 'string') {
       parsedTemplates = [
         {
-          metadata: DEFAULT_UPLOAD_METADATA,
           template: rawPathConfig,
         },
       ];
@@ -134,21 +131,20 @@ export class GcsTarget extends BaseTarget {
           reportError(
             `Invalid bucket destination: ${JSON.stringify(
               configEntry
-            )}. Use the object notation to specify bucket paths!`
+            )}. Use object notation to specify bucket paths!`
           );
         }
 
-        const template = configEntry.path;
+        const { path: template, metadata } = configEntry;
+
         if (!template) {
           reportError(`Invalid bucket path template: ${template}`);
         }
-
-        const metadata = configEntry.metadata || DEFAULT_UPLOAD_METADATA;
-        if (typeof metadata !== 'object') {
+        if (metadata && typeof metadata !== 'object') {
           reportError(
             `Invalid metadata for path "${template}": "${JSON.stringify(
               metadata
-            )}"`
+            )}. Use object notation to specify metadata!"`
           );
         }
 

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -3,7 +3,6 @@ import { TargetConfig } from '../schemas/project_config';
 import { forEachChained } from '../utils/async';
 import { ConfigurationError, reportError } from '../utils/errors';
 import {
-  BucketRole,
   DestinationPath,
   GCSBucket,
   GCSBucketConfig,
@@ -16,9 +15,7 @@ import {
   CraftArtifact,
 } from '../artifact_providers/base';
 
-const TARGET_ROLE_STR = BucketRole.TARGET;
-
-const logger = loggerRaw.withScope(`[gcs ${TARGET_ROLE_STR}]`);
+const logger = loggerRaw.withScope(`[gcs target]`);
 
 const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
 
@@ -67,8 +64,16 @@ export class GcsTarget extends BaseTarget {
    * Parses and checks configuration for the GCS target
    */
   protected getGCSTargetConfig(): GCSTargetConfig {
+    // tslint:disable: object-literal-sort-keys
     const { project_id, client_email, private_key } = getGCSCredsFromEnv(
-      TARGET_ROLE_STR
+      {
+        name: 'CRAFT_GCS_TARGET_CREDENTIALS_JSON',
+        legacyName: 'CRAFT_GCS_CREDENTIALS_JSON',
+      },
+      {
+        name: 'CRAFT_GCS_TARGET_CREDENTIALS_PATH',
+        legacyName: 'CRAFT_GCS_CREDENTIALS_PATH',
+      }
     );
 
     const bucketName = this.config.bucket;
@@ -82,7 +87,6 @@ export class GcsTarget extends BaseTarget {
 
     return {
       bucketName,
-      bucketRole: TARGET_ROLE_STR,
       credentials: { client_email, private_key },
       name: 'GCS target',
       pathTemplates,

--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+
+import { getGCSCredsFromEnv } from '../gcsApi';
+import { withTempFile } from '../files';
+
+describe('getGCSCredsFromEnv', () => {
+  const cleanEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...cleanEnv };
+  });
+
+  it('pulls JSON creds from env', () => {
+    process.env.DOG_CREDS_JSON = `{
+      "project_id": "squirrel-chasing",
+      "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE",
+      "client_email": "might_huntress@dogs.com",
+      "other_stuff": "can be anything",
+      "tail_wagging": "true",
+      "barking": "also VERY true"
+    }`;
+
+    const { project_id, client_email, private_key } = getGCSCredsFromEnv(
+      { name: 'DOG_CREDS_JSON' },
+      { name: 'DOG_CREDS_PATH' }
+    );
+
+    expect(project_id).toEqual('squirrel-chasing');
+    expect(client_email).toEqual('might_huntress@dogs.com');
+    expect(private_key).toEqual('DoGsArEgReAtSoMeSeCrEtStUfFhErE');
+  });
+
+  it('pulls filepath creds from env', async () => {
+    await withTempFile(tempFilepath => {
+      fs.writeFileSync(
+        tempFilepath,
+        `{
+          "project_id": "squirrel-chasing",
+          "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE",
+          "client_email": "might_huntress@dogs.com",
+          "other_stuff": "can be anything",
+          "tail_wagging": "true",
+          "barking": "also VERY true"
+        }`
+      );
+      process.env.DOG_CREDS_PATH = tempFilepath;
+
+      const { project_id, client_email, private_key } = getGCSCredsFromEnv(
+        { name: 'DOG_CREDS_JSON' },
+        { name: 'DOG_CREDS_PATH' }
+      );
+
+      expect(project_id).toEqual('squirrel-chasing');
+      expect(client_email).toEqual('might_huntress@dogs.com');
+      expect(private_key).toEqual('DoGsArEgReAtSoMeSeCrEtStUfFhErE');
+    });
+  });
+
+  it('errors if neither JSON creds nor creds filepath provided', () => {
+    // skip defining variables
+
+    expect(() => {
+      getGCSCredsFromEnv(
+        { name: 'DOG_CREDS_JSON' },
+        { name: 'DOG_CREDS_PATH' }
+      );
+    }).toThrowError('GCS credentials not found!');
+  });
+
+  it('errors given bogus JSON', () => {
+    process.env.DOG_CREDS_JSON = `Dogs!`;
+
+    expect(() => {
+      getGCSCredsFromEnv(
+        { name: 'DOG_CREDS_JSON' },
+        { name: 'DOG_CREDS_PATH' }
+      );
+    }).toThrowError('Error parsing JSON credentials');
+  });
+
+  it('errors if necessary field missing', () => {
+    process.env.DOG_CREDS_JSON = `{
+      "project_id": "squirrel-chasing",
+      "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE"
+    }`;
+
+    expect(() => {
+      getGCSCredsFromEnv(
+        { name: 'DOG_CREDS_JSON' },
+        { name: 'DOG_CREDS_PATH' }
+      );
+    }).toThrowError('GCS credentials missing `client_email`!');
+  });
+}); // end describe('getGCSCredsFromEnv')

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -49,7 +49,7 @@ export interface DestinationPath {
   /** Path inside the bucket to which files will be uploaded */
   path: string;
   /** Metadata to be associated with the files uploaded the path */
-  metadata: any;
+  metadata?: any;
 }
 
 /** Authentication credentials for GCS (pulled from env) */

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {
-  Bucket,
-  Storage,
+  Bucket as GCSBucket,
+  Storage as GCSStorage,
   UploadOptions as GCSUploadOptions,
 } from '@google-cloud/storage';
 import { isDryRun } from 'dryrun';
@@ -125,11 +125,11 @@ export function getGCSCredsFromEnv(
 /**
  * Abstraction for a GCS bucket
  */
-export class GCSBucket {
+export class CraftGCSClient {
   /** Bucket name */
   public readonly bucketName: string;
   /** CGS Client */
-  private readonly bucket: Bucket;
+  private readonly bucket: GCSBucket;
 
   public constructor(config: GCSBucketConfig) {
     const {
@@ -140,8 +140,8 @@ export class GCSBucket {
     } = config;
 
     this.bucketName = bucketName;
-    this.bucket = new Bucket(
-      new Storage({
+    this.bucket = new GCSBucket(
+      new GCSStorage({
         credentials,
         maxRetries,
         projectId,

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -1,0 +1,133 @@
+import * as fs from 'fs';
+
+import { Bucket, Storage } from '@google-cloud/storage';
+
+import { logger as loggerRaw } from '../logger';
+import { reportError } from './errors';
+import { checkEnvForPrerequisite, RequiredConfigVar } from './env';
+
+const logger = loggerRaw.withScope('[gcs]');
+
+const DEFAULT_GCS_MAX_RETRIES = 5;
+
+/**
+ * Is this bucket being used as an artifact store or a target?
+ */
+export const enum BucketRole {
+  /** Artifact storage (used in both `prepare` and `publish`) */
+  STORE = 'store',
+  /** Destination for `publish` */
+  TARGET = 'target',
+}
+
+/**
+ * Configuration options for the GCS bucket
+ */
+export interface GCSConfig {
+  /** Bucket name */
+  bucketName: string;
+  /** ID of the project containing the bucket   */
+  projectId: string;
+  /** CGS credentials */
+  credentials: { client_email: string; private_key: string };
+  /** Role (is this being used as an artifact store or a target?) */
+  role: BucketRole;
+  /** Maximum number of retries after unsuccessful request */
+  maxRetries?: number;
+}
+
+/**
+ * Abstraction for a GCS bucket
+ */
+export class GCSBucket {
+  /** Bucket name */
+  public readonly bucketName: string;
+  /** Role (is this being used as an artifact store or a target?) */
+  public readonly role: BucketRole; // TODO kmclb do I need this?
+  /** Bucket configuration */
+  private readonly config: GCSConfig;
+  /** CGS Client */
+  private readonly bucket: Bucket;
+  public constructor(config: GCSConfig) {
+    const {
+      bucketName,
+      projectId,
+      credentials,
+      role,
+      maxRetries = DEFAULT_GCS_MAX_RETRIES,
+    } = config;
+
+    this.config = config;
+    this.bucketName = bucketName;
+    this.role = role;
+
+    const storage = new Storage({
+      credentials,
+      maxRetries,
+      projectId,
+    });
+    this.bucket = new Bucket(storage, bucketName);
+  }
+
+  /**
+   * Pulls GCS redentials out of the environment, where they can be stored either
+   * as a path to a JSON file or as a JSON string.
+   *
+   * @returns An object containing the credentials
+   */
+  public static getGCSCredsFromEnv = (
+    gcsRole: BucketRole
+  ): { [key: string]: string } => {
+    // tslint:disable: object-literal-sort-keys
+    const jsonVar: RequiredConfigVar =
+      gcsRole === BucketRole.STORE
+        ? { name: 'CRAFT_GCS_STORE_CREDENTIALS_JSON' }
+        : {
+            name: 'CRAFT_GCS_TARGET_CREDENTIALS_JSON',
+            legacyName: 'CRAFT_GCS_CREDENTIALS_JSON',
+          };
+    const filepathVar: RequiredConfigVar =
+      gcsRole === BucketRole.STORE
+        ? { name: 'CRAFT_GCS_STORE_CREDENTIALS_PATH' }
+        : {
+            name: 'CRAFT_GCS_TARGET_CREDENTIALS_PATH',
+            legacyName: 'CRAFT_GCS_CREDENTIALS_PATH',
+          };
+
+    // make sure we have at least one of the necessary variables
+    checkEnvForPrerequisite(jsonVar, filepathVar);
+
+    const gcsCredsJson = process.env[jsonVar.name];
+    const gcsCredsPath = process.env[filepathVar.name];
+
+    // necessary in case we're doing a dry run, in which case missing
+    // credentials will log an error but not throw
+    let configRaw = '';
+
+    if (gcsCredsJson) {
+      logger.debug(`Using configuration from ${jsonVar.name}`);
+      configRaw = gcsCredsJson;
+    } else if (gcsCredsPath) {
+      logger.debug(`Using configuration located at ${filepathVar.name}`);
+      if (!fs.existsSync(gcsCredsPath)) {
+        reportError(`File does not exist: ${gcsCredsPath}`);
+      }
+      configRaw = fs.readFileSync(gcsCredsPath).toString();
+    } else {
+      const errorMsg =
+        `GCS credentials not found! Please provide the path to the ` +
+        `configuration via environment variable ${filepathVar.name}, or ` +
+        `specify the entire configuration in ${jsonVar.name}.`;
+      reportError(errorMsg);
+    }
+
+    let creds = {};
+    try {
+      creds = JSON.parse(configRaw);
+    } catch (err) {
+      reportError('Error parsing JSON credentials');
+    }
+
+    return creds;
+  };
+}

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -96,8 +96,6 @@ export class GCSBucket {
     );
   }
 
-  // TODO (kmclb) in readme deprecate CRAFT_GCS_CREDENTIALS_JSON/_PATH in favor of CRAFT_GCS_TARGET_CREDS_JSON/_PATH
-
   /**
    * Pulls GCS redentials out of the environment, where they can be stored either
    * as a path to a JSON file or as a JSON string.

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -75,7 +75,9 @@ export function getGCSCredsFromEnv(
   // make sure we have at least one of the necessary variables
   try {
     checkEnvForPrerequisite(jsonVar, filepathVar);
-  } catch (oO) {
+  } catch (e) {
+    // ditch e and create a new error in order to override the default
+    // `checkEnvForPrerequisite` error message and type
     const errorMsg =
       `GCS credentials not found! Please provide the path to the credentials ` +
       `file via environment variable ${filepathVar.name}, or specify the ` +

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -198,14 +198,11 @@ export class CraftGCSClient {
 
     const destinationPath = path.dirname(destinationFilePath);
     const filename = path.basename(localFilePath);
-    // const fileUploadConfig: GCSUploadOptions = { ...uploadConfig };
-    // const contentType = this.detectContentType(filename);
-    // if (contentType) {
-    //   fileUploadConfig.contentType = contentType;
-    // }
+
+    const contentType = this.detectContentType(filename);
     const fileUploadConfig: GCSUploadOptions = {
       ...uploadConfig,
-      contentType: this.detectContentType(filename),
+      ...(contentType && { contentType }),
     };
 
     logger.debug(


### PR DESCRIPTION
In preparation for the upcoming CGS artifact provider, this pulls all code from the GCS target module which might also useful to the artifact provider, collects it in a new GCS API module, and refactors the GCS target to use it.