### PR TITLE
feat: Add gem target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - build: Migrate from tslint to eslint (#113)
 - fix: Add stronger types for module exports (#114)
 - fix(github): Don't fail when there are queued check suites (#117)
+- feat: Add support for `gem` target (#119)
 
 ## 0.10.1
 

--- a/README.md
+++ b/README.md
@@ -823,9 +823,10 @@ statusProvider:
       - Travis CI - Branch # or whatever builds and pushes your source image
 ```
 
-### Ruby Gems Index (`pypi`)
+### Ruby Gems Index (`gem`)
 
 Pushes a gem [Ruby Gems](https://rubygems.org).
+It also requires you to be logged in `gem login`.
 
 **Environment**
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ then enforces a specific workflow for managing release branches, changelogs, art
   - [Sentry Release Registry (`registry`)](#sentry-release-registry-registry)
   - [Cocoapods (`cocoapods`)](#cocoapods-cocoapods)
   - [Docker (`docker`)](#docker-docker)
+  - [Ruby Gems (`gem`)](#ruby-gems-index-gem)
 - [Integrating Your Project with `craft`](#integrating-your-project-with-craft)
 - [Pre-release (Version-bumping) Script: Conventions](#pre-release-version-bumping-script-conventions)
 - [Development](#development)
@@ -820,6 +821,29 @@ statusProvider:
   config:
     contexts:
       - Travis CI - Branch # or whatever builds and pushes your source image
+```
+
+### Ruby Gems Index (`pypi`)
+
+Pushes a gem [Ruby Gems](https://rubygems.org).
+
+**Environment**
+
+`gem` must be installed on the system.
+
+| Name      | Description                                  |
+| --------- | -------------------------------------------- |
+| `GEM_BIN` | **optional**. Path to gem. Defaults to `gem` |
+
+**Configuration**
+
+_none_
+
+**Example**
+
+```yaml
+targets:
+  - name: gem
 ```
 
 ## Integrating Your Project with `craft`

--- a/src/targets/gem.ts
+++ b/src/targets/gem.ts
@@ -1,0 +1,77 @@
+import { logger as loggerRaw } from '../logger';
+import { TargetConfig } from '../schemas/project_config';
+import {
+  BaseArtifactProvider,
+  RemoteArtifact,
+} from '../artifact_providers/base';
+import { reportError } from '../utils/errors';
+import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
+import { BaseTarget } from './base';
+
+const logger = loggerRaw.withScope('[gem]');
+
+const DEFAULT_GEM_BIN = 'gem';
+
+/**
+ * Command to launch gem
+ */
+const GEM_BIN = process.env.TWINE_BIN || DEFAULT_GEM_BIN;
+
+/**
+ * RegExp for gems
+ */
+const DEFAULT_GEM_REGEX = /^.*(\.gem)$/;
+
+/**
+ * Target responsible for publishing releases to Ruby Gems (https://rubygems.org)
+ */
+export class GemTarget extends BaseTarget {
+  /** Target name */
+  public readonly name: string = 'gem';
+
+  public constructor(
+    config: Record<string, any>,
+    artifactProvider: BaseArtifactProvider
+  ) {
+    super(config, artifactProvider);
+    checkExecutableIsPresent(GEM_BIN);
+  }
+
+  /**
+   * Uploads a gem to rubygems
+   *
+   * @param path Absolute path to the archive to upload
+   * @returns A promise that resolves when the gem pushed
+   */
+  public async pushGem(path: string): Promise<any> {
+    return spawnProcess(GEM_BIN, ['push', path]);
+  }
+
+  /**
+   * Pushes a gem to rubygems.org
+   *
+   * @param version New version to be released
+   * @param revision Git commit SHA to be published
+   */
+  public async publish(_version: string, revision: string): Promise<any> {
+    logger.debug('Fetching artifact list...');
+    const packageFiles = await this.getArtifactsForRevision(revision, {
+      includeNames: DEFAULT_GEM_REGEX,
+    });
+
+    if (!packageFiles.length) {
+      reportError('Cannot push gem: no packages found');
+      return undefined;
+    }
+
+    await Promise.all(
+      packageFiles.map(async (file: RemoteArtifact) => {
+        const path = await this.artifactProvider.downloadArtifact(file);
+        logger.info(`Pushing gem "${file.filename}"`);
+        return this.pushGem(path);
+      })
+    );
+
+    logger.info('Successfully registered gem');
+  }
+}

--- a/src/targets/gem.ts
+++ b/src/targets/gem.ts
@@ -1,5 +1,4 @@
 import { logger as loggerRaw } from '../logger';
-import { TargetConfig } from '../schemas/project_config';
 import {
   BaseArtifactProvider,
   RemoteArtifact,

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -4,6 +4,7 @@ import { CocoapodsTarget } from './cocoapods';
 import { CratesTarget } from './crates';
 import { DockerTarget } from './docker';
 import { GcsTarget } from './gcs';
+import { GemTarget } from './gem';
 import { GhPagesTarget } from './ghPages';
 import { GithubTarget } from './github';
 import { NpmTarget } from './npm';
@@ -17,6 +18,7 @@ export const TARGET_MAP: { [key: string]: typeof BaseTarget } = {
   crates: CratesTarget,
   docker: DockerTarget,
   gcs: GcsTarget,
+  gem: GemTarget,
   'gh-pages': GhPagesTarget,
   github: GithubTarget,
   npm: NpmTarget,


### PR DESCRIPTION
I successfully did released https://github.com/getsentry/raven-ruby/releases/tag/3.0.2 with this branch.

```
➜ node ~/Projects/craft/dist/index.js publish 3.0.2
ℹ info craft 0.10.1
ℹ info "craft" version is compatible with the minimal version from the configuration file.
ℹ info Publishing version: "3.0.2"
ℹ info Using "GithubStatusProvider" for status checks
ℹ info Using "ZeusArtifactProvider" for artifacts
ℹ info No config provided for Github status provider, calculating the combined status...
ℹ info Revision df427b7320d36f30975d6746f730b1d12316bbf6 has been built successfully.
ℹ info
ℹ info Available artifacts:
┌────────────────────────┬─────────┬──────────────────────────────────┬─────────────────────┐
│ File Name              │ Size    │ Updated                          │ ContentType         │
├────────────────────────┼─────────┼──────────────────────────────────┼─────────────────────┤
│ sentry-raven-3.0.2.gem │ 46.5 kB │ 2020-08-20T10:11:00.038860+00:00 │ application/tar+gem │
└────────────────────────┴─────────┴──────────────────────────────────┴─────────────────────┘

ℹ info Publishing to targets:
ℹ info   - gem
ℹ info   - github
ℹ info   - registry
ℹ info
? Is everything OK? Type "yes" to proceed: yes
ℹ info
ℹ info =================================
ℹ info === Publishing to target: gem ===
ℹ info =================================
ℹ info [gem] › Pushing gem "sentry-raven-3.0.2.gem"
ℹ info [gem] › Successfully registered gem
ℹ info
ℹ info ====================================
ℹ info === Publishing to target: github ===
ℹ info ====================================
ℹ info [github] › Target "github": publishing version "3.0.2"...
ℹ info [github] › Git tag: "3.0.2"
ℹ info [github] › Creating a new release for tag "3.0.2"
ℹ info [github] › Uploading asset "sentry-raven-3.0.2.gem" to getsentry/raven-ruby:3.0.2
❯ log [github] › Uploaded asset "sentry-raven-3.0.2.gem".
ℹ info
ℹ info ======================================
ℹ info === Publishing to target: registry ===
ℹ info ======================================
ℹ info [registry] › Cloning "https://github.com/getsentry/sentry-release-registry/" to "/var/folders/7d/4fxc2_s94_z6ygyf5yk74t700000gn/T/craft-release-registry-v1HQuZ"...
ℹ info [registry] › Adding the version file to the registry for canonical name "gem:sentry-raven"...
ℹ info [registry] › Adding extra data (checksums, download links) for available artifacts...
ℹ info [registry] › Pushing the changes...
ℹ info [registry] › Release registry updated
ℹ info
ℹ info Merging release branch: "release/3.0.2" into "master"...
ℹ info Merging: done.
ℹ info Removed the remote branch: "release/3.0.2"
✔ success Version 3.0.2 has been published!
```