### PR TITLE
fix(docs): Fix npm `access` config option having wrong default

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,14 +450,14 @@ The `npm` utility must be installed on the system.
 
 | Option   | Description                                                                      |
 | -------- | -------------------------------------------------------------------------------- |
-| `access` | **optional**. Visibility for scoped packages: `public` (default) or `restricted` |
+| `access` | **optional**. Visibility for scoped packages: `restricted` (default) or `public` |
 
 **Example**
 
 ```yaml
 targets:
   - name: npm
-    access: restricted
+    access: public
 ```
 
 ### Python Package Index (`pypi`)


### PR DESCRIPTION
For scoped npm packages (ones which are `@orgname/package` or `@username/package` rather than just `package`), the default is to [publish them privately](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages):

![image](https://user-images.githubusercontent.com/14812505/82592050-209e6b80-9b55-11ea-8f05-ca2a7e4dcbee.png)

In our `npm` target config, we allow the user to specify a value for the `access` flag, in order to be able to publish scoped packages publicly:

![image](https://user-images.githubusercontent.com/14812505/82592302-8b4fa700-9b55-11ea-8efe-8a45547e7b62.png)

However, in spite of the fact that we say that the default is `public`, nowhere do we actually set that default. Therefore, we fall back to the `npm publish` default, which is private.

(This hasn't been as apparent because once a package is published once (either publicly or privately), the access setting won't change unless you use a [different command](https://docs.npmjs.com/changing-package-visibility), `npm access`. Therefore, any time after the first time, passing or not passing the `access` flag to the `publish` command (and what value you give that flag if you do pass it) doesn't matter... and new, never-before-published projects don't start using craft all that often.)

It may be worth thinking about whether we actually _do_ want the default to be `public`, but in the meantime, this PR changes the default listed in the docs so that the current behavior isn't surprising.