### PR TITLE
ref(zeus): Make zeus handle its own special cases

### DIFF
--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -32,7 +32,7 @@ export class NoneArtifactProvider extends BaseArtifactProvider {
    */
   protected async doListArtifactsForRevision(
     _revision: string
-  ): Promise<RemoteArtifact[] | undefined> {
+  ): Promise<RemoteArtifact[]> {
     return [];
   }
 }

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -9,9 +9,11 @@ import {
   RemoteArtifact,
   ArtifactProviderConfig,
 } from '../artifact_providers/base';
-import { logger } from '../logger';
+import { logger as loggerRaw } from '../logger';
 
 // TODO (kmclb) once `craft upload` is a thing, add an upload method here (and change the docstring below)
+
+const logger = loggerRaw.withScope(`[zeus api]`);
 
 /**
  * Zeus artifact provider
@@ -111,7 +113,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
    */
   protected async doListArtifactsForRevision(
     revision: string
-  ): Promise<RemoteArtifact[] | undefined> {
+  ): Promise<RemoteArtifact[]> {
     logger.debug(
       `Fetching Zeus artifacts for ${this.repoOwner}/${this.repoName}, revision ${revision}`
     );
@@ -123,14 +125,43 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
         revision
       );
     } catch (e) {
+      // zeus is the only artifact provider which could know about a commit
+      // (from its role as a status provider) but not have any files associated
+      // with that commit. (For all other artifact providers, not knowing about
+      // the commit and having no files associated with the commit are one and
+      // the same.) In the former case (known commit, no files), zeus will
+      // return an empty list, whereas in the latter case (unknown commit), it
+      // will error. This error message check and the length check below are
+      // here to disambiguate those two situations.
       const errorMessage: string = e.message || '';
       if (errorMessage.match(/404 not found|resource not found/i)) {
-        return undefined;
+        logger.debug(`Revision \`${revision}\` not found!`);
       }
       throw e;
     }
 
-    return artifacts.map(zeusArtifact =>
+    // see comment above
+    if (artifacts.length === 0) {
+      logger.debug(`Revision \`${revision}\` found.`);
+    }
+
+    // similarly, zeus is the only artifact provider which will store multiple
+    // copies of the same file for a given revision, so to mimic the behavior of
+    // the other providers (which overwrite pre-existing, identically-named
+    // files within the same commit), for each filename, take the one with the
+    // most recent update time
+    const nameToArtifacts = _.groupBy(artifacts, artifact => artifact.name);
+    const dedupedArtifacts = Object.keys(nameToArtifacts).map(artifactName => {
+      const artifactObjects = nameToArtifacts[artifactName];
+      // Sort by the update time
+      const sortedArtifacts = _.sortBy(
+        artifactObjects,
+        artifact => Date.parse(artifact.updated_at || '') || 0
+      );
+      return sortedArtifacts[sortedArtifacts.length - 1];
+    });
+
+    return dedupedArtifacts.map(zeusArtifact =>
       this.convertToRemoteArtifact(zeusArtifact)
     );
   }

--- a/src/commands/artifacts_cmds/download.ts
+++ b/src/commands/artifacts_cmds/download.ts
@@ -89,10 +89,7 @@ async function handlerMain(argv: ArtifactsDownloadOptions): Promise<any> {
   const outputDirectory = await prepareOutputDirectory(argv);
 
   const artifacts = await artifactProvider.listArtifactsForRevision(revision);
-  if (!artifacts) {
-    logger.warn(`Revision ${revision} can not be found.`);
-    return undefined;
-  } else if (artifacts.length === 0) {
+  if (artifacts.length === 0) {
     logger.info(`No artifacts found for revision ${revision}`);
     return undefined;
   }

--- a/src/commands/artifacts_cmds/list.ts
+++ b/src/commands/artifacts_cmds/list.ts
@@ -28,10 +28,7 @@ async function handlerMain(argv: ArtifactsOptions): Promise<any> {
 
   const artifacts = await artifactProvider.listArtifactsForRevision(revision);
 
-  if (!artifacts) {
-    logger.warn(`Revision ${revision} can not be found.`);
-    return undefined;
-  } else if (artifacts.length === 0) {
+  if (artifacts.length === 0) {
     logger.info(`No artifacts found for revision ${revision}`);
     return undefined;
   }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -184,7 +184,7 @@ async function printRevisionSummary(
   revision: string
 ): Promise<void> {
   const artifacts = await artifactProvider.listArtifactsForRevision(revision);
-  if (artifacts && artifacts.length > 0) {
+  if (artifacts.length > 0) {
     const artifactData = artifacts.map(ar => [
       ar.filename,
       formatSize(ar.storedFile.size),
@@ -199,8 +199,6 @@ async function printRevisionSummary(
       artifactData
     );
     logger.info(`Available artifacts: \n${table.toString()}\n`);
-  } else if (!artifacts) {
-    throw new Error(`Revision ${revision} not found!`);
   } else {
     logger.warn('No artifacts found for the revision.');
   }
@@ -253,9 +251,6 @@ async function checkRequiredArtifacts(
   }
   logger.debug('Checking that the required artifact names are present...');
   const artifacts = await artifactProvider.listArtifactsForRevision(revision);
-  if (!artifacts) {
-    throw new Error(`Revision ${revision} not found!`);
-  }
 
   for (const nameRegexString of requiredNames) {
     const nameRegex = stringToRegexp(nameRegexString);


### PR DESCRIPTION
Currently, all of the `listArtifactsForRevision` methods on artifact providers (the base and its descendants) have a signature indicating that they return one of three things: an array full of artifacts, an empty array, or `undefined`. The reason for this is historical, as these three possible return values correspond to the three possible responses when asking zeus for a commit's artifacts, respectively

1. "Yup, got that commit, and here are the associated artifacts."
2. "Yup, got that commit, but there are no artifacts associated with it."
3. "Wait, what commit do you want stuff for? Never heard of it."

The only reason response number two is a possibility, though, is because zeus is both a status provider _and_ an artifact provider, the former role being the one which would let it learn of a commit independent of any associated artifacts; any service serving solely as an artifact provider would have no way of landing in situation two.

Further, zeus - unlike other artifact providers - will store multiple copies of the same file attached to the same commit, rather than overwriting the file when a newer version is uploaded to a commit which already has an older version. Therefore, when retrieving the file list, we need to group them by filename and sort them by update date, to mimic the overwriting behavior.

This PR makes it so that zeus, rather than the base class, has to deal with its own differing behavior, thereby simplifying the base class, its other descendants, and any files which use methods from same. Specifically, it lets us cut `undefined` out of the signature for all of these methods, since we only need to represent situations one and three above, which we can do by returning either a full array or an empty array. (Zeus still handles all three cases, but now does so with log statements rather than return values, since functionally cases two and three are equivalent.)