### PR TITLE
fix(sentry): Remove initialization guard on sentry methods

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,6 @@
-import { Severity } from '@sentry/node';
+import { addBreadcrumb, Severity } from '@sentry/node';
 import Table = require('cli-table');
 import consola = require('consola');
-
-import { addBreadcrumb } from './utils/sentry';
 
 /**
  * Format a list as a table

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,6 @@
 import { logger } from '../logger';
 import { isDryRun } from './helpers';
-import { captureException } from './sentry';
+import { captureException } from '@sentry/node';
 
 /**
  * Custom error class that describes client configuration errors

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -5,16 +5,10 @@ import * as Sentry from '@sentry/node';
 import { logger } from '../logger';
 import { getPackageVersion } from './version';
 
-let sentryInitialized = false;
-
 /**
  * Initializes Sentry SDK if CRAFT_SENTRY_SDN is set
  */
 export function initSentrySdk(): void {
-  if (sentryInitialized) {
-    return;
-  }
-
   const sentryDsn = (process.env.CRAFT_SENTRY_DSN || '').trim();
   if (!sentryDsn.startsWith('http')) {
     logger.debug('Not initializing Sentry SDK');
@@ -35,33 +29,4 @@ export function initSentrySdk(): void {
     scope.setExtra('craft-version', getPackageVersion());
     scope.setExtra('working-directory', process.cwd());
   });
-
-  sentryInitialized = true;
-}
-
-/**
- * Returns "true" if Sentry SDK is initialized
- */
-export function isSentryInitialized(): boolean {
-  return sentryInitialized;
-}
-
-/**
- * Sends an exception to Sentry
- *
- * @param e Error (exception) object
- */
-export function captureException(e: any): string | undefined {
-  return sentryInitialized ? Sentry.captureException(e) : undefined;
-}
-
-/**
- * Records a breadcrumb to Sentry
- *
- * @param e Error (exception) object
- */
-export function addBreadcrumb(breadcrumb: Sentry.Breadcrumb): void {
-  if (sentryInitialized) {
-    Sentry.addBreadcrumb(breadcrumb);
-  }
 }


### PR DESCRIPTION
If the SDK hasn't yet been initialized (meaning the hub has no client bound to it), then all client methods (including `captureException`) [are no-ops](https://github.com/getsentry/sentry-javascript/blob/fd68dfa266fbea7c93712692aa8cfac7d6572802/packages/hub/src/hub.ts#L70-L75), and `addBreadcrumb` [is a no-op](https://github.com/getsentry/sentry-javascript/blob/fd68dfa266fbea7c93712692aa8cfac7d6572802/packages/hub/src/hub.ts#L238-L240), so it's safe to call them without checking the SDK's initialization status. Further, if the SDK _has_ already been initialized, then calling `init` again just replaces the bound client [with an identical client](https://github.com/getsentry/sentry-javascript/blob/a047ef28b9164597c8a57678810263d568f9d1b7/packages/hub/src/hub.ts#L87-L93), so it also doesn't need such a check.

Removing the wrapper on `addBreadcrumb`, in particular, lets us get out of the circular import problem of the logger [importing from the `sentry` module](https://github.com/getsentry/craft/blob/7ed856ac5fdc306b49f52ca1ed3a4a9a85ee36c2/src/logger.ts#L5), and the `sentry` module [importing from the logger](https://github.com/getsentry/craft/blob/7ed856ac5fdc306b49f52ca1ed3a4a9a85ee36c2/src/utils/sentry.ts#L5). (This is causing problems with mocks for testing.)