### PR TITLE
feat(docker): Add sourceFormat & targetFormat options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+- feat(docker): Add sourceFormat & targetFormat options (#125)
+
 ## 0.11.1
 
 - fix(gcs): Better error serialization (#120)

--- a/README.md
+++ b/README.md
@@ -803,10 +803,12 @@ non-idempotent targets, not for the Docker target.
 
 **Configuration**
 
-| Option   | Description                                  |
-| -------- | -------------------------------------------- |
-| `source` | Path to the source Docker image to be pulled |
-| `target` | Path to the target Docker image to be pushed |
+| Option         | Description                                                          |
+| -------------- | -------------------------------------------------------------------- |
+| `source`       | Path to the source Docker image to be pulled                         |
+| `sourceFormat` | Format for the source image name. Default: `{{source}}:{{revision}}` |
+| `target`       | Path to the target Docker image to be pushed                         |
+| `targetFormat` | Format for the target image name. Default: `{{target}}:{{release}}`  |
 
 **Example**
 


### PR DESCRIPTION
These options became necessary for us to be able to publish Py2 and Py3 versions of Sentry images at the same time, in the same release.
