### PR TITLE
feat(dry-run): Let dry run keep going after errors in `forEachChained`

### DIFF
--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { reportError } from './errors';
 
 /**
  * Asynchronously calls the predicate on every element of the array and filters
@@ -58,7 +59,9 @@ export async function forEachChained<T>(
 ): Promise<void> {
   return array.reduce(
     async (prev, ...args: [T]) =>
-      prev.then(() => iteratee.apply(thisArg, args)),
+      // catching errors after each .then() lets us report them and keep going
+      // if in dry-run mode (in regular mode, reportError() just re-throws)
+      prev.then(() => iteratee.apply(thisArg, args)).catch(reportError),
     Promise.resolve()
   );
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -21,17 +21,24 @@ export class ConfigurationError extends Error {
 }
 
 /**
- * Writes a message to "error" log if in dry-mode, throws an error otherwise
+ * Writes an error or message to "error" log if in dry-mode, throws an error
+ * otherwise
  *
- * @param message Error message
- * @param customLogger Optional logger to use
+ * @param error Error object or error message
+ * @param errorLogger Optional logger to use
  */
-export function reportError(message: string, customLogger?: any): void {
-  const errorLogger = customLogger || logger;
+export function reportError(
+  error: Error | string,
+  errorLogger: { error: Function; [key: string]: any } = logger
+): void {
   if (!isDryRun()) {
-    throw new Error(message);
+    // wrap the error in an Error object if it isn't already one
+    const errorObj = error instanceof Error ? error : new Error(error);
+    throw errorObj;
   } else {
-    errorLogger.error(`[dry-run] ${message}`);
+    // conversely, convert the error to a string if it isn't already one
+    const errorStr = typeof error === 'string' ? error : String(error);
+    errorLogger.error(`[dry-run] ${errorStr}`);
   }
 }
 


### PR DESCRIPTION
The basic idea of dry-run mode is to go through the entire process, with no side effects, reporting what would happen and/or any errors which occur. Currently, however, errors inside of a `forEachChained` call break the chain, so that the user can't see what would have happened had the rest of the links executed.

This PR fixes that by catching errors while executing each link. In order to accomplish the report-error-when-dry-run-throw-error-when-not behavior, it modifies the existing `reportError` function (which already does that with error _messages_) to also accept `Error` objects. Finally, it adds tests for each mode, with both sync and async iteratees.