### PR TITLE
ref: Remove cocoapods token requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Watch this space...
 
+- ref: Remove the need for `COCOAPODS_TRUNK_TOKEN` to be in the environment (#72)
+
 ## 0.9.2
 
 - feat: Artifact provider abstraction (#52, #54)

--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -25,8 +25,6 @@ const COCOAPODS_BIN = process.env.COCOAPODS_BIN || DEFAULT_COCOAPODS_BIN;
 
 /** Options for "cocoapods" target */
 export interface CocoapodsTargetOptions extends TargetConfig {
-  /** Cocoapods trunk (API) token */
-  trunkToken: string;
   /** Path to the spec file inside the repo */
   specPath: string;
 }
@@ -56,16 +54,6 @@ export class CocoapodsTarget extends BaseTarget {
    * Extracts Cocoapods target options from the environment
    */
   public getCocoapodsConfig(): CocoapodsTargetOptions {
-    if (!process.env.COCOAPODS_TRUNK_TOKEN) {
-      throw new ConfigurationError(
-        `Cannot perform Cocoapod release: missing credentials.
-         Please fill COCOAPODS_TRUNK_TOKEN environment variable.`.replace(
-          /^\s+/gm,
-          ''
-        )
-      );
-    }
-
     const specPath = this.config.specPath;
     if (!specPath) {
       throw new ConfigurationError('No podspec path provided!');
@@ -73,7 +61,6 @@ export class CocoapodsTarget extends BaseTarget {
 
     return {
       specPath,
-      trunkToken: process.env.COCOAPODS_TRUNK_TOKEN,
     };
   }
 
@@ -114,7 +101,6 @@ export class CocoapodsTarget extends BaseTarget {
           cwd: directory,
           env: {
             ...process.env,
-            COCOAPODS_TRUNK_TOKEN: this.cocoapodsConfig.trunkToken,
           },
         });
       },


### PR DESCRIPTION
We do not need to fetch the `COCOAPODS_TRUNK_TOKEN` from the env.
People should call `pod trunk register` themselves if they are allowed to publish the package. Cocoapods then will grab the auth credentials correctly.