### PR TITLE
fix(eslint): Address eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
     'no-constant-condition': ['error', { checkLoops: false }],
+    // Make sure variables marked with _ are ignored (ex. _varName)
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - build: Migrate from tslint to eslint (#113)
+- fix: Add stronger types for module exports (#114)
 
 ## 0.10.1
 

--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -4,7 +4,6 @@ import {
   HashOutputFormat,
 } from '../utils/system';
 import { clearObjectProperties } from '../utils/objects';
-import * as _ from 'lodash';
 import { ConfigurationError } from '../utils/errors';
 import { logger as loggerRaw } from '../logger';
 

--- a/src/commands/artifacts.ts
+++ b/src/commands/artifacts.ts
@@ -1,4 +1,4 @@
-import { Argv } from 'yargs';
+import { Argv, CommandBuilder } from 'yargs';
 
 export const command = ['artifacts <command>'];
 export const aliases = ['a', 'artifact'];
@@ -11,7 +11,7 @@ export interface ArtifactsOptions {
   rev: string;
 }
 
-export const builder = (yargs: Argv) =>
+export const builder: CommandBuilder = (yargs: Argv) =>
   yargs
     .option('rev', {
       alias: 'r',

--- a/src/commands/artifacts_cmds/download.ts
+++ b/src/commands/artifacts_cmds/download.ts
@@ -3,7 +3,7 @@ import { logger } from '../../logger';
 import { ArtifactsOptions } from '../artifacts';
 import { getArtifactProviderFromConfig } from '../../config';
 import { handleGlobalError, ConfigurationError } from '../../utils/errors';
-import { Argv } from 'yargs';
+import { Argv, CommandBuilder } from 'yargs';
 import { resolve } from 'path';
 import { existsSync, lstatSync } from 'fs';
 import mkdirp = require('mkdirp');
@@ -12,7 +12,7 @@ import { NoneArtifactProvider } from '../../artifact_providers/none';
 export const command = ['download [NAME..]'];
 export const aliases = ['d', 'get'];
 export const description = 'Download artifacts';
-export const builder = (yargs: Argv) =>
+export const builder: CommandBuilder = (yargs: Argv) =>
   yargs
     .positional('NAME', {
       alias: 'names',

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -2,7 +2,7 @@ import { existsSync, promises as fsPromises } from 'fs';
 import { dirname, join, relative } from 'path';
 import * as shellQuote from 'shell-quote';
 import * as simpleGit from 'simple-git/promise';
-import { Arguments, Argv } from 'yargs';
+import { Arguments, Argv, CommandBuilder } from 'yargs';
 
 import {
   checkMinimalConfigVersion,
@@ -39,7 +39,7 @@ export const description = '🚢 Prepare a new release branch';
 /** Default path to bump-version script, relative to project root */
 const DEFAULT_BUMP_VERSION_PATH = join('scripts', 'bump-version.sh');
 
-export const builder = (yargs: Argv) =>
+export const builder: CommandBuilder = (yargs: Argv) =>
   yargs
     .positional('NEW-VERSION', {
       description: 'The new version you want to release',
@@ -566,7 +566,7 @@ function getRemoteName(): string {
   return process.env.CRAFT_REMOTE || 'origin';
 }
 
-export const handler = async (argv: ReleaseOptions) => {
+export const handler = async (argv: ReleaseOptions): Promise<any> => {
   try {
     return await releaseMain(argv);
   } catch (e) {

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,6 +1,6 @@
 import * as Github from '@octokit/rest';
 import * as inquirer from 'inquirer';
-import { Arguments, Argv } from 'yargs';
+import { Arguments, Argv, CommandBuilder } from 'yargs';
 import chalk from 'chalk';
 import * as stringLength from 'string-length';
 
@@ -31,7 +31,7 @@ export const command = ['publish NEW-VERSION'];
 export const aliases = ['pp', 'publish'];
 export const description = '🛫 Publish artifacts';
 
-export const builder = (yargs: Argv) =>
+export const builder: CommandBuilder = (yargs: Argv) =>
   yargs
     .positional('NEW-VERSION', {
       description: 'Version to publish',
@@ -517,7 +517,7 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
   }
 }
 
-export const handler = async (argv: PublishOptions) => {
+export const handler = async (argv: PublishOptions): Promise<any> => {
   try {
     catchKeyboardInterrupt();
     return await publishMain(argv);

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,7 +118,9 @@ export function getProjectConfigSchema(): any {
  *
  * @param rawConfig Raw project configuration object
  */
-export function validateConfiguration(rawConfig: any): CraftProjectConfig {
+export function validateConfiguration(
+  rawConfig: Record<string, any>
+): CraftProjectConfig {
   logger.debug('Parsing and validating the configuration file...');
   const schemaName = 'projectConfig';
   const projectConfigSchema = getProjectConfigSchema();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,7 +8,10 @@ import consola = require('consola');
  * @param options Options that are passed to cli-table constructor
  * @param values A list (of lists) of values
  */
-export function formatTable(options: any, values: any[]): string {
+export function formatTable(
+  options: Record<string, any>,
+  values: any[]
+): string {
   const table = new Table(options);
   table.push(...values);
   return table.toString();

--- a/src/status_providers/github.ts
+++ b/src/status_providers/github.ts
@@ -16,7 +16,7 @@ export class GithubStatusProvider extends BaseStatusProvider {
   public constructor(
     private readonly repoOwner: string,
     private readonly repoName: string,
-    config?: any
+    config?: Record<string, any>
   ) {
     super();
     this.github = getGithubClient();

--- a/src/status_providers/zeus.ts
+++ b/src/status_providers/zeus.ts
@@ -8,7 +8,11 @@ export class ZeusStatusProvider extends BaseStatusProvider {
   /** Zeus API client */
   public readonly store: ZeusStore;
 
-  public constructor(repoOwner: string, repoName: string, config?: any) {
+  public constructor(
+    repoOwner: string,
+    repoName: string,
+    config?: Record<string, any>
+  ) {
     super();
     this.store = new ZeusStore(repoOwner, repoName);
     this.config = config;

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -1,6 +1,5 @@
 import { mapLimit } from 'async';
 import * as Github from '@octokit/rest';
-import * as _ from 'lodash';
 
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -55,7 +55,10 @@ export class BrewTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.brewConfig = this.getBrewConfig();
     this.github = getGithubClient();

--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -42,7 +42,10 @@ export class CocoapodsTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.cocoapodsConfig = this.getCocoapodsConfig();
     this.github = getGithubClient();

--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -107,7 +107,10 @@ export class CratesTarget extends BaseTarget {
   /** Target options */
   public readonly cratesConfig: CratesTargetOptions;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.cratesConfig = this.getCratesConfig();
     checkExecutableIsPresent(CARGO_BIN);

--- a/src/targets/docker.ts
+++ b/src/targets/docker.ts
@@ -33,7 +33,10 @@ export class DockerTarget extends BaseTarget {
   /** Target options */
   public readonly dockerConfig: DockerTargetOptions;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.dockerConfig = this.getDockerConfig();
     checkExecutableIsPresent(DOCKER_BIN);

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -52,7 +52,10 @@ export class GhPagesTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.github = getGithubClient();
     this.githubRepo = getGlobalGithubConfig();

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -68,7 +68,10 @@ export class GithubTarget extends BaseTarget {
   /** Github client */
   public readonly github: Github;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.githubConfig = {
       ...getGlobalGithubConfig(),

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -69,7 +69,10 @@ export class NpmTarget extends BaseTarget {
   /** Target options */
   public readonly npmConfig: NpmTargetOptions;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.checkRequirements();
     this.npmConfig = this.getNpmConfig();

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -36,7 +36,10 @@ export class NugetTarget extends BaseTarget {
   /** Target options */
   public readonly nugetConfig: NugetTargetOptions;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.nugetConfig = this.getNugetConfig();
     checkExecutableIsPresent(NUGET_DOTNET_BIN);

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -39,7 +39,10 @@ export class PypiTarget extends BaseTarget {
   /** Target options */
   public readonly pypiConfig: PypiTargetOptions;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.pypiConfig = this.getPypiConfig();
     checkExecutableIsPresent(TWINE_BIN);

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -87,7 +87,10 @@ export class RegistryTarget extends BaseTarget {
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
-  public constructor(config: any, artifactProvider: BaseArtifactProvider) {
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
     super(config, artifactProvider);
     this.github = getGithubClient();
     this.githubRepo = getGlobalGithubConfig();
@@ -102,7 +105,7 @@ export class RegistryTarget extends BaseTarget {
    *
    * @param checksums Raw configuration
    */
-  protected castChecksums(checksums: any): ChecksumEntry[] {
+  protected castChecksums(checksums: any[]): ChecksumEntry[] {
     if (!checksums) {
       return [];
     }

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -14,6 +14,7 @@ import { reportError } from './errors';
 export async function filterAsync<T>(
   array: T[],
   predicate: (arg: T) => boolean | Promise<boolean>,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   thisArg?: any
 ): Promise<T[]> {
   const verdicts = await Promise.all(array.map(predicate, thisArg));
@@ -28,7 +29,7 @@ export async function filterAsync<T>(
  * @returns A promise that resolves with each value
  * @async
  */
-export async function promiseProps(object: any): Promise<any> {
+export async function promiseProps(object: Record<string, any>): Promise<any> {
   const pairs = _.toPairs(object).map(async ([key, value]) => [
     key,
     await Promise.resolve(value),
@@ -55,6 +56,7 @@ export async function promiseProps(object: any): Promise<any> {
 export async function forEachChained<T>(
   array: T[],
   iteratee: (x: T) => any,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   thisArg?: any
 ): Promise<void> {
   return array.reduce(

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -85,6 +85,7 @@ export function coerceType<T>(
  *
  * @param e Error (exception) object to handle
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function handleGlobalError(e: any): void {
   if (!(e instanceof ConfigurationError)) {
     captureException(e);

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -4,7 +4,7 @@
  * @param obj Random object
  * @returns The input object with deleted properties
  */
-export function clearObjectProperties(obj: any): any {
+export function clearObjectProperties(obj: Record<string, any>): any {
   for (const prop of Object.keys(obj)) {
     delete obj[prop];
   }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -10,7 +10,7 @@ import * as mustache from 'mustache';
  * @param obj Object to normalize
  * @returns Normalized object
  */
-export function sanitizeObject(obj: any): any {
+export function sanitizeObject(obj: Record<string, any>): any {
   if (typeof obj !== 'object' || obj === null) {
     throw new Error(`Cannot normalize value: ${obj}`);
   }
@@ -50,7 +50,10 @@ export function sanitizeObject(obj: any): any {
  * @param context Template data
  * @returns Rendered template
  */
-export function renderTemplateSafe(template: string, context: any): string {
+export function renderTemplateSafe(
+  template: string,
+  context: Record<string, any>
+): string {
   return mustache.render(template, sanitizeObject(context));
 }
 
@@ -77,6 +80,9 @@ export function formatSize(size: number): string {
  *
  * @param obj Object to print out
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function formatJson(obj: any): string {
+  // Must type `obj` as any as JSON.stringify is typed as
+  // `JSON.stringify(value: any, ...)`.
   return JSON.stringify(obj, null, 4);
 }

--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -83,7 +83,10 @@ function processError(
  * @param arg String to process
  * @param env Environment-like key-value mapping
  */
-export function replaceEnvVariable(arg: string, env: any): string {
+export function replaceEnvVariable(
+  arg: string,
+  env: Record<string, any>
+): string {
   if (!env || !arg || arg[0] !== '$') {
     return arg;
   }


### PR DESCRIPTION
This PR continues from https://github.com/getsentry/craft/pull/113 and aims to reduce all the eslint related warnings to 0.

269aef6 has the changes related to fixing `@typescript-eslint/no-unused-vars`
See: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
- I added `{ argsIgnorePattern: '^_' }` to make sure that variables that start with `_` were fine to be unused, as this seems to be a pattern in the code base
- Caught some unnecessary imports of lodash though!

8539795 has the changes related to fixing `@typescript-eslint/explicit-module-boundary-types`
See: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
- This was mostly just typing exported functions, and using `Record<string, any>` to type config objects.