### PR TITLE
fix(GCS): Fix location of `contentType` upload option

### DIFF
--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -178,7 +178,9 @@ describe('gcsApi module', () => {
         expect(mockGCSUpload).toHaveBeenCalledWith(
           squirrelSimulatorLocalPath,
           expect.objectContaining({
-            contentType: 'application/javascript; charset=utf-8',
+            metadata: expect.objectContaining({
+              contentType: 'application/javascript; charset=utf-8',
+            }),
           })
         );
       });
@@ -189,12 +191,12 @@ describe('gcsApi module', () => {
           squirrelSimulatorBucketPath
         );
 
-        const { metadata } = squirrelSimulatorBucketPath;
+        const squirrelSimulatorMetadata = squirrelSimulatorBucketPath.metadata;
 
         expect(mockGCSUpload).toHaveBeenCalledWith(
           squirrelSimulatorLocalPath,
           expect.objectContaining({
-            metadata,
+            metadata: expect.objectContaining({ ...squirrelSimulatorMetadata }),
           })
         );
       });

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -13,6 +13,7 @@ import { logger as loggerRaw } from '../logger';
 import { reportError, ConfigurationError } from './errors';
 import { checkEnvForPrerequisite, RequiredConfigVar } from './env';
 import { RemoteArtifact } from '../artifact_providers/base';
+import { formatJson } from './strings';
 
 const DEFAULT_MAX_RETRIES = 5;
 export const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
@@ -212,6 +213,10 @@ export class CraftGCSClient {
       gzip: true,
       metadata,
     };
+
+    logger.debug(
+      `File \`${filename}\`, upload options: ${formatJson(uploadConfig)}`
+    );
 
     if (!isDryRun()) {
       logger.debug(

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -203,11 +203,14 @@ export class CraftGCSClient {
     }
 
     const contentType = this.detectContentType(filename);
+    const metadata = {
+      ...(bucketPath.metadata || DEFAULT_UPLOAD_METADATA),
+      ...(contentType && { contentType }),
+    };
     const uploadConfig: GCSUploadOptions = {
       destination: path.join(pathInBucket, filename),
       gzip: true,
-      metadata: bucketPath.metadata || DEFAULT_UPLOAD_METADATA,
-      ...(contentType && { contentType }),
+      metadata,
     };
 
     if (!isDryRun()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,11 +1845,6 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dryrun@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/dryrun/-/dryrun-1.0.2.tgz#bf59e1193efea0de5a140ee89f6a89af81cee305"
-  integrity sha1-v1nhGT7+oN5aFA7on2qJr4HO4wU=
-
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
According to the GCS docs ([1](https://googleapis.dev/nodejs/storage/latest/global.html#UploadOptions) and [2](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request_properties_JSON)), `contentType` is an attribute _inside of_ (rather than as a sibling to) `metadata` in the `UploadOptions` object. However, if you do put it in the wrong place, it appears that the underlying GCS library tries to be clever, and moves it for you... thereby mutating an object (in this case, `DEFAULT_UPLOAD_METADATA`) whose value would otherwise never change. As a result of that mutation, the `contentType` value from one file can leak into the upload options for other files, causing incorrect content types.

This PR fixes that by 1) including `contentType` in the right spot, an 2) cloning the `DEFAULT_UPLOAD_METADATA` object rather than just pointing to it.

Before:

![image](https://user-images.githubusercontent.com/14812505/80027906-3149bc00-8499-11ea-9f92-1f4a093e9e1f.png)

After:

![image](https://user-images.githubusercontent.com/14812505/80028171-93a2bc80-8499-11ea-97e4-96c252347040.png)
