### PR TITLE
fix(npm): Fix NPM_TOKEN usage again

### DIFF
--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -192,8 +192,7 @@ export class NpmTarget extends BaseTarget {
       args.push('--tag=next');
     }
 
-    let result;
-    await withTempFile(filePath => {
+    return withTempFile(filePath => {
       // Pass OTP if configured
       const spawnOptions: SpawnOptions = {};
       spawnOptions.env = { ...process.env };
@@ -212,12 +211,10 @@ export class NpmTarget extends BaseTarget {
       args.push(path);
 
       // Disable output buffering because NPM/Yarn can ask us for one-time passwords
-      result = spawnProcess(bin, args, spawnOptions, {
+      return spawnProcess(bin, args, spawnOptions, {
         showStdout: true,
       });
     });
-
-    return result;
   }
 
   /**

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -201,7 +201,7 @@ export class NpmTarget extends BaseTarget {
         spawnOptions.env.NPM_CONFIG_OTP = options.otp;
       }
       spawnOptions.env[NPM_TOKEN_ENV_VAR] = this.npmConfig.token;
-      // WARNING: This may fail for Yarn: https://github.com/yarnpkg/yarn/issues/4568
+      // NOTE(byk): Use npm_config_userconfig instead of --userconfig for yarn compat
       spawnOptions.env.npm_config_userconfig = filePath;
       writeFileSync(
         filePath,

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -12,7 +12,7 @@ import {
   BaseArtifactProvider,
   RemoteArtifact,
 } from '../artifact_providers/base';
-import { withTempFile } from 'src/utils/files';
+import { withTempFile } from '../utils/files';
 import { writeFileSync } from 'fs';
 
 const logger = loggerRaw.withScope('[npm]');


### PR DESCRIPTION
This is a retake on #130. Although npm/cli#8 claims to have support
for `npm_config_//registry.npmjs.org/:_authToken=` usage, my tests
and the reports on the internet says this still doesn't work, even
with the latest npm (7.0.15 at the time).

The only way to pass the token is to have the `authToken` line in
an `.npmrc` file. The quick&dirty way would have been to create one
in the project directory but that may collide with a potentially
pre-existing project `.npmrc`. Trying to merge these seems more
trouble than it is worth:
https://github.com/actions/setup-node/blob/59e61b89511ed136a0b17773f07c349fa5c01e8b/src/authutil.ts
(even worse as you'd need to revert these changes after the fact)

The "better" solution I found is:

1. Create a temporary file as your npmrc
2. Put the token/registry line there
3. Tell npm to use that file as the user config
4. Use the `npm_config_userconfig` for the above to support yarn too