### PR TITLE
fix(docker): Disable HTML escaping in image names by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,11 +803,11 @@ non-idempotent targets, not for the Docker target.
 
 **Configuration**
 
-| Option         | Description                                                          |
-| -------------- | -------------------------------------------------------------------- |
-| `source`       | Path to the source Docker image to be pulled                         |
+| Option         | Description                                                              |
+| -------------- | ------------------------------------------------------------------------ |
+| `source`       | Path to the source Docker image to be pulled                             |
 | `sourceFormat` | Format for the source image name. Default: `{{{source}}}:{{{revision}}}` |
-| `target`       | Path to the target Docker image to be pushed                         |
+| `target`       | Path to the target Docker image to be pushed                             |
 | `targetFormat` | Format for the target image name. Default: `{{{target}}}:{{{version}}}`  |
 
 **Example**

--- a/README.md
+++ b/README.md
@@ -806,9 +806,9 @@ non-idempotent targets, not for the Docker target.
 | Option         | Description                                                          |
 | -------------- | -------------------------------------------------------------------- |
 | `source`       | Path to the source Docker image to be pulled                         |
-| `sourceFormat` | Format for the source image name. Default: `{{source}}:{{revision}}` |
+| `sourceFormat` | Format for the source image name. Default: `{{{source}}}:{{{revision}}}` |
 | `target`       | Path to the target Docker image to be pushed                         |
-| `targetFormat` | Format for the target image name. Default: `{{target}}:{{version}}`  |
+| `targetFormat` | Format for the target image name. Default: `{{{target}}}:{{{version}}}`  |
 
 **Example**
 

--- a/src/targets/docker.ts
+++ b/src/targets/docker.ts
@@ -21,9 +21,9 @@ export interface DockerTargetOptions extends TargetConfig {
   password: string;
   /** Source image path, like `us.gcr.io/sentryio/craft` */
   source: string;
-  /** Full name template for the source image path, defaults to `{{source}}:{{revision}}` */
+  /** Full name template for the source image path, defaults to `{{{source}}}:{{{revision}}}` */
   sourceTemplate: string;
-  /** Full name template for the target image path, defaults to `{{target}}:{{version}}` */
+  /** Full name template for the target image path, defaults to `{{{target}}}:{{{version}}}` */
   targetTemplate: string;
   /** Target image path, like `getsentry/craft` */
   target: string;
@@ -65,8 +65,8 @@ export class DockerTarget extends BaseTarget {
       password: process.env.DOCKER_PASSWORD,
       source: this.config.source,
       target: this.config.target,
-      sourceTemplate: this.config.sourceFormat || '{{source}}:{{revision}}',
-      targetTemplate: this.config.targetFormat || '{{target}}:{{version}}',
+      sourceTemplate: this.config.sourceFormat || '{{{source}}}:{{{revision}}}',
+      targetTemplate: this.config.targetFormat || '{{{target}}}:{{{version}}}',
       username: process.env.DOCKER_USERNAME,
     };
   }


### PR DESCRIPTION
We used Mustache templates that were already available for image name formatting. Musache escapes all HTML-unsafe characters by default which rightly confused the Docker CLI client. This patch uses the `{{{varName}}}` pattern for the default format config to disable escaping.
