### PR TITLE
feat(crates): Add noDevDeps option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get -qq update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --  --profile minimal -y \
-  && cargo --version
+  && cargo --version \
+  && cargo install cargo-hack
 
 COPY --from=builder /app/package.json /app/yarn.lock /craft/
 RUN export YARN_CACHE_FOLDER="$(mktemp -d)" \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ then enforces a specific workflow for managing release branches, changelogs, art
   - [GitHub Pages (`gh-pages`)](#github-pages-gh-pages)
   - [Sentry Release Registry (`registry`)](#sentry-release-registry-registry)
   - [Cocoapods (`cocoapods`)](#cocoapods-cocoapods)
+  - [Docker (`docker`)](#docker-docker)
 - [Integrating Your Project with `craft`](#integrating-your-project-with-craft)
 - [Pre-release (Version-bumping) Script: Conventions](#pre-release-version-bumping-script-conventions)
 - [Development](#development)
@@ -274,9 +275,9 @@ In `auto` mode, `craft prepare` will use the following logic:
 
 **Configuration**
 
-| Option            | Description                                                                       |
-| ----------------- | --------------------------------------------------------------------------------- |
-| `changelog`       | **optional**. Path to the changelog file. Defaults to `CHANGELOG.md`              |
+| Option            | Description                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------ |
+| `changelog`       | **optional**. Path to the changelog file. Defaults to `CHANGELOG.md`                       |
 | `changelogPolicy` | **optional**. Changelog management mode (`none`, `simple`, or `auto`). Defaults to `none`. |
 
 **Example (`simple`):**
@@ -614,13 +615,18 @@ they are published in an order depending on their dependencies.
 
 **Configuration**
 
-_none_
+**Configuration**
+
+| Option      | Description                                                                                                                                                                                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `noDevDeps` | **optional**. Strips `devDependencies` from crates before publishing. This is useful if a workspace crate uses circular dependencies for docs. Requires [`cargo-hack`](https://github.com/taiki-e/cargo-hack#readme) installed. Defaults to `false`. |
 
 **Example**
 
 ```yaml
 targets:
   - name: crates
+    noDevDeps: false
 ```
 
 ### Google Cloud Storage (`gcs`)
@@ -790,18 +796,18 @@ non-idempotent targets, not for the Docker target.
 
 `docker` executable (or something equivalent) must be installed on the system.
 
-| Name                    | Description                               |
-| ----------------------- | ----------------------------------------- |
-| `DOCKER_USERNAME`       | The username for the Docker registry      |
-| `DOCKER_PASSWORD`       | The password for the Docker registry      |
-| `DOCKER_BIN`            | **optional**. Path to `docker` executable.   |
+| Name              | Description                                |
+| ----------------- | ------------------------------------------ |
+| `DOCKER_USERNAME` | The username for the Docker registry       |
+| `DOCKER_PASSWORD` | The password for the Docker registry       |
+| `DOCKER_BIN`      | **optional**. Path to `docker` executable. |
 
 **Configuration**
 
-| Option     | Description                                  |
-| ---------- | -------------------------------------------- |
-| `source`   | Path to the source Docker image to be pulled |
-| `target`   | Path to the target Docker image to be pushed |
+| Option   | Description                                  |
+| -------- | -------------------------------------------- |
+| `source` | Path to the source Docker image to be pulled |
+| `target` | Path to the target Docker image to be pushed |
 
 **Example**
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     '--build-arg', 'SOURCE_COMMIT=$COMMIT_SHA',
     '--destination=us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA'
   ]
-  timeout: 360s
+  timeout: 900s
 # Smoke tests
 - name: 'us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA'
   args:
@@ -29,7 +29,7 @@ steps:
     docker push getsentry/craft:$COMMIT_SHA
     docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:latest
     docker push getsentry/craft:latest
-timeout: 540s
+timeout: 960s
 secrets:
 - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
   secretEnv:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,41 +1,43 @@
 steps:
-- name: 'gcr.io/kaniko-project/executor:v0.23.0'
-  args: [
-    '--cache=true',
-    '--build-arg', 'SOURCE_COMMIT=$COMMIT_SHA',
-    '--destination=us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA'
-  ]
-  timeout: 900s
-# Smoke tests
-- name: 'us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA'
-  args:
-  - '--help'
-  timeout: 60s
-- name: 'gcr.io/cloud-builders/docker'
-  secretEnv: ['DOCKER_PASSWORD']
-  entrypoint: 'bash'
-  args:
-  - '-e'
-  - '-c'
-  - |
-    # Only push to Docker Hub from master
-    [ "$BRANCH_NAME" != "master" ] && exit 0
-    # Need to pull the image first due to Kaniko
-    docker pull us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA
-    echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
-    docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:$SHORT_SHA
-    docker push getsentry/craft:$SHORT_SHA
-    docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:$COMMIT_SHA
-    docker push getsentry/craft:$COMMIT_SHA
-    docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:latest
-    docker push getsentry/craft:latest
+  - name: 'gcr.io/kaniko-project/executor:v0.23.0'
+    args:
+      [
+        '--cache=true',
+        '--build-arg',
+        'SOURCE_COMMIT=$COMMIT_SHA',
+        '--destination=us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA',
+      ]
+    timeout: 900s
+  # Smoke tests
+  - name: 'us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA'
+    args:
+      - '--help'
+    timeout: 60s
+  - name: 'gcr.io/cloud-builders/docker'
+    secretEnv: ['DOCKER_PASSWORD']
+    entrypoint: 'bash'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        # Only push to Docker Hub from master
+        [ "$BRANCH_NAME" != "master" ] && exit 0
+        # Need to pull the image first due to Kaniko
+        docker pull us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA
+        echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
+        docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:$SHORT_SHA
+        docker push getsentry/craft:$SHORT_SHA
+        docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:$COMMIT_SHA
+        docker push getsentry/craft:$COMMIT_SHA
+        docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:latest
+        docker push getsentry/craft:latest
 timeout: 960s
 secrets:
-- kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
-  secretEnv:
-    # This is a personal access token for the sentrybuilder account, encrypted using the
-    # short guide at http://bit.ly/2Pg6uw9
-    DOCKER_PASSWORD: |
-      CiQAE8gN7y3OMxn+a1kofmK4Bi8jQZtdRFj2lYYwaZHVeIIBUzMSTQA9tvn8XCv2vqj6u8CHoeSP
-      TVW9pLvSCorKoeNtOp0eb+6V1yNJW/+JC07DNO1KLbTbodbuza6jKJHU5xeAJ4kGQI78UY5Vu1Gp
-      QcMK
+  - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
+    secretEnv:
+      # This is a personal access token for the sentrybuilder account, encrypted using the
+      # short guide at http://bit.ly/2Pg6uw9
+      DOCKER_PASSWORD: |
+        CiQAE8gN7y3OMxn+a1kofmK4Bi8jQZtdRFj2lYYwaZHVeIIBUzMSTQA9tvn8XCv2vqj6u8CHoeSP
+        TVW9pLvSCorKoeNtOp0eb+6V1yNJW/+JC07DNO1KLbTbodbuza6jKJHU5xeAJ4kGQI78UY5Vu1Gp
+        QcMK

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -151,6 +151,17 @@ const projectConfigJsonSchema = {
       },
       additionalProperties: false,
     },
+    cratesConfig: {
+      title: 'CratesTargetConfig',
+      description: 'Configuration options for the Crates target',
+      extends: { $ref: '#/definitions/targetConfig' },
+      properties: {
+        noDevDeps: {
+          type: 'boolean',
+        },
+      },
+      additionalProperties: false,
+    },
   },
 };
 

--- a/src/targets/__tests__/crates.test.ts
+++ b/src/targets/__tests__/crates.test.ts
@@ -22,11 +22,21 @@ function cratePackageToDependency(cratePackage: CratePackage): CrateDependency {
   };
 }
 
+function makeDev(dependency: CrateDependency): CrateDependency {
+  return {
+    ...dependency,
+    kind: 'dev',
+  };
+}
+
 describe('getPublishOrder', () => {
   process.env.CRATES_IO_TOKEN = 'xxx';
-  const target = new CratesTarget({}, new NoneArtifactProvider());
+  const target = new CratesTarget(
+    { noDevDeps: true },
+    new NoneArtifactProvider()
+  );
 
-  test('sorts crate packages properly', async () => {
+  test('sorts crate packages properly', () => {
     const packages = ['p1', 'p2', 'p3', 'p4'].map(cratePackageFactory);
     const [p1, p2, p3, p4] = packages;
     p1.dependencies = [p2, p3].map(cratePackageToDependency);
@@ -36,8 +46,29 @@ describe('getPublishOrder', () => {
     expect(target.getPublishOrder(packages)).toEqual(sortedPackages);
   });
 
-  test('does not fail on a single package', async () => {
+  test('does not fail on a single package', () => {
     const packages = [cratePackageFactory('p1')];
     expect(target.getPublishOrder(packages)).toEqual(packages);
+  });
+
+  test('errors on circular dependencies', () => {
+    const packages = ['p1', 'p2'].map(cratePackageFactory);
+    const [p1, p2] = packages;
+
+    p1.dependencies = [cratePackageToDependency(p2)];
+    p2.dependencies = [cratePackageToDependency(p1)];
+
+    expect(() => target.getPublishOrder(packages)).toThrowError(Error);
+  });
+
+  test('excludes dev dependencies', () => {
+    const packages = ['p1', 'p2'].map(cratePackageFactory);
+    const [p1, p2] = packages;
+
+    p1.dependencies = [cratePackageToDependency(p2)];
+    p2.dependencies = [makeDev(cratePackageToDependency(p1))];
+
+    const sortedPackages = [p2, p1];
+    expect(target.getPublishOrder(packages)).toEqual(sortedPackages);
   });
 });

--- a/src/targets/__tests__/crates.test.ts
+++ b/src/targets/__tests__/crates.test.ts
@@ -18,6 +18,7 @@ function cratePackageToDependency(cratePackage: CratePackage): CrateDependency {
   return {
     name: cratePackage.name,
     req: '1.0.0',
+    kind: null,
   };
 }
 

--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -28,6 +28,8 @@ const CARGO_BIN = process.env.CARGO_BIN || DEFAULT_CARGO_BIN;
 export interface CratesTargetOptions extends TargetConfig {
   /** Crates API token */
   apiToken: string;
+  /** Whether to use `cargo-hack` and remove dev dependencies */
+  noDevDeps: boolean;
 }
 
 /** A package dependency specification */
@@ -96,6 +98,7 @@ export class CratesTarget extends BaseTarget {
     }
     return {
       apiToken: process.env.CRATES_IO_TOKEN,
+      noDevDeps: !!this.config.noDevDeps,
     };
   }
 
@@ -152,7 +155,7 @@ export class CratesTarget extends BaseTarget {
     const isWorkspaceDependency = (dep: CrateDependency) => {
       // Optionally exclude dev dependencies from dependency resolution. When
       // this flag is provided, these usually lead to circular dependencies.
-      if (this.config.noDevDeps && dep.kind === 'dev') {
+      if (this.cratesConfig.noDevDeps && dep.kind === 'dev') {
         return false;
       }
 
@@ -214,7 +217,7 @@ export class CratesTarget extends BaseTarget {
    * @returns A promise that resolves when the upload has completed
    */
   public async publishPackage(crate: CratePackage): Promise<any> {
-    const args = this.config.noDevDeps
+    const args = this.cratesConfig.noDevDeps
       ? ['hack', 'publish', '--allow-dirty', '--no-dev-deps']
       : ['publish'];
 


### PR DESCRIPTION
Cargo does not allow to publish crates with circular dependencies. In dev dependencies, they would theoretically be fine since they are not required to run or build the crate. We need them in the Rust SDK to provide proper doc comments in sub-crates. 

This PR adds a new `noDevDeps` option, which uses `cargo hack` to strip dev dependencies before publishing.