### PR TITLE
feat(artifacts): Implement GCS artifact provider

### DIFF
--- a/src/__mocks__/logger.ts
+++ b/src/__mocks__/logger.ts
@@ -1,0 +1,10 @@
+// tslint:disable-next-line: no-var-requires
+const consola = require('consola');
+
+const loggerModule: typeof consola = jest.genMockFromModule('../logger');
+
+loggerModule.logger.withScope = function(): any {
+  return this;
+};
+
+module.exports = loggerModule;

--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -80,6 +80,8 @@ export interface ArtifactProviderConfig {
   repoOwner: string;
   /** Destination for any files the provider downloads */
   downloadDirectory?: string;
+  /** Other, provider-specific config options */
+  [key: string]: any;
 }
 
 /**
@@ -101,10 +103,8 @@ export abstract class BaseArtifactProvider {
     [path: string]: { [checksumType: string]: string };
   } = {};
 
-  /** Name of the repo containing the code getting released */
-  protected readonly repoName: string;
-  /** GitHub org to which the repo belongs */
-  protected readonly repoOwner: string;
+  /** The configuration object passed to the constructor */
+  protected readonly config: ArtifactProviderConfig;
 
   /** Directory that will be used for downloading artifacts by default */
   protected defaultDownloadDirectory: string | undefined;
