### PR TITLE
feat(targets): Add optional `id` field to target config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.12.0
 
 - feat(docker): Add sourceFormat & targetFormat options (#125)
+- feat(targets): Add optional `id` field to target config (#127)
 
 ## 0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.12.0
 
 - feat(docker): Add sourceFormat & targetFormat options (#125)
-- feat(targets): Add optional `id` field to target config (#127)
+- feat(targets): Add optional `id` field to target config (#128)
 
 ## 0.11.1
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -137,9 +137,12 @@ async function publishToTargets(
     logger.debug('Initializing targets');
     for (const targetConfig of targetConfigList) {
       const targetClass = getTargetByName(targetConfig.name);
+      const targetDescriptor = targetConfig.id
+        ? `${targetConfig.id}[${targetConfig.name}]`
+        : targetConfig.name;
       if (!targetClass) {
         logger.warn(
-          `Target implementation for "${targetConfig.name}" not found.`
+          `Target implementation for "${targetDescriptor}" not found.`
         );
         continue;
       }
@@ -154,8 +157,11 @@ async function publishToTargets(
 
     // Publish to all targets
     for (const target of targetList) {
+      const targetDescriptor = target.config.id
+        ? `${target.config.id}[${target.name}]`
+        : target.name;
       const publishMessage = `=== Publishing to target: ${chalk.bold(
-        chalk.cyan(target.name)
+        chalk.cyan(targetDescriptor)
       )} ===`;
       const delim = Array(stringLength(publishMessage) + 1).join('=');
       logger.info(' ');
@@ -455,7 +461,7 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
   if (targetList[0] !== SpecialTarget.All) {
     targetConfigList = targetConfigList.filter(
       (targetConf: { [key: string]: any }) =>
-        targetList.indexOf(targetConf.name) > -1
+        targetList.indexOf(targetConf.id || targetConf.name) > -1
     );
   }
 
@@ -476,7 +482,7 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
 
     // TODO init all targets earlier
     targetConfigList
-      .map(t => t.name || '__undefined__')
+      .map(t => (t.id ? `${t.id}[${t.name}]` : t.name))
       .forEach(target => logger.info(`  - ${target}`));
     logger.info(' ');
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -482,7 +482,7 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
 
     // TODO init all targets earlier
     targetConfigList
-      .map(t => (t.id ? `${t.id}[${t.name}]` : t.name))
+      .map(t => (t.id ? `${t.id}[${t.name}]` : t.name || '__undefined__'))
       .forEach(target => logger.info(`  - ${target}`));
     logger.info(' ');
 

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -96,6 +96,9 @@ const projectConfigJsonSchema = {
         name: {
           type: 'string',
         },
+        id: {
+          type: 'string',
+        },
         includeNames: {
           type: 'string',
         },

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -31,6 +31,7 @@ export interface GithubGlobalConfig {
  */
 export interface TargetConfig {
   name?: string;
+  id?: string;
   includeNames?: string;
   excludeNames?: string;
   [k: string]: any;


### PR DESCRIPTION
Craft allows using multiple instances of the same target with different (or same!) configurations but it assumes `name` field is a unique identifier. This PR adds an optional `id` field to distinguish multiple targets with the same name such as multiple Docker images to publish.
