### PR TITLE
fix(npm): Actually use NPM_TOKEN for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - feat(docker): Add sourceFormat & targetFormat options (#125)
 - feat(targets): Add optional `id` field to target config (#128)
-- fix(npm): Actually use NPM_TOKEN for publishing (#129)
+- fix(npm): Actually use NPM_TOKEN for publishing (#130)
 
 ## 0.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(docker): Add sourceFormat & targetFormat options (#125)
 - feat(targets): Add optional `id` field to target config (#128)
+- fix(npm): Actually use NPM_TOKEN for publishing (#129)
 
 ## 0.11.1
 


### PR DESCRIPTION
The current version relied on `.npmrc` being set on the machine manually. With this change, we read the NPM_TOKEN env variable and append it to the `--registry` option we already set as suggested on https://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules
