### PR TITLE
fix(github): Detect skipped status checks as successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix(gcs): Better error serialization (#120)
+- fix(github): Detect skipped status checks and Github actions runs as successful (#124)
 
 ## 0.11.0
 

--- a/src/status_providers/github.ts
+++ b/src/status_providers/github.ts
@@ -237,7 +237,7 @@ export class GithubStatusProvider extends BaseStatusProvider {
         continue;
       }
       if (run.status === 'completed') {
-        if (run.conclusion !== 'success') {
+        if (run.conclusion !== 'success' && run.conclusion !== 'skipped') {
           return CommitStatus.FAILURE;
         }
       } else {


### PR DESCRIPTION
When GitHub Actions runs are skipped based on a condition, the status check
conclusion reports `skipped`. This is currently detected as a failed status
check by craft, where instead it should be considered successful.

A use case of this is to skip certain status checks based on the kind of a release.
GitHub always reports all status checks and then marks them as skipped. See:

https://github.com/getsentry/relay/runs/1142527273