### PR TITLE
feat: Add allow-warnings to cocoapods target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Watch this space...
 
+- feat: Cocoapods Target add `--allow-warnings` by default
+
 ## 0.9.4
 
 - fix(gcs): Fix content-types issues (#78)

--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -97,12 +97,16 @@ export class CocoapodsTarget extends BaseTarget {
 
         logger.info(`Pushing podspec "${fileName}" to cocoapods...`);
         await spawnProcess(COCOAPODS_BIN, ['setup']);
-        await spawnProcess(COCOAPODS_BIN, ['trunk', 'push', fileName], {
-          cwd: directory,
-          env: {
-            ...process.env,
-          },
-        });
+        await spawnProcess(
+          COCOAPODS_BIN,
+          ['trunk', 'push', fileName, '--allow-warnings'],
+          {
+            cwd: directory,
+            env: {
+              ...process.env,
+            },
+          }
+        );
       },
       true,
       'craft-cocoapods-'


### PR DESCRIPTION
The cocoapods target always fails because we have some silly warning we can't get rid of.
This results in `craft publish` command never going through.

```
 pod: [!] The spec did not pass validation, due to 7 warnings (but you can use `--allow-warnings` to ignore them).
  pod:
```

This adds `--allow-warnings` by default so craft doesn't fail.

I know not 100% nice but I am trying to be pragmatic and save time on every release.