### PR TITLE
feat: Github Artifact Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,9 +379,9 @@ project, you can set it to `none`.
 
 **Configuration**
 
-| Option | Description                                                      |
-| ------ | ---------------------------------------------------------------- |
-| `name` | Name of the artifact provider: can be `zeus` (default) or `none` |
+| Option | Description                                                                |
+| ------ | -------------------------------------------------------------------------- |
+| `name` | Name of the artifact provider: can be `zeus` (default), `github` or `none` |
 
 **Example:**
 
@@ -834,8 +834,8 @@ It also requires you to be logged in with `gem login`.
 
 `gem` must be installed on the system.
 
-| Name      | Description                                  |
-| --------- | -------------------------------------------- |
+| Name      | Description                                               |
+| --------- | --------------------------------------------------------- |
 | `GEM_BIN` | **optional**. Path to "gem" executable. Defaults to `gem` |
 
 **Configuration**

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -58,12 +58,12 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
    * @inheritDoc
    */
   public async doDownloadArtifact(
-    _artifact: RemoteArtifact,
-    _downloadDirectory: string
+    artifact: RemoteArtifact,
+    downloadDirectory: string
   ): Promise<string> {
-    // TODO: Return list of paths
-
-    return '';
+    const destination = path.join(downloadDirectory, artifact.filename);
+    fs.renameSync(artifact.storedFile.downloadFilepath, destination);
+    return destination;
   }
 
   /**
@@ -120,10 +120,8 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
       const file = fs.createWriteStream(tempFilepath);
 
       await new Promise((resolve, reject) => {
-        request({
-          /* Here you should specify the exact link to the file you are trying to download */
-          uri: (result as any).url,
-        })
+        // we need any here since our github api client doesn't have support for artifacts requests yet
+        request({ uri: (result as any).url })
           .pipe(file)
           .on('finish', () => {
             logger.info(`Finished downloading.`);
@@ -144,7 +142,6 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
             storedFile: {
               downloadFilepath: file,
               filename: path.basename(file),
-
               size: fs.lstatSync(file).size,
             },
           } as RemoteArtifact);

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -1,0 +1,98 @@
+import * as Github from '@octokit/rest';
+import * as _ from 'lodash';
+
+import {
+  ArtifactProviderConfig,
+  BaseArtifactProvider,
+  RemoteArtifact,
+} from '../artifact_providers/base';
+import { getGlobalGithubConfig } from '../config';
+import { logger as loggerRaw } from '../logger';
+import { GithubGlobalConfig } from '../schemas/project_config';
+import { getGithubClient } from '../utils/githubApi';
+
+const logger = loggerRaw.withScope(`[artifact-provider/github]`);
+
+interface ArtifactItem {
+  id: number;
+  name: string;
+  size_in_bytes: number;
+  url: string;
+  archive_download_url: string;
+  created_at: string;
+  expires_at: string;
+}
+
+interface ArtifactList {
+  total_count: number;
+  artifacts: Array<ArtifactItem>;
+}
+
+/**
+ * Github artifact provider
+ */
+export class HithubArtifactProvider extends BaseArtifactProvider {
+  /** Github client */
+  public readonly github: Github;
+
+  /** Github repo configuration */
+  public readonly githubRepo: GithubGlobalConfig;
+
+  public constructor(config: ArtifactProviderConfig) {
+    super(config);
+    this.github = getGithubClient();
+    this.githubRepo = getGlobalGithubConfig();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async doDownloadArtifact(
+    artifact: RemoteArtifact,
+    downloadDirectory: string
+  ): Promise<string> {
+    // TODO: Return list of paths
+    await this.github.request(
+      '/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}',
+      {
+        owner: 'octocat',
+        repo: 'hello-world',
+        artifact_id: 42,
+        archive_format: 'archive_format',
+      }
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected async doListArtifactsForRevision(
+    revision: string
+  ): Promise<RemoteArtifact[]> {
+    const { repoName, repoOwner } = this.config;
+    logger.debug(
+      `Fetching Github artifacts for ${repoOwner}/${repoName}, revision ${revision}`
+    );
+    const artifactResponse = ((await this.github.request(
+      'GET /repos/{owner}/{repo}/actions/artifacts',
+      {
+        owner: repoOwner,
+        repo: repoName,
+      }
+    )) as unknown) as ArtifactList;
+
+    // see comment above
+    if (artifactResponse.total_count === 0) {
+      logger.debug(`Revision \`${revision}\` found.`);
+    }
+
+    // We need to find the archive where name maches the revision
+    const foundArtifacts = _.filter(
+      artifactResponse.artifacts,
+      artifact => artifact.name === revision
+    );
+
+    // TODO: need to return RemoteArtifact here
+    return foundArtifacts as RemoteArtifact;
+  }
+}

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -158,7 +158,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
             },
           } as RemoteArtifact);
         });
