### PR TITLE
feat(changelog): Add "auto" changeset policy

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,7 +2,7 @@ minVersion: "0.8.4"
 github:
   owner: getsentry
   repo: craft
-changelogPolicy: auto
+changelogPolicy: simple
 requireNames:
   - /^sentry-craft.*\.tgz$/
 targets:

--- a/.craft.yml
+++ b/.craft.yml
@@ -2,7 +2,7 @@ minVersion: "0.8.4"
 github:
   owner: getsentry
   repo: craft
-changelogPolicy: simple
+changelogPolicy: auto
 requireNames:
   - /^sentry-craft.*\.tgz$/
 targets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Watch this space...
+- feat(changelog): Add "auto" changeset policy
 
 ## 0.9.6
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ In `auto` mode, `craft prepare` will use the following logic:
 
 1. If there's already an entry for the given version, use that
 2. Else if there is an entry named `Unreleased`, rename that to the given
-   version.
+   version
 3. Else, create a new section for the version and populate it with a default
    text: ` - No documented changes for this release.`
 
@@ -298,7 +298,7 @@ changelogPolicy: simple
 * Added something
 ```
 
-**Example (`simple`):**
+**Example (`auto`):**
 
 ```yaml
 changelog: CHANGES

--- a/README.md
+++ b/README.md
@@ -259,9 +259,18 @@ releaseBranchPrefix: publish
 ### Changelog Policies
 
 `craft` can help you to maintain change logs for your projects. At the moment,
-`craft` supports only one approach (`"simple"`) to changelog management.
-In this mode, `craft prepare` will remind you to add a changelog entry to the
+`craft` supports two approaches: `simple`, and `auto` to changelog management.
+
+In `simple` mode, `craft prepare` will remind you to add a changelog entry to the
 changelog file (`CHANGELOG.md` by default).
+
+In `auto` mode, `craft prepare` will use the following logic:
+
+1. If there's already an entry for the given version, use that
+2. Else if there is an entry named `Unreleased`, rename that to the given
+   version.
+3. Else, create a new section for the version and populate it with a default
+   text: ` - No documented changes for this release.`
 
 **Configuration**
 
@@ -270,7 +279,7 @@ changelog file (`CHANGELOG.md` by default).
 | `changelog`       | **optional**. Path to the changelog file. Defaults to `CHANGELOG.md`              |
 | `changelogPolicy` | **optional**. Changelog management mode (`simple` or `none`). Defaults to `none`. |
 
-**Example:**
+**Example (`simple`):**
 
 ```yaml
 changelog: CHANGES
@@ -281,6 +290,25 @@ changelogPolicy: simple
 
 ```text
 ## 1.3.5
+
+* Removed something
+
+## 1.3.4
+
+* Added something
+```
+
+**Example (`simple`):**
+
+```yaml
+changelog: CHANGES
+changelogPolicy: auto
+```
+
+**Changelog with staged changes example:**
+
+```text
+## Unreleased
 
 * Removed something
 

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -414,14 +414,15 @@ async function prepareChangelog(
         changeset = { name: newVersion, body: '' };
       }
       if (!changeset.body) {
-        changeset.body = ` - No documented changes in this release.`;
         replaceSection = changeset.name;
       }
       if (changeset.name === DEFAULT_UNRELEASED_TITLE) {
         replaceSection = changeset.name;
         changeset.name = newVersion;
       }
