### PR TITLE
fix(dry-run): Fix reporting of required artifact check in dry-run mode

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -257,12 +257,17 @@ async function checkRequiredArtifacts(
     throw new Error(`Revision ${revision} not found!`);
   }
 
+  // innocent until proven guilty...
+  let checkPassed = true;
+
   for (const nameRegexString of requiredNames) {
     const nameRegex = stringToRegexp(nameRegexString);
+
     const matchedArtifacts = artifacts.filter(artifact =>
       nameRegex.test(artifact.filename)
     );
     if (matchedArtifacts.length === 0) {
+      checkPassed = false;
       reportError(
         `No matching artifact found for the required pattern: ${nameRegexString}`
       );
@@ -272,7 +277,13 @@ async function checkRequiredArtifacts(
       );
     }
   }
-  logger.debug('Check for "requiredNames" passed.');
+
+  // only in dry-run mode might we fail the overall test but still get here
+  if (checkPassed) {
+    logger.debug('Check for "requiredNames" passed.');
+  } else {
+    logger.error('Check for "requiredNames" failed.');
+  }
 }
 
 // TODO there is at least one case that is not covered: how to detect Zeus builds


### PR DESCRIPTION
In dry-run mode, errors don't actually stop iteration of a for loop (since they're just logged, not thrown), so it's possible to make it all the way through a fail-fast loop, even having failed on at least one iteration. Therefore, we can't assume that just because we made it past the for loop, the test succeeded.

This adds a flag and a check of that flag, so that we report the correct result in dry-run mode.