### PR TITLE
fix(github): Don't fail when there are queued check suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# Unreleased
+## Unreleased
 
 - build: Migrate from tslint to eslint (#113)
 - fix: Add stronger types for module exports (#114)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+# Unreleased
+
 - build: Migrate from tslint to eslint (#113)
 - fix: Add stronger types for module exports (#114)
+- fix(github): Don't fail when there are queued check suits (#117)
 
 ## 0.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - build: Migrate from tslint to eslint (#113)
 - fix: Add stronger types for module exports (#114)
-- fix(github): Don't fail when there are queued check suits (#117)
+- fix(github): Don't fail when there are queued check suites (#117)
 
 ## 0.10.1
 

--- a/src/status_providers/github.ts
+++ b/src/status_providers/github.ts
@@ -284,7 +284,7 @@ export class GithubStatusProvider extends BaseStatusProvider {
   }
 
   /**
-   * Gets revision checks from GitHub Check runs API
+   * Gets revision checks from GitHub Check suites API
    *
    * API docs:
    * https://developer.github.com/v3/checks/suites/#list-check-suites-for-a-git-reference


### PR DESCRIPTION
When the check suites are queued but the check runs haven't started yet, Craft immediately fails. With this patch, it also checks the Check Suites API to see if there are any pending check suites.

Fixes #111.
