### PR TITLE
fix: Use git show-ref over error code parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Watch this space...
 
-- fix: Localized git branch checks (#75)
+- fix: Localized git branch checks (#84)
 
 ## 0.9.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Watch this space...
 
+- fix: Localized git branch checks (#75)
+
 ## 0.9.4
 
 - fix(gcs): Fix content-types issues (#78)

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -115,12 +115,7 @@ async function createReleaseBranch(
 ): Promise<string> {
   const branchName = `release/${newVersion}`;
 
-  let branchHead;
-  try {
-    branchHead = await git.raw(['show-ref', '--heads', branchName]);
-  } catch (e) {
-    throw e;
-  }
+  const branchHead = await git.raw(['show-ref', '--heads', branchName]);
 
   // in case `show-ref` can't find a branch it returns `null`
   if (branchHead) {

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -122,7 +122,8 @@ async function createReleaseBranch(
     throw e;
   }
 
-  if (branchHead.length > 0) {
+  // in case `show-ref` can't find a branch it returns `null`
+  if (branchHead) {
     let errorMsg = `Branch already exists: ${branchName}. `;
     const remoteName = getRemoteName();
     errorMsg +=

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -117,19 +117,12 @@ async function createReleaseBranch(
 
   let branchHead;
   try {
-    // ideally this throws an error, because the branch shouldn't exist yet
-    branchHead = await git.revparse([branchName]);
+    branchHead = await git.raw(['show-ref', '--heads', branchName]);
   } catch (e) {
-    // 'unkown revision' is the error we want, but if it's something different
-    // we're in trouble, so re-throw
-    if (!e.message.match(/unknown revision/)) {
-      throw e;
-    }
-    // otherwise, just mark that there's no branch and keep going
-    branchHead = '';
+    throw e;
   }
 
-  if (branchHead) {
+  if (branchHead.length > 0) {
     let errorMsg = `Branch already exists: ${branchName}. `;
     const remoteName = getRemoteName();
     errorMsg +=


### PR DESCRIPTION
Fixes https://github.com/getsentry/craft/issues/75

Tested locally, console output:

```
➜ node ~/Projects/craft/dist/index.js prepare 3.5.1 --no-git-checks
ℹ info craft 0.9.4
ℹ info "craft" version is compatible with the minimal version from the configuration file.
⚠ warn Not checking the status of the local repository
⚠ warn Not checking if the version (git tag) already exists
ℹ info Changelog policy is set to "none", nothing to do.
ℹ info Preparing to release the version: 3.5.1

<-- console.log -->
null
<-- console.log -->

ℹ info Created a new release branch: "release/3.5.1"
ℹ info Switched to branch "release/3.5.1"
⚠ warn Not running the pre-release command: no command specified
ℹ info Not commiting anything since preReleaseCommand is empty.
ℹ info Pushing the release branch "release/3.5.1"...
ℹ info View diff at: https://github.com/getsentry/sentry-symfony/compare/release/3.5.1
✔ success Done. Do not forget to run "craft publish" to publish the artifacts:
    $ craft publish 3.5.1
ℹ info Switching back to the default branch (master)...

~/Projects/sentry-symfony on  master [!] took 6s
➜ node ~/Projects/craft/dist/index.js prepare 3.5.1 --no-git-checks
ℹ info craft 0.9.4
ℹ info "craft" version is compatible with the minimal version from the configuration file.
⚠ warn Not checking the status of the local repository
⚠ warn Not checking if the version (git tag) already exists
ℹ info Changelog policy is set to "none", nothing to do.
ℹ info Preparing to release the version: 3.5.1

<-- console.log -->
6a4664c83f6a71717d45fcf8f30e067fa8da5cc0 refs/heads/release/3.5.1
<-- console.log -->

✖ error Error: Branch already exists: release/3.5.1. Run the following commands to delete the branch, and then rerun "prepare":
  git branch -D release/3.5.1; git push origin --delete release/3.5.1

  at Object.reportError (/Users/haza/Projects/craft/dist/utils/errors.js:26:59)
  at createReleaseBranch (/Users/haza/Projects/craft/dist/commands/prepare.js:98:18)
  at processTicksAndRejections (internal/process/task_queues.js:97:5)
  at async releaseMain (/Users/haza/Projects/craft/dist/commands/prepare.js:366:24)
  at async Object.exports.handler (/Users/haza/Projects/craft/dist/commands/prepare.js:399:16)

```