@@ -112,10 +112,9 @@ export abstract class BaseArtifactProvider {
   public constructor(config: ArtifactProviderConfig) {
     this.clearCaches();
 
-    const { repoName, repoOwner, downloadDirectory } = config;
+    this.config = config;
 
-    this.repoName = repoName;
-    this.repoOwner = repoOwner;
+    const { downloadDirectory } = config;
     if (downloadDirectory) {
       this.setDownloadDirectory(downloadDirectory);
     }

--- a/src/artifact_providers/gcs.ts
+++ b/src/artifact_providers/gcs.ts
@@ -1,0 +1,67 @@
+import {
+  BaseArtifactProvider,
+  RemoteArtifact,
+  ArtifactProviderConfig,
+} from '../artifact_providers/base';
+import { CraftGCSClient, getGCSCredsFromEnv } from '../utils/gcsApi';
+import { ConfigurationError } from '../utils/errors';
+
+/**
+ * Google Cloud Storage artifact provider
+ */
+export class GCSArtifactProvider extends BaseArtifactProvider {
+  /** Client for interacting with the GCS bucket */
+  private readonly gcsClient: CraftGCSClient;
+
+  public constructor(config: ArtifactProviderConfig) {
+    super(config);
+    const { project_id, client_email, private_key } = getGCSCredsFromEnv(
+      {
+        name: 'CRAFT_GCS_STORE_CREDS_JSON',
+      },
+      {
+        name: 'CRAFT_GCS_STORE_CREDS_PATH',
+      }
+    );
+
+    // TODO (kmclb) get rid of this check once config validation is working
+    if (!config.bucket) {
+      throw new ConfigurationError(
+        'No GCS bucket provided in artifact provider config!'
+      );
+    }
+
+    this.gcsClient = new CraftGCSClient({
+      bucketName: config.bucket,
+      credentials: { client_email, private_key },
+      projectId: project_id,
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected async doDownloadArtifact(
+    artifact: RemoteArtifact,
+    downloadDirectory: string
+  ): Promise<string> {
+    return this.gcsClient.downloadArtifact(
+      artifact.storedFile.downloadFilepath,
+      downloadDirectory
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected async doListArtifactsForRevision(
+    revision: string
+  ): Promise<RemoteArtifact[]> {
+    const { repoName, repoOwner } = this.config;
+    return this.gcsClient.listArtifactsForRevision(
+      repoOwner,
+      repoName,
+      revision
+    );
+  }
+}

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -114,14 +114,15 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
   protected async doListArtifactsForRevision(
     revision: string
   ): Promise<RemoteArtifact[]> {
+    const { repoName, repoOwner } = this.config;
     logger.debug(
-      `Fetching Zeus artifacts for ${this.repoOwner}/${this.repoName}, revision ${revision}`
+      `Fetching Zeus artifacts for ${repoOwner}/${repoName}, revision ${revision}`
     );
     let artifacts;
     try {
       artifacts = await this.client.listArtifactsForRevision(
-        this.repoOwner,
-        this.repoName,
+        repoOwner,
+        repoName,
         revision
       );
     } catch (e) {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -426,9 +426,11 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
   logger.debug('Revision to publish: ', revision);
 
   const statusProvider = getStatusProviderFromConfig();
-  logger.info(`Using "${statusProvider.constructor.name}" for status checks`);
   const artifactProvider = getArtifactProviderFromConfig();
+  logger.info(' ');
+  logger.info(`Using "${statusProvider.constructor.name}" for status checks`);
   logger.info(`Using "${artifactProvider.constructor.name}" for artifacts`);
+  logger.info(' ');
 
   // Check status of all CI builds linked to the revision
   await checkRevisionStatus(statusProvider, revision, argv.noStatusCheck);

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,17 +223,15 @@ export function getGitTagPrefix(): string {
  * NoneArtifactProvider if artifact storage is disabled).
  */
 export function getArtifactProviderFromConfig(): BaseArtifactProvider {
-  const config = getConfiguration() || {};
-  const artifactProviderConfig = {
-    repoName: config.github.repo,
-    repoOwner: config.github.owner,
-  };
+  const projectConfig = getConfiguration();
 
-  const rawArtifactProvider = config.artifactProvider || {
-    config: undefined,
-    name: undefined,
+  const artifactProviderName = projectConfig.artifactProvider?.name;
+
+  const artifactProviderConfig = {
+    ...projectConfig.artifactProvider?.config,
+    repoName: projectConfig.github.repo,
+    repoOwner: projectConfig.github.owner,
   };
-  const artifactProviderName = rawArtifactProvider.name;
 
   switch (artifactProviderName) {
     case undefined: // Zeus is the default at the moment

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,8 @@ import {
 import { BaseArtifactProvider } from './artifact_providers/base';
 import { ZeusArtifactProvider } from './artifact_providers/zeus';
 import { NoneArtifactProvider } from './artifact_providers/none';
+import { GCSArtifactProvider } from './artifact_providers/gcs';
+
 import { ZeusStatusProvider } from './status_providers/zeus';
 import { GithubStatusProvider } from './status_providers/github';
 import { BaseStatusProvider } from './status_providers/base';
@@ -239,6 +241,8 @@ export function getArtifactProviderFromConfig(): BaseArtifactProvider {
       return new ZeusArtifactProvider(artifactProviderConfig);
     case ArtifactProviderName.None:
       return new NoneArtifactProvider();
+    case ArtifactProviderName.GCS:
+      return new GCSArtifactProvider(artifactProviderConfig);
     default: {
       throw new ConfigurationError('Invalid artifact provider');
     }

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -66,11 +66,11 @@ export class GcsTarget extends BaseTarget {
     // tslint:disable: object-literal-sort-keys
     const { project_id, client_email, private_key } = getGCSCredsFromEnv(
       {
-        name: 'CRAFT_GCS_TARGET_CREDENTIALS_JSON',
+        name: 'CRAFT_GCS_TARGET_CREDS_JSON',
         legacyName: 'CRAFT_GCS_CREDENTIALS_JSON',
       },
       {
-        name: 'CRAFT_GCS_TARGET_CREDENTIALS_PATH',
+        name: 'CRAFT_GCS_TARGET_CREDS_PATH',
         legacyName: 'CRAFT_GCS_CREDENTIALS_PATH',
       }
     );

--- a/src/utils/__fixtures__/gcsApi.ts
+++ b/src/utils/__fixtures__/gcsApi.ts
@@ -1,6 +1,15 @@
 import { RemoteArtifact } from '../../artifact_providers/base';
 
+export const dogsGHOrg = 'dogs-rule';
+
+export const squirrelRepo = 'squirrel-operations';
+
 export const squirrelBucket = 'squirrel-chasing';
+
+export const squirrelSimulatorCommit =
+  '4d6169736579203c33203c3320436861726c6965';
+
+export const squirrelStatsCommit = '3c3320446f67732061726520677265617421203c33';
 
 export const gcsCredsJSON = JSON.stringify({
   // tslint:disable: object-literal-sort-keys

--- a/src/utils/__fixtures__/gcsApi.ts
+++ b/src/utils/__fixtures__/gcsApi.ts
@@ -1,0 +1,55 @@
+import { RemoteArtifact } from '../../artifact_providers/base';
+
+export const squirrelBucket = 'squirrel-chasing';
+
+export const gcsCredsJSON = JSON.stringify({
+  // tslint:disable: object-literal-sort-keys
+  project_id: 'o-u-t-s-i-d-e',
+  private_key: 'DoGsArEgReAtSoMeSeCrEtStUfFhErE',
+  client_email: 'might_huntress@dogs.com',
+  other_stuff: 'can be anything',
+  tail_wagging: 'true',
+  barking: 'also VERY true',
+});
+
+export const squirrelStatsArtifact: RemoteArtifact = {
+  filename: 'march-2020-stats.csv',
+  mimeType: 'text/csv',
+  storedFile: {
+    downloadFilepath: 'captured-squirrels/march-2020-stats.csv',
+    filename: 'march-2020-stats.csv',
+    lastUpdated: '2020-03-30T19:14:44.694Z',
+    size: 112112,
+  },
+};
+
+export const squirrelStatsLocalPath = './temp/march-2020-stats.csv';
+
+export const squirrelStatsBucketPath = {
+  path: '/stats/2020/',
+};
+
+export const squirrelSimulatorArtifact: RemoteArtifact = {
+  filename: 'bundle.js',
+  mimeType: 'application/json',
+  storedFile: {
+    downloadFilepath: 'squirrel-simulator/bundle.js',
+    filename: 'bundle.js',
+    lastUpdated: '2020-03-30T19:14:44.694Z',
+    size: 123112,
+  },
+};
+
+export const squirrelSimulatorLocalPath = './dist/bundle.js';
+
+export const squirrelSimulatorBucketPath = {
+  path: '/simulator/v1.12.1/dist/',
+  metadata: { cacheControl: `public, max-age=3600` },
+};
+
+export {
+  squirrelSimulatorGCSFileObj,
+  squirrelStatsGCSFileObj,
+} from './gcsFileObj';
+
+export const tempDownloadDirectory = './temp/';

--- a/src/utils/__fixtures__/gcsFileObj.ts
+++ b/src/utils/__fixtures__/gcsFileObj.ts
@@ -1,0 +1,179 @@
+// tslint:disable: object-literal-sort-keys
+
+// Note: All but the last two objects in this file (the ones which are exported)
+// exist purely because real-life GCS File objects are enormous, deeply nested,
+// and full of repetition, so breaking them up is the only way to have any idea
+// of what's in them.
+
+const acl = {
+  owners: {},
+  readers: {},
+  writers: {},
+  pathPrefix: '/acl',
+};
+
+const defaultAcl = {
+  ...acl,
+  pathPrefix: '/defaultObjectAcl',
+};
+
+const aclWithDefault = {
+  ...acl,
+  default: defaultAcl,
+};
+
+const aclRoles = {
+  OWNER_ROLE: 'OWNER',
+  READER_ROLE: 'READER',
+  WRITER_ROLE: 'WRITER',
+};
+
+const scopes = [
+  'https://www.googleapis.com/auth/iam',
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/devstorage.full_control',
+];
+
+const authClient = {
+  jsonContent: {
+    client_email: 'mighty_huntress@dogs.com',
+    private_key: 'DoGsArEgReAtSoMeSeCrEtStUfFhErE',
+  },
+  cachedCredential: {
+    domain: null,
+    _events: {},
+    _eventsCount: 0,
+    transporter: {},
+    credentials: {
+      access_token: 'IaMaGoOdDoGpLeAsElEtMeIn',
+      token_type: 'Bearer',
+      expiry_date: 1585600265000,
+      refresh_token: 'jwt-placeholder',
+    },
+    certificateExpiry: null,
+    refreshTokenPromises: {},
+    eagerRefreshThresholdMillis: 300000,
+    email: 'mighty_huntress@dogs.com',
+    key: 'DoGsArEgReAtSoMeSeCrEtStUfFhErE',
+    scopes,
+    gtoken: {
+      token: 'IaMaGoOdDoGpLeAsElEtMeIn',
+      expiresAt: 1585600265000,
+      rawToken: {
+        access_token: 'IaMaGoOdDoGpLeAsElEtMeIn',
+        expires_in: 3599,
+        token_type: 'Bearer',
+      },
+      tokenExpires: null,
+      key: 'DoGsArEgReAtSoMeSeCrEtStUfFhErE',
+      iss: 'mighty_huntress@dogs.com',
+      scope:
+        'https://www.googleapis.com/auth/iam https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.full_control',
+    },
+  },
+  _cachedProjectId: 'o-u-t-s-i-d-e',
+  scopes,
+};
+
+const storage = {
+  baseUrl: 'https://www.googleapis.com/storage/v1',
+  globalInterceptors: [],
+  interceptors: [],
+  packageJson: '<irrelevant and large - removed from fixture>',
+  projectId: 'o-u-t-s-i-d-e',
+  projectIdRequired: false,
+  authClient,
+  acl: aclRoles,
+};
+
+const bucket = {
+  domain: null,
+  _events: {},
+  _eventsCount: 0,
+  metadata: {},
+  baseUrl: '/b',
+  parent: storage,
+  id: 'squirrel-chasing',
+  methods: {
+    create: true,
+  },
+  interceptors: [],
+  name: 'squirrel-chasing',
+  storage,
+  acl: aclWithDefault,
+  iam: {
+    resourceId_: 'buckets/[object Promise]',
+  },
+};
+
+export const squirrelStatsGCSFileObj = {
+  domain: null,
+  _events: {},
+  _eventsCount: 0,
+  metadata: {
+    kind: 'storage#object',
+    id: 'squirrel-chasing/captured-squirrels/march-2020-stats.csv/12312012',
+    selfLink:
+      'https://www.googleapis.com/storage/v1/b/squirrel-chasing/o/captured-squirrels%2Fmarch-2020-stats.csv',
+    mediaLink:
+      'https://www.googleapis.com/download/storage/v1/b/squirrel-chasing/o/captured-squirrels%2Fmarch-2020-stats.csv?generation=12312012&alt=media',
+    name: 'captured-squirrels/march-2020-stats.csv',
+    bucket: 'squirrel-chasing',
+    generation: '12312012',
+    metageneration: '1',
+    contentType: 'text/csv',
+    storageClass: 'STANDARD',
+    size: '112112',
+    md5Hash: 'DOX0leRinotMTM7EGGXpjQ==',
+    crc32c: 'fVcyCg==',
+    etag: 'CI/UrJz0wugCEAE=',
+    timeCreated: '2020-03-30T19:14:44.694Z',
+    updated: '2020-03-30T19:14:44.694Z',
+    timeStorageClassUpdated: '2020-03-30T19:14:44.694Z',
+  },
+  baseUrl: '/o',
+  parent: bucket,
+  id: 'captured-squirrels%2Fmarch-2020-stats.csv',
+  methods: {},
+  interceptors: [],
+  bucket,
+  storage,
+  name: 'captured-squirrels/march-2020-stats.csv',
+  acl,
+};
+
+export const squirrelSimulatorGCSFileObj = {
+  domain: null,
+  _events: {},
+  _eventsCount: 0,
+  metadata: {
+    kind: 'storage#object',
+    id: 'squirrel-chasing/squirrel-simulator/bundle.js/11212012',
+    selfLink:
+      'https://www.googleapis.com/storage/v1/b/squirrel-chasing/o/squirrel-simulator%2Fbundle.js',
+    mediaLink:
+      'https://www.googleapis.com/download/storage/v1/b/squirrel-chasing/o/squirrel-simulator%2Fbundle.js?generation=11212012&alt=media',
+    name: 'squirrel-simulator/bundle.js',
+    bucket: 'squirrel-chasing',
+    generation: '11212012',
+    metageneration: '1',
+    contentType: 'application/javascript',
+    storageClass: 'STANDARD',
+    size: '123112',
+    md5Hash: 'DOX0leRinotMTM7EGGXpjQ==',
+    crc32c: 'fVcyCg==',
+    etag: 'CI/UrJz0wugCEAE=',
+    timeCreated: '2020-03-30T19:14:44.694Z',
+    updated: '2020-03-30T19:14:44.694Z',
+    timeStorageClassUpdated: '2020-03-30T19:14:44.694Z',
+  },
+  baseUrl: '/o',
+  parent: bucket,
+  id: 'squirrel-simulator%2Fbundle.js',
+  methods: {},
+  interceptors: [],
+  bucket,
+  storage,
+  name: 'squirrel-simulator/bundle.js',
+  acl,
+};

--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -28,21 +28,7 @@ import {
 
 /*************** mocks and other setup ***************/
 
-jest.mock('../../logger', () => ({
-  logger: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-
-    // normally withScope returns a new logger instance, but then we lose the
-    // mocked one, so instead, have it just return the instance on which it was
-    // called. Written as an old-skool function because arrow functions don't
-    // bind `this` the same way.
-    withScope(): {} {
-      return this;
-    },
-  },
-}));
+jest.mock('../../logger');
 
 const mockGCSUpload = jest.fn();
 const mockGCSDownload = jest.fn();

--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 
 import {
   getGCSCredsFromEnv,
@@ -6,58 +7,101 @@ import {
   DEFAULT_UPLOAD_METADATA,
 } from '../gcsApi';
 import { withTempFile } from '../files';
+import { RemoteArtifact } from '../../../dist/artifact_providers/base.d';
+
+const cleanEnv = { ...process.env };
+
+/**
+ * Mocks for parts of the gcs client package, and for controling whether or not
+ * we can find given files
+ */
 
 const mockGCSUpload = jest.fn();
+const mockGCSDownload = jest.fn();
 jest.mock('@google-cloud/storage', () => ({
-  Bucket: jest.fn(() => ({ upload: mockGCSUpload })),
+  Bucket: jest.fn(() => ({
+    file: jest.fn(() => ({ download: mockGCSDownload })),
+    upload: mockGCSUpload,
+  })),
   Storage: jest.fn(() => ({})),
 }));
 
-describe('getGCSCredsFromEnv', () => {
-  const cleanEnv = { ...process.env };
+const syncExistsSpy = jest.spyOn(fs, 'existsSync');
+// skip checking whether our fake files and directory exist - it doesn't matter,
+// since we’re not actually going to attempt to do anything with them
+syncExistsSpy.mockReturnValue(true);
 
-  beforeEach(() => {
+/**
+ * Client for testing, along with a few example artifacts
+ */
+
+const client = new CraftGCSClient({
+  bucketName: 'captured-squirrels',
+  credentials: {
+    client_email: 'mighty_huntress@dogs.com',
+    private_key: 'DoGsArEgReAtSoMeSeCrEtStUfFhErE',
+  },
+  projectId: 'squirrel-chasing',
+});
+
+const squirrelStatsArtifact: RemoteArtifact = {
+  // tslint:disable: object-literal-sort-keys
+  filename: 'march-squirrel-stats.csv',
+  storedFile: {
+    downloadFilepath: 'squirrel-chasing/march-2020-squirrel-stats.csv',
+    filename: 'march-2020-squirrel-stats.csv',
+    size: 1231,
+  },
+};
+
+const squirrelStatsLocalPath = './temp/march-squirrel-stats.csv';
+
+const squirrelStatsBucketPath = {
+  path: '/stats/2020/',
+};
+
+const tempDownloadDirectory = './temp/';
+
+const squirrelSimulatorArtifact: RemoteArtifact = {
+  filename: 'bundle.js',
+  storedFile: {
+    downloadFilepath: 'squirrel-chasing/squirrel-simulator-bundle.js',
+    filename: 'squirrel-simulator-bundle.js',
+    size: 123112,
+  },
+};
+
+const squirrelSimulatorLocalPath = './dist/bundle.js';
+
+const squirrelSimulatorBucketPath = {
+  path: '/simulator/v1.12.1/dist/',
+  metadata: { cacheControl: `public, max-age=3600` },
+};
+
+/**
+ * Finally, the tests themselves
+ */
+
+describe('gcsApi module', () => {
+  afterEach(() => {
+    // in case we've modified the env in any way, reset it
     process.env = { ...cleanEnv };
+
+    // this clears out calls and results, but preserves mocked return values and
+    // mocked implemenations
+    jest.clearAllMocks();
   });
 
-  it('pulls JSON creds from env', () => {
-    process.env.DOG_CREDS_JSON = `{
-      "project_id": "squirrel-chasing",
-      "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE",
-      "client_email": "might_huntress@dogs.com",
-      "other_stuff": "can be anything",
-      "tail_wagging": "true",
-      "barking": "also VERY true"
-    }`;
-
-    const { project_id, client_email, private_key } = getGCSCredsFromEnv(
-      { name: 'DOG_CREDS_JSON' },
-      { name: 'DOG_CREDS_PATH' }
-    );
-
-    expect(project_id).toEqual('squirrel-chasing');
-    expect(client_email).toEqual('might_huntress@dogs.com');
-    expect(private_key).toEqual('DoGsArEgReAtSoMeSeCrEtStUfFhErE');
-  });
-
-  it('pulls filepath creds from env', async () => {
-    // ensure that the assertions below actually happen, since they in an async
-    // function
-    expect.assertions(3);
-
-    await withTempFile(tempFilepath => {
-      fs.writeFileSync(
-        tempFilepath,
-        `{
-          "project_id": "squirrel-chasing",
-          "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE",
-          "client_email": "might_huntress@dogs.com",
-          "other_stuff": "can be anything",
-          "tail_wagging": "true",
-          "barking": "also VERY true"
-        }`
-      );
-      process.env.DOG_CREDS_PATH = tempFilepath;
+  describe('getGCSCredsFromEnv', () => {
+    it('pulls JSON creds from env', () => {
+      process.env.DOG_CREDS_JSON = `{
+        "project_id": "squirrel-chasing",
+        "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE",
+        "client_email": "might_huntress@dogs.com",
+        "other_stuff": "can be anything",
+        "tail_wagging": "true",
+        "barking": "also VERY true"
+      }`;
 
       const { project_id, client_email, private_key } = getGCSCredsFromEnv(
         { name: 'DOG_CREDS_JSON' },
@@ -68,174 +112,226 @@ describe('getGCSCredsFromEnv', () => {
       expect(client_email).toEqual('might_huntress@dogs.com');
       expect(private_key).toEqual('DoGsArEgReAtSoMeSeCrEtStUfFhErE');
     });
-  });
 
-  it('errors if neither JSON creds nor creds filepath provided', () => {
-    // skip defining variables
+    it('pulls filepath creds from env', async () => {
+      // ensure that the assertions below actually happen, since they in an async
+      // function
+      expect.assertions(3);
 
-    expect(() => {
-      getGCSCredsFromEnv(
-        { name: 'DOG_CREDS_JSON' },
-        { name: 'DOG_CREDS_PATH' }
-      );
-    }).toThrowError('GCS credentials not found!');
-  });
+      await withTempFile(tempFilepath => {
+        fs.writeFileSync(
+          tempFilepath,
+          `{
+            "project_id": "squirrel-chasing",
+            "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE",
+            "client_email": "might_huntress@dogs.com",
+            "other_stuff": "can be anything",
+            "tail_wagging": "true",
+            "barking": "also VERY true"
+          }`
+        );
+        process.env.DOG_CREDS_PATH = tempFilepath;
 
-  it('errors given bogus JSON', () => {
-    process.env.DOG_CREDS_JSON = `Dogs!`;
+        const { project_id, client_email, private_key } = getGCSCredsFromEnv(
+          { name: 'DOG_CREDS_JSON' },
+          { name: 'DOG_CREDS_PATH' }
+        );
 
-    expect(() => {
-      getGCSCredsFromEnv(
-        { name: 'DOG_CREDS_JSON' },
-        { name: 'DOG_CREDS_PATH' }
-      );
-    }).toThrowError('Error parsing JSON credentials');
-  });
-
-  it('errors if creds file missing from given path', () => {
-    process.env.DOG_CREDS_PATH = './iDontExist.json';
-
-    expect(() => {
-      getGCSCredsFromEnv(
-        { name: 'DOG_CREDS_JSON' },
-        { name: 'DOG_CREDS_PATH' }
-      );
-    }).toThrowError('File does not exist: `./iDontExist.json`!');
-  });
-
-  it('errors if necessary field missing', () => {
-    process.env.DOG_CREDS_JSON = `{
-      "project_id": "squirrel-chasing",
-      "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE"
-    }`;
-
-    expect(() => {
-      getGCSCredsFromEnv(
-        { name: 'DOG_CREDS_JSON' },
-        { name: 'DOG_CREDS_PATH' }
-      );
-    }).toThrowError('GCS credentials missing `client_email`!');
-  });
-}); // end describe('getGCSCredsFromEnv')
-
-describe('CraftGCSClient class', () => {
-  const client = new CraftGCSClient({
-    bucketName: 'captured-squirrels',
-    credentials: {
-      client_email: 'mighty_huntress@dogs.com',
-      private_key: 'DoGsArEgReAtSoMeSeCrEtStUfFhErE',
-    },
-    projectId: 'squirrel-chasing',
-  });
-
-  const squirrelStatsArtifact = {
-    // tslint:disable: object-literal-sort-keys
-    filename: 'march-squirrel-stats.csv',
-    storedFile: {
-      downloadFilepath: 'squirrel-chasing/march-2020-squirrel-stats.csv',
-      filename: 'march-2020-squirrel-stats.csv',
-      size: 1231,
-    },
-  };
-
-  const squirrelStatsLocalPath = './temp/march-squirrel-stats.csv';
-
-  const squirrelStatsBucketPath = {
-    path: '/stats/2020/',
-  };
-
-  const squirrelSimulatorArtifact = {
-    // tslint:disable: object-literal-sort-keys
-    filename: 'bundle.js',
-    storedFile: {
-      downloadFilepath: 'squirrel-chasing/squirrel-simulator-bundle.js',
-      filename: 'squirrel-simulator-bundle.js',
-      size: 123112,
-    },
-  };
-
-  const squirrelSimulatorLocalPath = './dist/bundle.js';
-
-  const squirrelSimulatorBucketPath = {
-    path: '/simulator/v1.12.1/dist/',
-    metadata: { cacheControl: `public, max-age=3600` },
-  };
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it('calls the GCS library upload method with the right parameters', async () => {
-    await client.uploadArtifact(
-      squirrelStatsLocalPath,
-      squirrelStatsBucketPath
-    );
-
-    const { filename } = squirrelStatsArtifact;
-    const { path: destinationPath } = squirrelStatsBucketPath;
-
-    expect(mockGCSUpload).toHaveBeenCalledWith(squirrelStatsLocalPath, {
-      destination: `${destinationPath}${filename}`,
-      gzip: true,
-      metadata: DEFAULT_UPLOAD_METADATA,
-    });
-  });
-
-  it('detects content type correctly for JS and map files', async () => {
-    await client.uploadArtifact(
-      squirrelSimulatorLocalPath,
-      squirrelSimulatorBucketPath
-    );
-
-    expect(mockGCSUpload).toHaveBeenCalledWith(
-      squirrelSimulatorLocalPath,
-      expect.objectContaining({
-        contentType: 'application/javascript; charset=utf-8',
-      })
-    );
-  });
-
-  it('allows overriding of default metadata', async () => {
-    await client.uploadArtifact(
-      squirrelSimulatorLocalPath,
-      squirrelSimulatorBucketPath
-    );
-
-    const { metadata } = squirrelSimulatorBucketPath;
-
-    expect(mockGCSUpload).toHaveBeenCalledWith(
-      squirrelSimulatorLocalPath,
-      expect.objectContaining({
-        metadata,
-      })
-    );
-  });
-
-  it('errors if GCS upload goes sideways', async () => {
-    mockGCSUpload.mockImplementation(() => {
-      throw new Error('The squirrel got away!');
+        expect(project_id).toEqual('squirrel-chasing');
+        expect(client_email).toEqual('might_huntress@dogs.com');
+        expect(private_key).toEqual('DoGsArEgReAtSoMeSeCrEtStUfFhErE');
+      });
     });
 
-    const { filename } = squirrelSimulatorArtifact;
+    it('errors if neither JSON creds nor creds filepath provided', () => {
+      // skip defining variables
 
-    await expect(
-      client.uploadArtifact(
-        squirrelSimulatorLocalPath,
-        squirrelSimulatorBucketPath
-      )
-    ).rejects.toThrowError(
-      `Encountered an error while uploading \`${filename}\``
-    );
-  });
+      expect(() => {
+        getGCSCredsFromEnv(
+          { name: 'DOG_CREDS_JSON' },
+          { name: 'DOG_CREDS_PATH' }
+        );
+      }).toThrowError('GCS credentials not found!');
+    });
 
-  it("doesn't upload anything in dry run mode", async () => {
-    process.env.DRY_RUN = 'true';
+    it('errors if given bogus JSON', () => {
+      process.env.DOG_CREDS_JSON = `Dogs!`;
 
-    await client.uploadArtifact(
-      squirrelStatsLocalPath,
-      squirrelStatsBucketPath
-    );
+      expect(() => {
+        getGCSCredsFromEnv(
+          { name: 'DOG_CREDS_JSON' },
+          { name: 'DOG_CREDS_PATH' }
+        );
+      }).toThrowError('Error parsing JSON credentials');
+    });
 
-    expect(mockGCSUpload).not.toHaveBeenCalled();
-  });
-}); // end describe('CraftGCSClient class')
+    it('errors if creds file missing from given path', () => {
+      process.env.DOG_CREDS_PATH = './iDontExist.json';
+
+      // make sure it won't find the file
+      syncExistsSpy.mockReturnValueOnce(false);
+
+      expect(() => {
+        getGCSCredsFromEnv(
+          { name: 'DOG_CREDS_JSON' },
+          { name: 'DOG_CREDS_PATH' }
+        );
+      }).toThrowError('File does not exist: `./iDontExist.json`!');
+    });
+
+    it('errors if necessary field missing', () => {
+      process.env.DOG_CREDS_JSON = `{
+        "project_id": "squirrel-chasing",
+        "private_key": "DoGsArEgReAtSoMeSeCrEtStUfFhErE"
+      }`;
+
+      expect(() => {
+        getGCSCredsFromEnv(
+          { name: 'DOG_CREDS_JSON' },
+          { name: 'DOG_CREDS_PATH' }
+        );
+      }).toThrowError('GCS credentials missing `client_email`!');
+    });
+  }); // end describe('getGCSCredsFromEnv')
+
+  describe('CraftGCSClient class', () => {
+    describe('upload', () => {
+      it('calls the GCS library upload method with the right parameters', async () => {
+        await client.uploadArtifact(
+          squirrelStatsLocalPath,
+          squirrelStatsBucketPath
+        );
+
+        const { filename } = squirrelStatsArtifact;
+        const { path: destinationPath } = squirrelStatsBucketPath;
+
+        expect(mockGCSUpload).toHaveBeenCalledWith(squirrelStatsLocalPath, {
+          destination: `${destinationPath}${filename}`,
+          gzip: true,
+          metadata: DEFAULT_UPLOAD_METADATA,
+        });
+      });
+
+      it('detects content type correctly for JS and map files', async () => {
+        await client.uploadArtifact(
+          squirrelSimulatorLocalPath,
+          squirrelSimulatorBucketPath
+        );
+
+        expect(mockGCSUpload).toHaveBeenCalledWith(
+          squirrelSimulatorLocalPath,
+          expect.objectContaining({
+            contentType: 'application/javascript; charset=utf-8',
+          })
+        );
+      });
+
+      it('allows overriding of default metadata', async () => {
+        await client.uploadArtifact(
+          squirrelSimulatorLocalPath,
+          squirrelSimulatorBucketPath
+        );
+
+        const { metadata } = squirrelSimulatorBucketPath;
+
+        expect(mockGCSUpload).toHaveBeenCalledWith(
+          squirrelSimulatorLocalPath,
+          expect.objectContaining({
+            metadata,
+          })
+        );
+      });
+
+      it('errors if GCS upload goes sideways', async () => {
+        mockGCSUpload.mockImplementation(() => {
+          throw new Error('The squirrel got away!');
+        });
+
+        const { filename } = squirrelSimulatorArtifact;
+
+        await expect(
+          client.uploadArtifact(
+            squirrelSimulatorLocalPath,
+            squirrelSimulatorBucketPath
+          )
+        ).rejects.toThrowError(
+          `Encountered an error while uploading \`${filename}\``
+        );
+      });
+
+      it("doesn't upload anything in dry run mode", async () => {
+        process.env.DRY_RUN = 'true';
+
+        await client.uploadArtifact(
+          squirrelStatsLocalPath,
+          squirrelStatsBucketPath
+        );
+
+        expect(mockGCSUpload).not.toHaveBeenCalled();
+      });
+    }); // end describe('upload')
+
+    describe('download', () => {
+      it('calls the GCS library download method with the right parameters', async () => {
+        expect.assertions(1);
+
+        await client.downloadArtifact(
+          squirrelStatsArtifact.storedFile.downloadFilepath,
+          tempDownloadDirectory
+        );
+
+        const { filename } = squirrelStatsArtifact;
+
+        expect(mockGCSDownload).toHaveBeenCalledWith({
+          destination: path.join(tempDownloadDirectory, filename),
+        });
+      });
+
+      it("errors if download directory doesn't exist", async () => {
+        expect.assertions(1);
+
+        // make sure it thinks it doesn't exist
+        syncExistsSpy.mockReturnValueOnce(false);
+
+        await expect(
+          client.downloadArtifact(
+            squirrelSimulatorArtifact.storedFile.downloadFilepath,
+            './iDontExist/'
+          )
+        ).rejects.toThrowError(`directory does not exist!`);
+      });
+
+      it('errors if GCS download goes sideways', async () => {
+        expect.assertions(1);
+
+        mockGCSDownload.mockImplementation(() => {
+          throw new Error('The squirrel got away!');
+        });
+
+        const { filename } = squirrelSimulatorArtifact;
+
+        await expect(
+          client.downloadArtifact(
+            squirrelSimulatorArtifact.storedFile.downloadFilepath,
+            tempDownloadDirectory
+          )
+        ).rejects.toThrowError(
+          `Encountered an error while downloading \`${filename}\``
+        );
+      });
+
+      it("doesn't upload anything in dry run mode", async () => {
+        expect.assertions(1);
+
+        process.env.DRY_RUN = 'true';
+
+        await client.downloadArtifact(
+          squirrelSimulatorArtifact.storedFile.downloadFilepath,
+          tempDownloadDirectory
+        );
+
+        expect(mockGCSDownload).not.toHaveBeenCalled();
+      });
+    }); // end describe('download')
+  }); // end describe('CraftGCSClient class')
+}); // end describe('gcsApi module')

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -11,6 +11,7 @@ import { isDryRun } from './helpers';
 import { logger as loggerRaw } from '../logger';
 import { reportError, ConfigurationError } from './errors';
 import { checkEnvForPrerequisite, RequiredConfigVar } from './env';
+import { RemoteArtifact } from '../artifact_providers/base';
 
 const DEFAULT_MAX_RETRIES = 5;
 export const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
@@ -233,5 +234,50 @@ export class CraftGCSClient {
     } else {
       logger.info(`[dry-run] Skipping upload for \`${filename}\``);
     }
+  }
+
+  /**
+   * Downloads a file stored on the artifact provider
+   *
+   * @param downloadFilepath Path to the file within the bucket, including
+   * filename
+   * @param destinationDirectory Path to directory into which to download the
+   * file
+   * @param destinationFilename Name to give the downloaded file, if different from its
+   * name on the artifact provider
+   * @returns Path to the downloaded file
+   */
+  public async downloadArtifact(
+    downloadFilepath: string,
+    destinationDirectory: string,
+    destinationFilename: string = path.basename(downloadFilepath)
+  ): Promise<string> {
+    if (!fs.existsSync(destinationDirectory)) {
+      reportError(
+        `Unable to download \`${destinationFilename}\` to ` +
+          `\`${destinationDirectory}\` - directory does not exist!`
+      );
+    }
+
+    if (!isDryRun()) {
+      logger.debug(
+        `Attempting to download \`${destinationFilename}\` to \`${destinationDirectory}\`.`
+      );
+
+      try {
+        await this.bucket.file(downloadFilepath).download({
+          destination: path.join(destinationDirectory, destinationFilename),
+        });
+      } catch (err) {
+        reportError(`Encountered an error while downloading \`${destinationFilename}\`:
+          ${err}`);
+      }
+
+      logger.debug(`Success!`);
+    } else {
+      logger.info(`[dry-run] Skipping download for \`${destinationFilename}\``);
+    }
+
+    return path.join(destinationDirectory, destinationFilename);
   }
 }


### PR DESCRIPTION
Adds another option besides zeus for artifact storage.

Things happening in this PR (commits should be relatively self-contained) :

- All config provided to artifact constructors is now passed in a `config` object, which is then stored on the provider instance. This config now also includes any options specified for the artifact provider in the project config file.
- New `GCSArtifactProvider` class, implementing artifact listing and downloading (and underlying methods implemented in GCS client).
- Fix for GCS creds env variable name, which didn't match README.
- Tests for new GCS client methods. Includes pulling fixtures and the logger mock each into their own file.

Things to happen in further PRs:

- General clean up of code and logging associated with the above changes.
- Creation of an `upload` CLI command.
- Hopefully some testing of the artifact providers themselves.