### PR TITLE
fix(crates): Skip crates with publish=false

### DIFF
--- a/src/targets/__tests__/crates.test.ts
+++ b/src/targets/__tests__/crates.test.ts
@@ -10,6 +10,7 @@ function cratePackageFactory(name: string): CratePackage {
     manifest_path: '',
     name,
     version: '1.0.0',
+    publish: null,
   };
 }
 


### PR DESCRIPTION
Crates can be prevented from publishing by setting `publish=false` in Cargo.toml. The cargo metadata command then returns an empty list in the `publish` key, instead of `null`. This can be used to detect such crates and skip them during the publish stage.

Fixes #80 