-      });
+      }, false);
     });
 
     return artifacts;

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -66,6 +66,9 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     downloadDirectory: string
   ): Promise<string> {
     const destination = path.join(downloadDirectory, artifact.filename);
+    logger.debug(
+      `rename ${artifact.storedFile.downloadFilepath} to ${destination}`
+    );
     fs.renameSync(artifact.storedFile.downloadFilepath, destination);
     return destination;
   }

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -89,6 +89,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
         owner: repoOwner,
         repo: repoName,
         per_page,
+        page,
       })
     ).data as unknown) as ArtifactList;
 
@@ -103,7 +104,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     );
 
     if (foundArtifacts.length === 0) {
-      if (artifactResponse.total_count > per_page) {
+      if (artifactResponse.total_count > per_page * (page + 1)) {
         return this.listArtifact(revision, page + 1);
       }
       throw new Error(`Can't find artifacts for revision \`${revision}\``);

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -174,7 +174,7 @@ async function publishToTargets(
 
   if (keepDownloads) {
     logger.info(
-      'Difectory with the downloaded artifacts will not be removed',
+      'Directory with the downloaded artifacts will not be removed',
       `Path: ${downloadDirectoryPath}`
     );
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ import {
   versionGreaterOrEqualThan,
 } from './utils/version';
 import { BaseArtifactProvider } from './artifact_providers/base';
+import { GithubArtifactProvider } from './artifact_providers/github';
 import { ZeusArtifactProvider } from './artifact_providers/zeus';
 import { NoneArtifactProvider } from './artifact_providers/none';
 import { GCSArtifactProvider } from './artifact_providers/gcs';
@@ -250,6 +251,8 @@ export function getArtifactProviderFromConfig(): BaseArtifactProvider {
       return new NoneArtifactProvider();
     case ArtifactProviderName.GCS:
       return new GCSArtifactProvider(artifactProviderConfig);
+    case ArtifactProviderName.Github:
+      return new GithubArtifactProvider(artifactProviderConfig);
     default: {
       throw new ConfigurationError('Invalid artifact provider');
     }

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -73,8 +73,8 @@ const projectConfigJsonSchema = {
           title: 'ArtifactProviderName',
           description: 'Name of the artifact provider',
           type: 'string',
-          enum: ['zeus', 'gcs', 'none'],
-          tsEnumNames: ['Zeus', 'GCS', 'None'],
+          enum: ['zeus', 'gcs', 'github', 'none'],
+          tsEnumNames: ['Zeus', 'GCS', 'Github', 'None'],
         },
         config: {
           type: 'object',

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -76,5 +76,6 @@ export const enum StatusProviderName {
 export const enum ArtifactProviderName {
   Zeus = 'zeus',
   GCS = 'gcs',
+  Github = 'github',
   None = 'none',
 }


### PR DESCRIPTION
aka. we can kill Zeus

![giphy-4](https://user-images.githubusercontent.com/363802/97001616-efc5c680-1538-11eb-8694-6d68719707e2.gif)

You need to use Github actions to upload your artifacts, here is one example from the JS repo:

```yaml
  job_artifacts:
    name: Artifacts Upload
    needs: job_build
    runs-on: ubuntu-latest
    if: "contains(github.ref, 'release/')"
    steps:
      - uses: actions/checkout@v2
      - uses: actions/setup-node@v1
      - uses: actions/cache@v2
        with:
          path: |
            ${{ github.workspace }}/node_modules
            ${{ github.workspace }}/packages/**/node_modules
            ${{ github.workspace }}/packages/**/build
            ${{ github.workspace }}/packages/**/dist
            ${{ github.workspace }}/packages/**/esm
          key: ${{ runner.os }}-${{ github.sha }}
      - name: Pack
        run: yarn pack:changed
      - name: Archive Artifacts
        uses: actions/upload-artifact@v2
        with:
          name: ${{ github.sha }}
          path: |
            ${{ github.workspace }}/packages/browser/build/**
            ${{ github.workspace }}/packages/integrations/build/**
            ${{ github.workspace }}/packages/apm/build/**
            ${{ github.workspace }}/packages/tracing/build/**
            ${{ github.workspace }}/packages/**/*.tgz
```

the important part is this:

```yaml
- name: Archive Artifacts
        uses: actions/upload-artifact@v2
        with:
          name: ${{ github.sha }}
          path: |
            ${{ github.workspace }}/packages/browser/build/**
            ${{ github.workspace }}/packages/integrations/build/**
            ${{ github.workspace }}/packages/apm/build/**
            ${{ github.workspace }}/packages/tracing/build/**
            ${{ github.workspace }}/packages/**/*.tgz
```

using `actions/upload-artifact@v2` gha + setting the name to the `${{ github.sha }}` is the key since there is no other way to uniquely identify uploaded artifacts.

config in `craft.yaml`
```yaml
statusProvider:
  name: github
artifactProvider:
  name: github
```