### PR TITLE
feat(config): Add a releaseBranchName config attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ then enforces a specific workflow for managing release branches, changelogs, art
 - [Configuration File: `.craft.yml`](#configuration-file-craftyml)
   - [GitHub project](#github-project)
   - [Pre-release Command](#pre-release-command)
+  - [Release Branch Name](#release-branch-name)
   - [Changelog Policies](#changelog-policies)
   - [Minimal Version](#minimal-version)
   - [Required Files](#required-files)
@@ -243,6 +244,16 @@ to [this section](#pre-release-version-bumping-script-conventions) for more deta
 
 ```yaml
 preReleaseCommand: bash scripts/bump-version.sh
+```
+
+### Release Branch Name
+
+This overrides the prefix for the release branch name. The full branch name used
+for a release is `{releaseBranchPrefix}/{version}`. The prefix defaults to
+`"release"`.
+
+```yaml
+releaseBranchPrefix: publish
 ```
 
 ### Changelog Policies
@@ -743,7 +754,8 @@ Here is how you can integrate your GitHub project with `craft`:
 
 - Enable your project in Zeus: https://zeus.ci/settings/github/repos
 - Configure your CI systems (Travis, AppVeyor, etc.) to send build artifacts to Zeus
-  - Allow building release branches (their names follow pattern `release/VERSION`)
+  - Allow building release branches (their names follow `release/{VERSION}` by
+    default, configurable through `releaseBranchPrefix`)
   - Add ZEUS_HOOK_BASE as protected to CI environment
 - Add `.craft.yml` configuration file to your project
   - List there all the targets you want to publish to

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -9,6 +9,7 @@ import {
   checkMinimalConfigVersion,
   getConfigFilePath,
   getConfiguration,
+  DEFAULT_RELEASE_BRANCH_NAME,
 } from '../config';
 import { logger } from '../logger';
 import { ChangelogPolicy } from '../schemas/project_config';
@@ -108,12 +109,15 @@ function checkVersionOrPart(argv: Arguments<any>, _opt: any): any {
  *
  * @param git Local git client
  * @param newVersion Version we are releasing
+ * @param releaseBranchPrefix Prefix of the release branch. Defaults to "release".
  */
 async function createReleaseBranch(
   git: simpleGit.SimpleGit,
-  newVersion: string
+  newVersion: string,
+  releaseBranchPrefix?: string
 ): Promise<string> {
-  const branchName = `release/${newVersion}`;
+  const branchPrefix = releaseBranchPrefix || DEFAULT_RELEASE_BRANCH_NAME;
+  const branchName = `${branchPrefix}/${newVersion}`;
 
   const branchHead = await git.raw(['show-ref', '--heads', branchName]);
 
@@ -467,7 +471,11 @@ export async function releaseMain(argv: ReleaseOptions): Promise<any> {
 
   // Create a new release branch and check it out. Throw an error if it already
   // exists.
-  const branchName = await createReleaseBranch(git, newVersion);
+  const branchName = await createReleaseBranch(
+    git,
+    newVersion,
+    config.releaseBranchPrefix
+  );
 
   // Run a pre-release script (e.g. for version bumping)
   const preReleaseCommandRan = await runPreReleaseCommand(

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -9,6 +9,7 @@ import {
   getConfiguration,
   getStatusProviderFromConfig,
   getArtifactProviderFromConfig,
+  DEFAULT_RELEASE_BRANCH_NAME,
 } from '../config';
 import { formatTable, logger } from '../logger';
 import { GithubGlobalConfig } from '../schemas/project_config';
@@ -420,7 +421,10 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
     revision = response.data.sha;
   } else {
     // Find the remote branch
-    branchName = `release/${newVersion}`;
+    const branchPrefix =
+      config.releaseBranchPrefix || DEFAULT_RELEASE_BRANCH_NAME;
+    branchName = `${branchPrefix}/${newVersion}`;
+
     logger.debug('Fetching branch information', branchName);
     const response = await githubClient.repos.getBranch({
       branch: branchName,

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,11 @@ import { BaseStatusProvider } from './status_providers/base';
 export const CONFIG_FILE_NAME = '.craft.yml';
 
 /**
+ * The default prefix for the release branch.
+ */
+export const DEFAULT_RELEASE_BRANCH_NAME = 'release';
+
+/**
  * Cached path to the configuration file
  */
 let _configPathCache: string;

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -29,6 +29,7 @@ const projectConfigJsonSchema = {
       items: { $ref: '#/definitions/targetConfig' },
     },
     preReleaseCommand: { type: 'string' },
+    releaseBranchPrefix: { type: 'string' },
     changelog: { type: 'string' },
     changelogPolicy: {
       title: 'ChangelogPolicy',

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -11,6 +11,7 @@ export interface CraftProjectConfig {
   github: GithubGlobalConfig;
   targets?: TargetConfig[];
   preReleaseCommand?: string;
+  releaseBranchPrefix?: string;
   changelog?: string;
   changelogPolicy?: ChangelogPolicy;
   minVersion?: string;


### PR DESCRIPTION
This adds a new config parameter to override the branch name prefix used for release branches. Docs state:

> This overrides the prefix for the release branch name. The full branch name used for a release is `{releaseBranchPrefix}/{version}`. The prefix defaults to `"release"`.
>
> ```yaml
> releaseBranchPrefix: publish
> ```