-      logger.debug(`Updating the changelog file for the new version:`);
+      logger.debug(
+        `Updating the changelog file for the new version: ${newVersion}`
+      );
 
       if (replaceSection) {
         changelogString = removeChangeset(changelogString, replaceSection);
@@ -437,6 +438,7 @@ async function prepareChangelog(
         await fsPromises.writeFile(relativePath, changelogString);
       } else {
         logger.info('[dry-run] Not updating changelog file.');
+        logger.debug(`New changelog:\n${changelogString}`);
       }
 
       break;

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -429,11 +429,6 @@ async function prepareChangelog(
         changelogString = prependChangeset(changelogString, changeset);
       }
 
-      changelogString = prependChangeset(changelogString, {
-        body: '',
-        name: DEFAULT_UNRELEASED_TITLE,
-      });
-
       if (!isDryRun()) {
         await fsPromises.writeFile(relativePath, changelogString);
       } else {

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -35,8 +35,8 @@ const projectConfigJsonSchema = {
       title: 'ChangelogPolicy',
       description: 'Different policies for changelog management',
       type: 'string',
-      enum: ['simple', 'none'],
-      tsEnumNames: ['Simple', 'None'],
+      enum: ['auto', 'simple', 'none'],
+      tsEnumNames: ['Auto', 'Simple', 'None'],
     },
     minVersion: {
       type: 'string',

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -58,6 +58,7 @@ export interface BaseArtifactProvider {
  * Different policies for changelog management
  */
 export const enum ChangelogPolicy {
+  Auto = 'auto',
   Simple = 'simple',
   None = 'none',
 }

--- a/src/utils/__tests__/changes.test.ts
+++ b/src/utils/__tests__/changes.test.ts
@@ -1,9 +1,6 @@
 /* eslint-env jest */
 
-import {
-  findChangeset,
-  removeChangeset /*, prependChangeset*/,
-} from '../changes';
+import { findChangeset, removeChangeset, prependChangeset } from '../changes';
 
 test.each([
   [
@@ -188,4 +185,49 @@ test.each([
     `;
 
   expect(removeChangeset(markdown, header)).toEqual(expected);
+});
+
+test.each([
+  [
+    'prepend to empty text',
+    '',
+    '## 2.0.0\n\nrewrote everything from scratch\n\n',
+  ],
+  [
+    'prepend without top-level header',
+    '## 1.0.0\n\nthis is a test\n',
+    '## 2.0.0\n\nrewrote everything from scratch\n\n## 1.0.0\n\nthis is a test\n',
+  ],
+  [
+    'prepend after top-level header (empty body)',
+    '# Changelog\n',
+    '# Changelog\n## 2.0.0\n\nrewrote everything from scratch\n\n',
+  ],
+  [
+    'prepend after top-level header',
+    '# Changelog\n\n## 1.0.0\n\nthis is a test\n',
+    '# Changelog\n\n## 2.0.0\n\nrewrote everything from scratch\n\n## 1.0.0\n\nthis is a test\n',
+  ],
+  [
+    'prepend with underlined when detected',
+    '# Changelog\n\n1.0.0\n-----\n\nthis is a test\n',
+    '# Changelog\n\n2.0.0\n-----\n\nrewrote everything from scratch\n\n1.0.0\n-----\n\nthis is a test\n',
+  ],
+  [
+    'prepend with consistent padding with the rest',
+    '# Changelog\n\n   ## 1.0.0\n\n   this is a test\n',
+    '# Changelog\n\n   ## 2.0.0\n\n   rewrote everything from scratch\n\n   ## 1.0.0\n\n   this is a test\n',
+  ],
+  [
+    'prepend with consistent padding with the rest (underlined)',
+    '# Changelog\n\n   1.0.0\n-----\n\n   this is a test\n',
+    '# Changelog\n\n   2.0.0\n-----\n\n   rewrote everything from scratch\n\n   1.0.0\n-----\n\n   this is a test\n',
+  ],
+])('prependChangeset should %s', (_testName, markdown, expected) => {
+  expect(
+    prependChangeset(markdown, {
+      body: 'rewrote everything from scratch',
+      name: '2.0.0',
+    })
+  ).toEqual(expected);
 });

--- a/src/utils/__tests__/changes.test.ts
+++ b/src/utils/__tests__/changes.test.ts
@@ -2,73 +2,78 @@
 
 import { findChangeset, removeChangeset, prependChangeset } from '../changes';
 
-test.each([
-  [
-    'regular',
-    (name: string, body: string) => `# Changelog\n## ${name}\n${body}\n`,
-  ],
-  [
-    'ignore date in parentheses',
-    (name: string, body: string) => `# Changelog
+describe('findChangeset', () => {
+  const sampleChangeset = {
+    body: 'this is a test',
+    name: 'Version 1.0.0',
+  };
+
+  test.each([
+    [
+      'regular',
+      `# Changelog\n## ${sampleChangeset.name}\n${sampleChangeset.body}\n`,
+    ],
+    [
+      'ignore date in parentheses',
+      `# Changelog
     ## 1.0.1
     newer
 
-    ## ${name} (2019-02-02)
-    ${body}
+    ## ${sampleChangeset.name} (2019-02-02)
+    ${sampleChangeset.body}
 
     ## 0.9.0
     older
     `,
-  ],
-  [
-    'extracts a change between headings',
-    (name: string, body: string) => `# Changelog
+    ],
+    [
+      'extracts a change between headings',
+      `# Changelog
     ## 1.0.1
     newer
 
-    ## ${name}
-    ${body}
+    ## ${sampleChangeset.name}
+    ${sampleChangeset.body}
 
     ## 0.9.0
     older
     `,
-  ],
-  [
-    'extracts changes from underlined headings',
-    (name: string, body: string) => `Changelog\n====\n${name}\n----\n${body}\n`,
-  ],
-  [
-    'extracts changes from alternating headings',
-    (name: string, body: string) => `# Changelog
+    ],
+    [
+      'extracts changes from underlined headings',
+      `Changelog\n====\n${sampleChangeset.name}\n----\n${sampleChangeset.body}\n`,
+    ],
+    [
+      'extracts changes from alternating headings',
+      `# Changelog
     ## 1.0.1
     newer
 
-    ${name}
+    ${sampleChangeset.name}
     -------
-    ${body}
+    ${sampleChangeset.body}
 
     ## 0.9.0
     older
     `,
-  ],
-])('findChangeset should extract %s', (_testName, markdown) => {
-  const name = 'Version 1.0.0';
-  const body = 'this is a test';
-  expect(findChangeset(markdown(name, body), 'v1.0.0')).toEqual({ name, body });
-});
+    ],
+  ])('should extract %s', (_testName, markdown) => {
+    expect(findChangeset(markdown, 'v1.0.0')).toEqual(sampleChangeset);
+  });
 
-test.each([
-  ['changeset cannot be found', 'v1.0.0'],
-  ['invalid version', 'not a version'],
-])('findChangeset should return null on %s', (_testName, version) => {
-  const markdown = `# Changelog
+  test.each([
+    ['changeset cannot be found', 'v1.0.0'],
+    ['invalid version', 'not a version'],
+  ])('should return null on %s', (_testName, version) => {
+    const markdown = `# Changelog
     ## 1.0.1
     newer
 
     ## 0.9.0
     older
     `;
-  expect(findChangeset(markdown, version)).toEqual(null);
+    expect(findChangeset(markdown, version)).toEqual(null);
+  });
 });
 
 test.each([

--- a/src/utils/__tests__/changes.test.ts
+++ b/src/utils/__tests__/changes.test.ts
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 
 import {
-  findChangeset /*, removeChangeset, prependChangeset*/,
+  findChangeset,
+  removeChangeset /*, prependChangeset*/,
 } from '../changes';
 
 test.each([
@@ -71,4 +72,120 @@ test.each([
     older
     `;
   expect(findChangeset(markdown, version)).toEqual(null);
+});
+
+test.each([
+  [
+    'remove from the top',
+    '1.0.1',
+    `# Changelog
+    1.0.0
+    -------
+    this is a test
+
+    ## 0.9.1
+    slightly older
+
+    ## 0.9.0
+    older
+    `,
+  ],
+  [
+    'remove from the middle',
+    '0.9.1',
+    `# Changelog
+    ## 1.0.1
+    newer
+
+    1.0.0
+    -------
+    this is a test
+
+    ## 0.9.0
+    older
+    `,
+  ],
+  [
+    'remove from underlined',
+    '1.0.0',
+    `# Changelog
+    ## 1.0.1
+    newer
+
+    ## 0.9.1
+    slightly older
+
+    ## 0.9.0
+    older
+    `,
+  ],
+  [
+    'remove from the bottom',
+    '0.9.0',
+    `# Changelog
+    ## 1.0.1
+    newer
+
+    1.0.0
+    -------
+    this is a test
+
+    ## 0.9.1
+    slightly older
+
+`,
+  ],
+  [
+    'not remove missing',
+    'non-existent version',
+    `# Changelog
+    ## 1.0.1
+    newer
+
+    1.0.0
+    -------
+    this is a test
+
+    ## 0.9.1
+    slightly older
+
+    ## 0.9.0
+    older
+    `,
+  ],
+  [
+    'not remove empty',
+    '',
+    `# Changelog
+    ## 1.0.1
+    newer
+
+    1.0.0
+    -------
+    this is a test
+
+    ## 0.9.1
+    slightly older
+
+    ## 0.9.0
+    older
+    `,
+  ],
+])('remove changeset should %s', (_testName, header, expected) => {
+  const markdown = `# Changelog
+    ## 1.0.1
+    newer
+
+    1.0.0
+    -------
+    this is a test
+
+    ## 0.9.1
+    slightly older
+
+    ## 0.9.0
+    older
+    `;
+
+  expect(removeChangeset(markdown, header)).toEqual(expected);
 });

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -157,14 +157,15 @@ export function prependChangeset(
   const padding = start?.[1]?.length || 0;
   const padStr = new Array(padding + 1).join(' ');
   const body = changeset.body || `${padStr}${DEFAULT_CHANGESET_BODY}`;
-  let newChangeset;
+  let header;
   if (start?.[3]) {
     const underline = new Array(changeset.name.length + 1).join('-');
-    newChangeset = `${changeset.name}\n${underline}\n\n${body}\n\n`;
+    header = `${changeset.name}\n${underline}`;
   } else {
-    newChangeset = `${padStr}## ${changeset.name}\n\n${body}\n\n`;
+    header = `## ${changeset.name}`;
   }
+  const newSection = `${padStr}${header}\n\n${padStr}${body}\n\n`;
   const startIdx = start?.index ?? markdown.length;
 
-  return markdown.slice(0, startIdx) + newChangeset + markdown.slice(startIdx);
+  return markdown.slice(0, startIdx) + newSection + markdown.slice(startIdx);
 }

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -63,7 +63,7 @@ function locateChangeset(
   markdown: string,
   predicate: (match: string) => boolean
 ): ChangesetLoc | null {
-  const HEADER_REGEX = /^(?:( *)## *([^\n]+?) *#*|^([^\n]+)\n *(?:-){2,}) *(?:\n+|$)/gm;
+  const HEADER_REGEX = /^( *)(?:## *([^\n]+?) *#*|([^\n]+)\n *(?:-){2,}) *(?:\n+|$)/gm;
 
   for (
     let match = HEADER_REGEX.exec(markdown);
@@ -154,17 +154,14 @@ export function prependChangeset(
 ): string {
   // Try to locate the top-most non-empty header, no matter what is inside
   const start = locateChangeset(markdown, Boolean)?.start;
-  let body;
+  const padding = start?.[1]?.length || 0;
+  const padStr = new Array(padding + 1).join(' ');
+  const body = changeset.body || `${padStr}${DEFAULT_CHANGESET_BODY}`;
   let newChangeset;
   if (start?.[3]) {
-    body = changeset.body || DEFAULT_CHANGESET_BODY;
     const underline = new Array(changeset.name.length + 1).join('-');
     newChangeset = `${changeset.name}\n${underline}\n\n${body}\n\n`;
   } else {
-    const padding = start?.[1]?.length || 0;
-    const padStr = new Array(padding + 1).join(' ');
-
-    body = changeset.body || `${padStr}${DEFAULT_CHANGESET_BODY}`;
     newChangeset = `${padStr}## ${changeset.name}\n\n${body}\n\n`;
   }
   const startIdx = start?.index ?? markdown.length;

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -51,9 +51,17 @@ export function extractChangeset(
 }
 
 /**
- * Does something
+ * Locates and returns a changeset section with the title passed in header.
+ * Supports an optional "predicate" callback used to compare the expected title
+ * and the title found in text. Useful for normalizing versions.
+ *
  * @param markdown The full changelog markdown
  * @param header The header of the section to extract
+ * @param predicate A callback that takes the found title and the expected title
+ *                  and returns true if they match, false otherwise
+ * @returns A ChangesetLoc object where "start" has the matche for the header,
+ *          and "end" has the match for the next header so the contents
+ *          inbetween can be extracted
  */
 export function locateChangeset(
   markdown: string,
@@ -88,7 +96,8 @@ export function locateChangeset(
  *
  * @param markdown The markdown containing the changeset
  * @param tag A git tag containing a version number
- * @param [fallbackToUnreleased=false] Whether to fallback to "unreleased" when tag is not found
+ * @param [fallbackToUnreleased=false] Whether to fallback to "unreleased" when
+ *        tag is not found
  * @returns The changeset if found; otherwise null
  */
 export function findChangeset(
@@ -117,6 +126,7 @@ export function findChangeset(
  * Removes a given changeset from the provided markdown and returns the modified markdown
  * @param markdown The markdown containing the changeset
  * @param header The header of the changeset to-be-removed
+ * @returns The markdown string without the changeset with the provided header
  */
 export function removeChangeset(markdown: string, header: string): string {
   const location = locateChangeset(markdown, header);
@@ -130,9 +140,15 @@ export function removeChangeset(markdown: string, header: string): string {
 }
 
 /**
- * Prepends a changeset to the provided markdown text and returns the result
+ * Prepends a changeset to the provided markdown text and returns the result.
+ * It tries to prepend before the first ever changeset header, to keep any
+ * higher-level content intact and in order. If none found, then the changeset
+ * is *appended* instead.
+ *
  * @param markdown The markdown that will be prepended
  * @param changeset The changeset data to prepend to
+ * @returns The markdown string with the changeset prepedend before the top-most
+ *          existing changeset.
  */
 export function prependChangeset(
   markdown: string,
@@ -140,7 +156,7 @@ export function prependChangeset(
 ): string {
   // Try to locate the top-most header, no matter what is inside
   const location = locateChangeset(markdown, '', () => true);
-  const start = location?.start.index ?? 0;
+  const start = location?.start.index ?? markdown.length;
 
   const newChangeset = `## ${changeset.name}\n\n${changeset.body || ''}\n\n`;
 

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -4,6 +4,8 @@ import { getVersion } from './version';
  * Path to the changelog file in the target repository
  */
 export const DEFAULT_CHANGELOG_PATH = 'CHANGELOG.md';
+export const DEFAULT_UNRELEASED_TITLE = 'Unreleased';
+const HEADER_REGEX = /^ *## *([^\n]+?) *#* *(?:\n+|$)|^([^\n]+)\n *(?:-){2,} *(?:\n+|$)/gm;
 
 /**
  * A single changeset with name and description
@@ -16,6 +18,14 @@ export interface Changeset {
 }
 
 /**
+ * A changeset location based on RegExpExecArrays
+ */
+export interface ChangesetLoc {
+  start: RegExpExecArray;
+  end: RegExpExecArray | null;
+}
+
+/**
  * Extracts a specific changeset from a markdown document
  *
  * The changes are bounded by a header preceding the changes and an optional
@@ -24,20 +34,47 @@ export interface Changeset {
  * given header.
  *
  * @param markdown The full changelog markdown
- * @param header The header of the section to extract
- * @param nextHeader An optional header of the next section
+ * @param location The start & end location for the section
  * @returns The extracted changes
  */
 export function extractChangeset(
   markdown: string,
-  header: RegExpExecArray,
-  nextHeader?: RegExpExecArray
+  location: ChangesetLoc
 ): Changeset {
-  const start = header.index + header[0].length;
-  const end = nextHeader ? nextHeader.index : undefined;
+  const start = location.start.index + location.start[0].length;
+  const end = location.end ? location.end.index : undefined;
   const body = markdown.substring(start, end).trim();
-  const name = (header[1] || header[2]).replace(/\(.*\)$/, '').trim();
+  const name = (location.start[1] || location.start[2])
+    .replace(/\(.*\)$/, '')
+    .trim();
   return { name, body };
+}
+
+/**
+ * Does something
+ * @param markdown The full changelog markdown
+ * @param header The header of the section to extract
+ */
+export function locateChangeset(
+  markdown: string,
+  header: string,
+  predicate: (match: string, expected: string) => boolean = (a, b) => a === b
+): ChangesetLoc | undefined {
+  HEADER_REGEX.lastIndex = 0;
+  for (
+    let match = HEADER_REGEX.exec(markdown);
+    match !== null;
+    match = HEADER_REGEX.exec(markdown)
+  ) {
+    const matchedTitle = match[1] || match[2];
+    if (predicate(matchedTitle, header)) {
+      return {
+        end: HEADER_REGEX.exec(markdown),
+        start: match,
+      };
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -51,27 +88,61 @@ export function extractChangeset(
  *
  * @param markdown The markdown containing the changeset
  * @param tag A git tag containing a version number
+ * @param [fallbackToUnreleased=false] Whether to fallback to "unreleased" when tag is not found
  * @returns The changeset if found; otherwise null
  */
 export function findChangeset(
   markdown: string,
-  tag: string
+  tag: string,
+  fallbackToUnreleased: boolean = false
 ): Changeset | undefined {
   const version = getVersion(tag);
   if (version === null) {
     return undefined;
   }
 
-  const regex = /^ *## *([^\n]+?) *#* *(?:\n+|$)|^([^\n]+)\n *(?:-){2,} *(?:\n+|$)/gm;
-  for (
-    let match = regex.exec(markdown);
-    match !== null;
-    match = regex.exec(markdown)
-  ) {
-    if (getVersion(match[1] || match[2]) === version) {
-      const nextMatch = regex.exec(markdown) || undefined;
-      return extractChangeset(markdown, match, nextMatch);
-    }
+  let changesetLoc = locateChangeset(
+    markdown,
+    version,
+    (match, header) => getVersion(match) === header
+  );
+  if (!changesetLoc && fallbackToUnreleased) {
+    changesetLoc = locateChangeset(markdown, DEFAULT_UNRELEASED_TITLE);
   }
-  return undefined;
+
+  return changesetLoc ? extractChangeset(markdown, changesetLoc) : undefined;
+}
+
+/**
+ * Removes a given changeset from the provided markdown and returns the modified markdown
+ * @param markdown The markdown containing the changeset
+ * @param header The header of the changeset to-be-removed
+ */
+export function removeChangeset(markdown: string, header: string): string {
+  const location = locateChangeset(markdown, header);
+  if (!location) {
+    return markdown;
+  }
+
+  const start = location.start.index;
+  const end = location.end?.index ?? markdown.length;
+  return markdown.slice(0, start) + markdown.slice(end);
+}
+
+/**
+ * Prepends a changeset to the provided markdown text and returns the result
+ * @param markdown The markdown that will be prepended
+ * @param changeset The changeset data to prepend to
+ */
+export function prependChangeset(
+  markdown: string,
+  changeset: Changeset
+): string {
+  // Try to locate the top-most header, no matter what is inside
+  const location = locateChangeset(markdown, '', () => true);
+  const start = location?.start.index ?? 0;
+
+  const newChangeset = `## ${changeset.name}\n\n${changeset.body || ''}\n\n`;
+
+  return markdown.slice(0, start) + newChangeset + markdown.slice(start);
 }

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -37,10 +37,7 @@ export interface ChangesetLoc {
  * @param location The start & end location for the section
  * @returns The extracted changes
  */
-export function extractChangeset(
-  markdown: string,
-  location: ChangesetLoc
-): Changeset {
+function extractChangeset(markdown: string, location: ChangesetLoc): Changeset {
   const start = location.start.index + location.start[0].length;
   const end = location.end ? location.end.index : undefined;
   const body = markdown.substring(start, end).trim();
@@ -62,7 +59,7 @@ export function extractChangeset(
  *          and "end" has the match for the next header so the contents
  *          inbetween can be extracted
  */
-export function locateChangeset(
+function locateChangeset(
   markdown: string,
   predicate: (match: string) => boolean
 ): ChangesetLoc | undefined {

--- a/src/utils/changes.ts
+++ b/src/utils/changes.ts
@@ -62,7 +62,7 @@ function extractChangeset(markdown: string, location: ChangesetLoc): Changeset {
 function locateChangeset(
   markdown: string,
   predicate: (match: string) => boolean
-): ChangesetLoc | undefined {
+): ChangesetLoc | null {
   const HEADER_REGEX = /^(?:( *)## *([^\n]+?) *#*|^([^\n]+)\n *(?:-){2,}) *(?:\n+|$)/gm;
 
   for (
@@ -78,7 +78,7 @@ function locateChangeset(
       };
     }
   }
-  return undefined;
+  return null;
 }
 
 /**
@@ -100,10 +100,10 @@ export function findChangeset(
   markdown: string,
   tag: string,
   fallbackToUnreleased: boolean = false
-): Changeset | undefined {
+): Changeset | null {
   const version = getVersion(tag);
   if (version === null) {
-    return undefined;
+    return null;
   }
 
   let changesetLoc = locateChangeset(
@@ -117,7 +117,7 @@ export function findChangeset(
     );
   }
 
-  return changesetLoc ? extractChangeset(markdown, changesetLoc) : undefined;
+  return changesetLoc ? extractChangeset(markdown, changesetLoc) : null;
 }
 
 /**


### PR DESCRIPTION
This patch adds the "auto" changeset policy, which works as follows:

1. If there is already a changeset entry for the new version, use that (same as simple)
2. Else if there is an "Unreleased" changeset, rename that to the new version
3. Else, create a new version section with a default text
~~4. In all cases, create an empty "Unreleased" section at the top~~

Decided to remove the creation of an empty "Unreleased" section as that would end up in the final commit/tag which is pointless: you don't expect to see an "unreleased" section on your version commit/tag.

TODO:

1. ~~Add tests~~
2. Make "Unreleased title" configurable (follow up)
3. ~~Respect existing changelog files indentation and header style~~
4. Add a bunch more tests for `prepare` command, especially for dry run (follow up)