### PR TITLE
chore(dependencies): Remove `node-dryrun` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "chalk": "2.4.1",
     "cli-table": "0.3.1",
     "consola": "1.4.5",
-    "dryrun": "1.0.2",
     "inquirer": "6.2.1",
     "js-yaml": "3.12.0",
     "json-schema-to-typescript": "5.7.0",

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,5 +1,4 @@
 import * as Github from '@octokit/rest';
-import { shouldPerform } from 'dryrun';
 import * as inquirer from 'inquirer';
 import { Arguments, Argv } from 'yargs';
 import chalk from 'chalk';
@@ -20,6 +19,7 @@ import { coerceType, handleGlobalError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import { stringToRegexp } from '../utils/filters';
 import { getGithubClient, mergeReleaseBranch } from '../utils/githubApi';
+import { isDryRun } from '../utils/helpers';
 import { hasInput } from '../utils/noInput';
 import { formatSize, formatJson } from '../utils/strings';
 import { catchKeyboardInterrupt } from '../utils/system';
@@ -334,7 +334,7 @@ async function handleReleaseBranch(
   }
 
   logger.debug(`Merging the release branch: ${branchName}`);
-  if (shouldPerform()) {
+  if (!isDryRun()) {
     await mergeReleaseBranch(
       github,
       githubConfig.owner,
@@ -350,7 +350,7 @@ async function handleReleaseBranch(
   } else {
     const ref = `heads/${branchName}`;
     logger.debug(`Deleting the release branch, ref: ${ref}`);
-    if (shouldPerform()) {
+    if (!isDryRun()) {
       const response = await github.git.deleteRef({
         owner: githubConfig.owner,
         ref,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { isDryRun, setDryRun } from 'dryrun';
 import * as once from 'once';
 import * as yargs from 'yargs';
 
 import { readEnvironmentConfig } from './utils/env';
 import { logger } from './logger';
+import { isDryRun } from './utils/helpers';
 import { hasNoInput, setNoInput } from './utils/noInput';
 import { initSentrySdk } from './utils/sentry';
 import { checkForUpdates, getPackageVersion } from './utils/version';
@@ -13,12 +13,16 @@ import { checkForUpdates, getPackageVersion } from './utils/version';
  * Handler for '--dry-run' option
  */
 function processDryRun<T>(arg: T): T {
-  if (arg) {
-    setDryRun(true);
+  // if the user explicitly set the flag on the command line, their choice
+  // should override any previously set env var
+  if (process.argv.indexOf('--dry-run') > -1) {
+    process.env.DRY_RUN = String(arg);
   }
+
   if (isDryRun()) {
     logger.info('[dry-run] Dry-run mode is on!');
   }
+
   return arg;
 }
 

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -1,6 +1,5 @@
 import { mapLimit } from 'async';
 import * as Github from '@octokit/rest';
-import { shouldPerform } from 'dryrun';
 import * as _ from 'lodash';
 
 import { getGlobalGithubConfig } from '../config';
@@ -8,6 +7,7 @@ import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError } from '../utils/errors';
 import { getGithubClient } from '../utils/githubApi';
+import { isDryRun } from '../utils/helpers';
 import { renderTemplateSafe } from '../utils/strings';
 import { HashAlgorithm, HashOutputFormat } from '../utils/system';
 import { BaseTarget } from './base';
@@ -205,7 +205,7 @@ export class BrewTarget extends BaseTarget {
       `${action} file ${params.owner}/${params.repo}:${params.path} (${params.sha})`
     );
 
-    if (shouldPerform()) {
+    if (!isDryRun()) {
       await this.github.repos.createOrUpdateFile(params);
     } else {
       logger.info(`[dry-run] Skipping file action: ${action}`);

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import * as Github from '@octokit/rest';
-import { shouldPerform } from 'dryrun';
 // tslint:disable-next-line:no-submodule-imports
 import * as simpleGit from 'simple-git/promise';
 
@@ -17,6 +16,7 @@ import {
   getGithubClient,
   GithubRemote,
 } from '../utils/githubApi';
+import { isDryRun } from '../utils/helpers';
 import { extractZipArchive } from '../utils/system';
 import { BaseTarget } from './base';
 import { BaseArtifactProvider } from '../artifact_providers/base';
@@ -186,7 +186,7 @@ export class GhPagesTarget extends BaseTarget {
 
     // Push!
     logger.info(`Pushing branch "${branch}"...`);
-    if (shouldPerform()) {
+    if (!isDryRun()) {
       await git.push('origin', branch, { '--set-upstream': true });
     } else {
       logger.info('[dry-run] Not pushing the branch.');

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -1,5 +1,4 @@
 import * as Github from '@octokit/rest';
-import { shouldPerform, isDryRun } from 'dryrun';
 import { createReadStream, statSync } from 'fs';
 import { basename } from 'path';
 
@@ -14,6 +13,7 @@ import {
   HTTP_UNPROCESSABLE_ENTITY,
   retryHttp,
 } from '../utils/githubApi';
+import { isDryRun } from '../utils/helpers';
 import { isPreviewRelease, versionToTag } from '../utils/version';
 import { BaseTarget } from './base';
 import { BaseArtifactProvider } from '../artifact_providers/base';
@@ -189,7 +189,7 @@ export class GithubTarget extends BaseTarget {
     };
 
     logger.debug(`Annotated tag: ${this.githubConfig.annotatedTag}`);
-    if (shouldPerform()) {
+    if (!isDryRun()) {
       if (this.githubConfig.annotatedTag) {
         await this.createAnnotatedTag(version, revision, tag);
         // We've just created the tag, so "target_commitish" will not be used.
@@ -324,7 +324,7 @@ export class GithubTarget extends BaseTarget {
     logger.info(
       `Uploading asset "${name}" to ${this.githubConfig.owner}/${this.githubConfig.repo}:${release.tag_name}`
     );
-    if (shouldPerform()) {
+    if (!isDryRun()) {
       try {
         await retryHttp(
           async () => this.github.repos.uploadReleaseAsset(params),

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -1,10 +1,10 @@
 import { SpawnOptions, spawnSync } from 'child_process';
-import { shouldPerform } from 'dryrun';
 import * as inquirer from 'inquirer';
 
 import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
+import { isDryRun } from '../utils/helpers';
 import { hasExecutable, spawnProcess } from '../utils/system';
 import { isPreviewRelease, parseVersion } from '../utils/version';
 import { BaseTarget } from './base';
@@ -219,7 +219,7 @@ export class NpmTarget extends BaseTarget {
     }
 
     const publishOptions: NpmPublishOptions = { version };
-    if (shouldPerform() && this.npmConfig.useOtp) {
+    if (!isDryRun() && this.npmConfig.useOtp) {
       publishOptions.otp = await this.requestOtp();
     }
 

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 
 import { mapLimit } from 'async';
 import * as Github from '@octokit/rest';
-import { shouldPerform } from 'dryrun';
 // tslint:disable-next-line:no-submodule-imports
 import * as simpleGit from 'simple-git/promise';
 import * as _ from 'lodash';
@@ -19,6 +18,7 @@ import {
   getGithubClient,
   GithubRemote,
 } from '../utils/githubApi';
+import { isDryRun } from '../utils/helpers';
 import { renderTemplateSafe } from '../utils/strings';
 import { HashAlgorithm, HashOutputFormat } from '../utils/system';
 import {
@@ -550,7 +550,7 @@ export class RegistryTarget extends BaseTarget {
 
     // Push!
     logger.info(`Pushing the changes...`);
-    if (shouldPerform()) {
+    if (!isDryRun()) {
       await git.push('origin', 'master');
     } else {
       logger.info('[dry-run] Not pushing the branch.');

--- a/src/types/dryrun.d.ts
+++ b/src/types/dryrun.d.ts
@@ -1,5 +1,0 @@
-declare module 'dryrun' {
-  function isDryRun(): boolean;
-  function shouldPerform(): boolean;
-  function setDryRun(active: boolean): void;
-}

--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -179,4 +179,14 @@ describe('CraftGCSClient class', () => {
       'Error uploading `someFile` to `/some/destination/spot/someFile`'
     );
   });
+
+  it("doesn't upload anything in dry run mode", async () => {
+    process.env.DRY_RUN = 'true';
+
+    await client.uploadArtifacts(['./dist/someFile'], {
+      path: '/some/destination/spot/',
+    });
+
+    expect(mockGCSUpload).not.toHaveBeenCalled();
+  });
 }); // end describe('CraftGCSClient class')

--- a/src/utils/__tests__/helpers.test.ts
+++ b/src/utils/__tests__/helpers.test.ts
@@ -1,0 +1,35 @@
+import { isDryRun } from '../helpers';
+
+describe('isDryRun', () => {
+  /**
+   * Helper function to test expected isDryRun() output given a DRY_RUN value
+   *
+   * @param envVarValue The DRY_RUN value to test
+   * @param expectedDryRunStatus The expected output of isDryRun()
+   */
+  function testValue(
+    envVarValue: string | undefined,
+    expectedDryRunStatus: boolean
+  ): void {
+    // undefined represents the env var not being set
+    if (envVarValue !== undefined) {
+      process.env.DRY_RUN = envVarValue;
+    }
+
+    expect(isDryRun()).toEqual(expectedDryRunStatus);
+  }
+
+  afterEach(() => {
+    delete process.env.DRY_RUN;
+  });
+
+  test('undefined', () => testValue(undefined, false));
+  test('empty string', () => testValue('', false));
+  test('false', () => testValue('false', false));
+  test('0', () => testValue('0', false));
+  test('no', () => testValue('no', false));
+  test('true', () => testValue('true', true));
+  test('1', () => testValue('1', true));
+  test('yes', () => testValue('yes', true));
+  test('any non-empty string', () => testValue('dogs are great!', true));
+}); // end describe('isDryRun')

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,5 @@
-import { shouldPerform } from 'dryrun';
 import { logger } from '../logger';
+import { isDryRun } from './helpers';
 import { captureException } from './sentry';
 
 /**
@@ -28,7 +28,7 @@ export class ConfigurationError extends Error {
  */
 export function reportError(message: string, customLogger?: any): void {
   const errorLogger = customLogger || logger;
-  if (shouldPerform()) {
+  if (!isDryRun()) {
     throw new Error(message);
   } else {
     errorLogger.error(`[dry-run] ${message}`);

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -6,7 +6,7 @@ import {
   Storage as GCSStorage,
   UploadOptions as GCSUploadOptions,
 } from '@google-cloud/storage';
-import { isDryRun } from 'dryrun';
+import { isDryRun } from './helpers';
 
 import { logger as loggerRaw } from '../logger';
 import { reportError, ConfigurationError } from './errors';
@@ -14,8 +14,6 @@ import { checkEnvForPrerequisite, RequiredConfigVar } from './env';
 
 const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
-
-const IS_DRY_RUN = isDryRun();
 
 const logger = loggerRaw.withScope(`[gcs api]`);
 
@@ -203,7 +201,8 @@ export class CraftGCSClient {
       `Uploading \`${filename}\` to \`${destinationPath}\`. Upload options:
         ${JSON.stringify(fileUploadConfig)}`
     );
-    if (!IS_DRY_RUN) {
+
+    if (!isDryRun()) {
       try {
         await this.bucket.upload(localFilePath, fileUploadConfig);
       } catch (err) {

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -1,11 +1,11 @@
 import * as Github from '@octokit/rest';
-import { isDryRun } from 'dryrun';
 import * as request from 'request';
 import { Duplex, Readable } from 'stream';
 
 import { LOG_LEVELS, logger } from '../logger';
 
 import { ConfigurationError } from './errors';
+import { isDryRun } from './helpers';
 import { sleepAsync } from './system';
 
 export const HTTP_UNPROCESSABLE_ENTITY = 422;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns true or false depending on the value of process.env.DRY_RUN.
+ *
+ * @returns false if DRY_RUN is unset or is set to '', 'false', '0', or 'no',
+ * true otherwise
+ */
+export function isDryRun(): boolean {
+  const dryRun = process.env.DRY_RUN;
+  return (
+    Boolean(dryRun) && dryRun !== 'false' && dryRun !== '0' && dryRun !== 'no'
+  );
+}

--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -1,6 +1,5 @@
 import { spawn, SpawnOptions } from 'child_process';
 import { createHash, Hash } from 'crypto';
-import { isDryRun } from 'dryrun';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as split from 'split';
@@ -12,6 +11,7 @@ import { logger } from '../logger';
 
 import { reportError } from './errors';
 import { downloadSources } from './githubApi';
+import { isDryRun } from './helpers';
 
 /**
  * Types of supported hashing algorithms


### PR DESCRIPTION
As recommended by various folks, vendor the env var check ourselves instead of relying on a package. Works identically to the package except:

1) the dry-run status is never cached, and
2) instead of two functions (`isDryRun` and `shouldPerform`, which are opposites), this only includes the former, for simplicity.

This also adds one test to the GCS client test suite which wasn't working because of the caching behavior of the package.