### PR TITLE
ref(artifact providers): Assorted clean up and tweaks

### DIFF
--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -70,6 +70,17 @@ export interface FilterOptions {
   /** Exclude files that match this regexp */
   excludeNames?: RegExp;
 }
+/**
+ * Configuration options needed for all artifact providers
+ */
+export interface ArtifactProviderConfig {
+  /** Name of the repo containing the code getting released */
+  repoName: string;
+  /** GitHub org to which the repo belongs */
+  repoOwner: string;
+  /** Destination for any files the provider downloads */
+  downloadDirectory?: string;
+}
 
 /**
  * Base interface for artifact providers.
@@ -90,11 +101,21 @@ export abstract class BaseArtifactProvider {
     [path: string]: { [checksumType: string]: string };
   } = {};
 
+  /** Name of the repo containing the code getting released */
+  protected readonly repoName: string;
+  /** GitHub org to which the repo belongs */
+  protected readonly repoOwner: string;
+
   /** Directory that will be used for downloading artifacts by default */
   protected defaultDownloadDirectory: string | undefined;
 
-  public constructor(downloadDirectory?: string) {
+  public constructor(config: ArtifactProviderConfig) {
     this.clearCaches();
+
+    const { repoName, repoOwner, downloadDirectory } = config;
+
+    this.repoName = repoName;
+    this.repoOwner = repoOwner;
     if (downloadDirectory) {
       this.setDownloadDirectory(downloadDirectory);
     }

--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -1,6 +1,6 @@
 import {
   BaseArtifactProvider,
-  CraftArtifact,
+  RemoteArtifact,
 } from '../artifact_providers/base';
 
 /**
@@ -13,7 +13,7 @@ export class NoneArtifactProvider extends BaseArtifactProvider {
    * @returns A promise rejection with an error message
    */
   protected async doDownloadArtifact(
-    _artifact: CraftArtifact,
+    _artifact: RemoteArtifact,
     _downloadDirectory: string
   ): Promise<string> {
     return Promise.reject('NoneProvider does not suuport file downloads!');
@@ -26,7 +26,7 @@ export class NoneArtifactProvider extends BaseArtifactProvider {
    */
   protected async doListArtifactsForRevision(
     _revision: string
-  ): Promise<CraftArtifact[] | undefined> {
+  ): Promise<RemoteArtifact[] | undefined> {
     return [];
   }
 }

--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -1,12 +1,18 @@
 import {
   BaseArtifactProvider,
   RemoteArtifact,
+  ArtifactProviderConfig,
 } from '../artifact_providers/base';
 
 /**
  * Empty artifact provider that does nothing.
  */
 export class NoneArtifactProvider extends BaseArtifactProvider {
+  public constructor(
+    config: ArtifactProviderConfig = { repoName: 'none', repoOwner: 'none' }
+  ) {
+    super(config);
+  }
   /**
    * Empty provider cannot download any files.
    *

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -6,7 +6,7 @@ import {
 import * as _ from 'lodash';
 import {
   BaseArtifactProvider,
-  CraftArtifact,
+  RemoteArtifact,
 } from '../artifact_providers/base';
 import { logger } from '../logger';
 
@@ -44,9 +44,9 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
    * Rearranges and renames data to convert from one interface to another.
    *
    * @param zeusArtifact A zeus-style Artifact to convert
-   * @returns The data transformed into a CraftArtifact
+   * @returns The data transformed into a RemoteArtifact
    */
-  private convertToCraftArtifact(zeusArtifact: ZeusArtifact): CraftArtifact {
+  private convertToRemoteArtifact(zeusArtifact: ZeusArtifact): RemoteArtifact {
     // unpacking...
     const {
       name: filename,
@@ -73,12 +73,12 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
   /**
    * Rearranges and renames data to convert from one interface to another.
    *
-   * @param craftArtifact A CraftArtifact to convert
+   * @param remoteArtifact A RemoteArtifact to convert
    * @returns  The data transformed into a Zeus-style Artifact
    */
-  private convertToZeusArtifact(craftArtifact: CraftArtifact): ZeusArtifact {
+  private convertToZeusArtifact(remoteArtifact: RemoteArtifact): ZeusArtifact {
     // unpacking...
-    const { filename: name, storedFile, mimeType: type } = craftArtifact;
+    const { filename: name, storedFile, mimeType: type } = remoteArtifact;
     const {
       // tslint:disable: variable-name
       lastUpdated: updated_at,
@@ -106,7 +106,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
    * @inheritDoc
    */
   public async doDownloadArtifact(
-    artifact: CraftArtifact,
+    artifact: RemoteArtifact,
     downloadDirectory: string
   ): Promise<string> {
     return this.client.downloadArtifact(
@@ -120,7 +120,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
    */
   protected async doListArtifactsForRevision(
     revision: string
-  ): Promise<CraftArtifact[] | undefined> {
+  ): Promise<RemoteArtifact[] | undefined> {
     logger.debug(
       `Fetching Zeus artifacts for ${this.repoOwner}/${this.repoName}, revision ${revision}`
     );
@@ -140,7 +140,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
     }
 
     return artifacts.map(zeusArtifact =>
-      this.convertToCraftArtifact(zeusArtifact)
+      this.convertToRemoteArtifact(zeusArtifact)
     );
   }
 }

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -7,6 +7,7 @@ import * as _ from 'lodash';
 import {
   BaseArtifactProvider,
   RemoteArtifact,
+  ArtifactProviderConfig,
 } from '../artifact_providers/base';
 import { logger } from '../logger';
 
@@ -21,23 +22,13 @@ import { logger } from '../logger';
 export class ZeusArtifactProvider extends BaseArtifactProvider {
   /** Zeus API client */
   public readonly client: ZeusClient;
-  /** Zeus project owner */
-  public readonly repoOwner: string;
-  /** Zeus project name */
-  public readonly repoName: string;
 
-  public constructor(
-    repoOwner: string,
-    repoName: string,
-    downloadDirectory?: string
-  ) {
-    super();
+  public constructor(config: ArtifactProviderConfig) {
+    super(config);
     this.client = new ZeusClient({
-      defaultDirectory: downloadDirectory,
+      defaultDirectory: config.downloadDirectory,
       logger,
     });
-    this.repoOwner = repoOwner;
-    this.repoName = repoName;
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -224,7 +224,10 @@ export function getGitTagPrefix(): string {
  */
 export function getArtifactProviderFromConfig(): BaseArtifactProvider {
   const config = getConfiguration() || {};
-  const githubConfig = config.github;
+  const artifactProviderConfig = {
+    repoName: config.github.repo,
+    repoOwner: config.github.owner,
+  };
 
   const rawArtifactProvider = config.artifactProvider || {
     config: undefined,
@@ -235,7 +238,7 @@ export function getArtifactProviderFromConfig(): BaseArtifactProvider {
   switch (artifactProviderName) {
     case undefined: // Zeus is the default at the moment
     case ArtifactProviderName.Zeus:
-      return new ZeusArtifactProvider(githubConfig.owner, githubConfig.repo);
+      return new ZeusArtifactProvider(artifactProviderConfig);
     case ArtifactProviderName.None:
       return new NoneArtifactProvider();
     default: {

--- a/src/targets/base.ts
+++ b/src/targets/base.ts
@@ -4,7 +4,7 @@ import { FilterOptions } from '../stores/zeus';
 import { stringToRegexp } from '../utils/filters';
 import {
   BaseArtifactProvider,
-  CraftArtifact,
+  RemoteArtifact,
 } from '../artifact_providers/base';
 
 // TODO: make abstract?
@@ -62,7 +62,7 @@ export class BaseTarget {
   public async getArtifactsForRevision(
     revision: string,
     defaultFilterOptions: FilterOptions = {}
-  ): Promise<CraftArtifact[]> {
+  ): Promise<RemoteArtifact[]> {
     const filterOptions = {
       ...defaultFilterOptions,
       ...this.filterOptions,

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -12,7 +12,7 @@ import { renderTemplateSafe } from '../utils/strings';
 import { BaseTarget } from './base';
 import {
   BaseArtifactProvider,
-  CraftArtifact,
+  RemoteArtifact,
 } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope(`[gcs target]`);
@@ -220,7 +220,7 @@ export class GcsTarget extends BaseTarget {
     // download them from the artifact provider
     const localFilePaths = await Promise.all(
       artifacts.map(
-        async (artifact: CraftArtifact): Promise<string> =>
+        async (artifact: RemoteArtifact): Promise<string> =>
           this.artifactProvider.downloadArtifact(artifact)
       )
     );

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -3,7 +3,7 @@ import { TargetConfig } from '../schemas/project_config';
 import { forEachChained } from '../utils/async';
 import { ConfigurationError, reportError } from '../utils/errors';
 import {
-  DestinationPath,
+  BucketPath,
   CraftGCSClient,
   GCSBucketConfig,
   getGCSCredsFromEnv,
@@ -18,14 +18,14 @@ import {
 const logger = loggerRaw.withScope(`[gcs target]`);
 
 /**
- * Adds templating to the DestinationPath interface. (Partial so that the
- * required `path` property of that interface can be optional here, since we
- * won't have values to fill into the template until later.)
+ * Adds templating to the BucketPath interface.
+ *
+ * Omits required property `path` since that will be computed dynamically later.
  */
-interface PathTemplate extends Partial<DestinationPath> {
+interface PathTemplate extends Omit<BucketPath, 'path'> {
   /**
-   * Template for the destination path, into which `version` and `revision` can
-   * be substituted
+   * Template for the path, into which `version` and `revision` can be
+   * substituted
    */
   template: string;
 }
@@ -234,7 +234,7 @@ export class GcsTarget extends BaseTarget {
         this.materializePathTemplate(pathTemplate, version, revision);
         await this.gcsClient.uploadArtifacts(
           localFilePaths,
-          pathTemplate as DestinationPath
+          pathTemplate as BucketPath
         );
       }
     );

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -10,7 +10,7 @@ import { isPreviewRelease, parseVersion } from '../utils/version';
 import { BaseTarget } from './base';
 import {
   BaseArtifactProvider,
-  CraftArtifact,
+  RemoteArtifact,
 } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[npm]');
@@ -224,7 +224,7 @@ export class NpmTarget extends BaseTarget {
     }
 
     await Promise.all(
-      packageFiles.map(async (file: CraftArtifact) => {
+      packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
         logger.info(`Releasing ${file.filename} to NPM`);
         return this.publishPackage(path, publishOptions);

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -5,7 +5,7 @@ import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
 import {
   BaseArtifactProvider,
-  CraftArtifact,
+  RemoteArtifact,
 } from '../artifact_providers/base';
 
 const logger = loggerRaw.withScope('[nuget]');
@@ -95,7 +95,7 @@ export class NugetTarget extends BaseTarget {
     }
 
     await Promise.all(
-      packageFiles.map(async (file: CraftArtifact) => {
+      packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
         logger.info(`Uploading file "${file.filename}" via "dotnet nuget"`);
         return this.uploadAsset(path);

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -2,7 +2,7 @@ import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
 import {
   BaseArtifactProvider,
-  CraftArtifact,
+  RemoteArtifact,
 } from '../artifact_providers/base';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
@@ -96,7 +96,7 @@ export class PypiTarget extends BaseTarget {
     }
 
     await Promise.all(
-      packageFiles.map(async (file: CraftArtifact) => {
+      packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
         logger.info(`Uploading file "${file.filename}" via twine`);
         return this.uploadAsset(path);

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -29,7 +29,7 @@ import {
 import { stringToRegexp } from '../utils/filters';
 import { BaseTarget } from './base';
 import {
-  CraftArtifact,
+  RemoteArtifact,
   BaseArtifactProvider,
   MAX_DOWNLOAD_CONCURRENCY,
 } from '../artifact_providers/base';
@@ -363,7 +363,7 @@ export class RegistryTarget extends BaseTarget {
    *
    */
   public async getArtifactData(
-    artifact: CraftArtifact,
+    artifact: RemoteArtifact,
     version: string,
     revision: string
   ): Promise<any> {

--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 
-import { getGCSCredsFromEnv, CraftGCSClient } from '../gcsApi';
+import {
+  getGCSCredsFromEnv,
+  CraftGCSClient,
+  DEFAULT_UPLOAD_METADATA,
+} from '../gcsApi';
 import { withTempFile } from '../files';
 
 const mockGCSUpload = jest.fn();
@@ -118,49 +122,102 @@ describe('CraftGCSClient class', () => {
   const client = new CraftGCSClient({
     bucketName: 'captured-squirrels',
     credentials: {
-      client_email: 'might_huntress@dogs.com',
+      client_email: 'mighty_huntress@dogs.com',
       private_key: 'DoGsArEgReAtSoMeSeCrEtStUfFhErE',
     },
     projectId: 'squirrel-chasing',
   });
+
+  const squirrelStatsArtifact = {
+    // tslint:disable: object-literal-sort-keys
+    filename: 'march-squirrel-stats.csv',
+    storedFile: {
+      downloadFilepath: 'squirrel-chasing/march-2020-squirrel-stats.csv',
+      filename: 'march-2020-squirrel-stats.csv',
+      size: 1231,
+    },
+  };
+
+  const squirrelStatsLocalPath = './temp/march-squirrel-stats.csv';
+
+  const squirrelStatsBucketPath = {
+    path: '/stats/2020/',
+  };
+
+  const squirrelSimulatorArtifact = {
+    // tslint:disable: object-literal-sort-keys
+    filename: 'bundle.js',
+    storedFile: {
+      downloadFilepath: 'squirrel-chasing/squirrel-simulator-bundle.js',
+      filename: 'squirrel-simulator-bundle.js',
+      size: 123112,
+    },
+  };
+
+  const squirrelSimulatorLocalPath = './dist/bundle.js';
+
+  const squirrelSimulatorBucketPath = {
+    path: '/simulator/v1.12.1/dist/',
+    metadata: { cacheControl: `public, max-age=3600` },
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('calls the GCS library upload method with the right parameters', async () => {
-    await client.uploadArtifacts(['./dist/someFile'], {
-      path: '/some/destination/spot/',
-    });
+    await client.uploadArtifacts(
+      [squirrelStatsLocalPath],
+      squirrelStatsBucketPath
+    );
 
-    expect(mockGCSUpload).toHaveBeenCalledWith('./dist/someFile', {
-      // contentType: 'application/javascript; charset=utf-8',
-      destination: '/some/destination/spot/someFile',
+    const { filename } = squirrelStatsArtifact;
+    const { path: destinationPath } = squirrelStatsBucketPath;
+
+    expect(mockGCSUpload).toHaveBeenCalledWith(squirrelStatsLocalPath, {
+      destination: `${destinationPath}${filename}`,
       gzip: true,
-      metadata: { cacheControl: `public, max-age=300` },
+      metadata: DEFAULT_UPLOAD_METADATA,
     });
   });
 
-  it('detects content type correctly', async () => {
-    await client.uploadArtifacts(['./dist/bundle.js'], {
-      path: '/some/destination/spot/',
-    });
+  it('detects content type correctly for JS and map files', async () => {
+    await client.uploadArtifacts(
+      [squirrelSimulatorLocalPath],
+      squirrelSimulatorBucketPath
+    );
 
     expect(mockGCSUpload).toHaveBeenCalledWith(
-      './dist/bundle.js',
+      squirrelSimulatorLocalPath,
       expect.objectContaining({
         contentType: 'application/javascript; charset=utf-8',
       })
     );
   });
 
+  it('allows overriding of default metadata', async () => {
+    await client.uploadArtifacts(
+      [squirrelSimulatorLocalPath],
+      squirrelSimulatorBucketPath
+    );
+
+    const { metadata } = squirrelSimulatorBucketPath;
+
+    expect(mockGCSUpload).toHaveBeenCalledWith(
+      squirrelSimulatorLocalPath,
+      expect.objectContaining({
+        metadata,
+      })
+    );
+  });
+
   it('errors if destination path not specified', async () => {
     await expect(
-      client.uploadArtifacts(['./dogs'], undefined as any)
+      client.uploadArtifacts([squirrelSimulatorLocalPath], undefined as any)
     ).rejects.toThrowError('no destination path specified!');
 
     await expect(
-      client.uploadArtifacts(['./dogs'], {
+      client.uploadArtifacts([squirrelStatsLocalPath], {
         path: undefined,
       } as any)
     ).rejects.toThrowError('no destination path specified!');
@@ -168,24 +225,29 @@ describe('CraftGCSClient class', () => {
 
   it('errors if GCS upload goes sideways', async () => {
     mockGCSUpload.mockImplementation(() => {
-      throw new Error('whoops');
+      throw new Error('The squirrel got away!');
     });
 
+    const { filename } = squirrelSimulatorArtifact;
+    const { path: destinationPath } = squirrelSimulatorBucketPath;
+
     await expect(
-      client.uploadArtifacts(['./dist/someFile'], {
-        path: '/some/destination/spot/',
-      })
+      client.uploadArtifacts(
+        [squirrelSimulatorLocalPath],
+        squirrelSimulatorBucketPath
+      )
     ).rejects.toThrowError(
-      'Error uploading `someFile` to `/some/destination/spot/someFile`'
+      `Error uploading \`${filename}\` to \`${destinationPath}${filename}\``
     );
   });
 
   it("doesn't upload anything in dry run mode", async () => {
     process.env.DRY_RUN = 'true';
 
-    await client.uploadArtifacts(['./dist/someFile'], {
-      path: '/some/destination/spot/',
-    });
+    await client.uploadArtifacts(
+      [squirrelStatsLocalPath],
+      squirrelStatsBucketPath
+    );
 
     expect(mockGCSUpload).not.toHaveBeenCalled();
   });

--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -166,8 +166,8 @@ describe('CraftGCSClient class', () => {
   });
 
   it('calls the GCS library upload method with the right parameters', async () => {
-    await client.uploadArtifacts(
-      [squirrelStatsLocalPath],
+    await client.uploadArtifact(
+      squirrelStatsLocalPath,
       squirrelStatsBucketPath
     );
 
@@ -182,8 +182,8 @@ describe('CraftGCSClient class', () => {
   });
 
   it('detects content type correctly for JS and map files', async () => {
-    await client.uploadArtifacts(
-      [squirrelSimulatorLocalPath],
+    await client.uploadArtifact(
+      squirrelSimulatorLocalPath,
       squirrelSimulatorBucketPath
     );
 
@@ -196,8 +196,8 @@ describe('CraftGCSClient class', () => {
   });
 
   it('allows overriding of default metadata', async () => {
-    await client.uploadArtifacts(
-      [squirrelSimulatorLocalPath],
+    await client.uploadArtifact(
+      squirrelSimulatorLocalPath,
       squirrelSimulatorBucketPath
     );
 
@@ -211,41 +211,28 @@ describe('CraftGCSClient class', () => {
     );
   });
 
-  it('errors if destination path not specified', async () => {
-    await expect(
-      client.uploadArtifacts([squirrelSimulatorLocalPath], undefined as any)
-    ).rejects.toThrowError('no destination path specified!');
-
-    await expect(
-      client.uploadArtifacts([squirrelStatsLocalPath], {
-        path: undefined,
-      } as any)
-    ).rejects.toThrowError('no destination path specified!');
-  });
-
   it('errors if GCS upload goes sideways', async () => {
     mockGCSUpload.mockImplementation(() => {
       throw new Error('The squirrel got away!');
     });
 
     const { filename } = squirrelSimulatorArtifact;
-    const { path: destinationPath } = squirrelSimulatorBucketPath;
 
     await expect(
-      client.uploadArtifacts(
-        [squirrelSimulatorLocalPath],
+      client.uploadArtifact(
+        squirrelSimulatorLocalPath,
         squirrelSimulatorBucketPath
       )
     ).rejects.toThrowError(
-      `Error uploading \`${filename}\` to \`${destinationPath}${filename}\``
+      `Encountered an error while uploading \`${filename}\``
     );
   });
 
   it("doesn't upload anything in dry run mode", async () => {
     process.env.DRY_RUN = 'true';
 
-    await client.uploadArtifacts(
-      [squirrelStatsLocalPath],
+    await client.uploadArtifact(
+      squirrelStatsLocalPath,
       squirrelStatsBucketPath
     );
 

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -13,7 +13,7 @@ import { reportError, ConfigurationError } from './errors';
 import { checkEnvForPrerequisite, RequiredConfigVar } from './env';
 
 const DEFAULT_MAX_RETRIES = 5;
-const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
+export const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
 
 const logger = loggerRaw.withScope(`[gcs api]`);
 


### PR DESCRIPTION
A few different changes to interfaces and other inner workings of artifact providers. See individual commits for details. 

(Oh, and now the GCS client tests have way more squirrels in them. Hey, I had to do _something_ to amuse myself while on lockdown!) 
