### PR TITLE
feat(publish): Add optional post-release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.13.4
+## 0.14.0
 
+- feat(publish): Add support for optional post-release script (#144)
 - fix(publish): Fix error when special target 'all' is used (#142)
 
 ## 0.13.3

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ preReleaseCommand: bash scripts/bump-version.sh
 This command will run after a successful `publish`. By default, it is set to
 `bash scripts/post-release.sh`. It will *not* error if the default script is
 missing though, as this may not be needed by all projects. Please refer to the
-[Post-release scipt conventions section](#post-release-script-conventions)
+[Post-release script conventions section](#post-release-script-conventions)
 for more details.
 
 ```yaml
@@ -907,7 +907,7 @@ Here is how you can integrate your GitHub project with `craft`:
 Among other actions, `craft prepare` runs an external, project-specific command
 or script that is responsible for version bumping. By default, this script
 should be located at: `./scripts/bump-version.sh`. The command can be configured
-by specifying `preReleaseCommand` configuration option in `craft.yml`.
+by specifying the `preReleaseCommand` configuration option in `craft.yml`.
 
 The following requirements are on the script interface and functionality:
 

--- a/README.md
+++ b/README.md
@@ -242,11 +242,24 @@ github:
 ### Pre-release Command
 
 This command will run on your newly created release branch as part of `prepare`
-command. By default, it is set to "bash scripts/bump-version.sh". Please refer
-to [this section](#pre-release-version-bumping-script-conventions) for more details.
+command. By default, it is set to `bash scripts/bump-version.sh`. Please refer
+to the [Pre-release version bumping script conventions section](#pre-release-version-bumping-script-conventions)
+for more details.
 
 ```yaml
 preReleaseCommand: bash scripts/bump-version.sh
+```
+
+### Post-release Command
+
+This command will run after a successful `publish`. By default, it is set to
+`bash scripts/post-release.sh`. It will *not* error if the default script is
+missing though, as this may not be needed by all projects. Please refer to the
+[Post-release scipt conventions section](#post-release-script-conventions)
+for more details.
+
+```yaml
+preReleaseCommand: bash scripts/post-release.sh
 ```
 
 ### Release Branch Name
@@ -891,17 +904,15 @@ Here is how you can integrate your GitHub project with `craft`:
 
 ## Pre-release (Version-bumping) Script: Conventions
 
-Among other actions, `craft prepare` runs an external project-specific command
+Among other actions, `craft prepare` runs an external, project-specific command
 or script that is responsible for version bumping. By default, this script
-should be located at the following path: `scripts/bump-version.sh` (relative
-to the project root). The command can be configured by specifying
-`preReleaseCommand` configuration option in `craft.yml`.
+should be located at: `./scripts/bump-version.sh`. The command can be configured
+by specifying `preReleaseCommand` configuration option in `craft.yml`.
 
 The following requirements are on the script interface and functionality:
 
-- The script must accept at least two arguments. Craft will pass the following
-  values as the last two arguments (in the specified order): the old ("from")
-  version, and the second one is the new ("to") version.
+- The script should accept at least two arguments. Craft will pass the old ("from")
+  version and the new ("to") version as the last two arguments, respectively.
 - The script must replace all relevant occurrences of the old version string
   with the new one.
 - The script must not commit the changes made.
@@ -912,7 +923,7 @@ The following requirements are on the script interface and functionality:
 ```bash
 #!/bin/bash
 ### Example of a version-bumping script for an NPM project.
-### Located at: scripts/bump-version.sh
+### Located at: ./scripts/bump-version.sh
 set -eux
 OLD_VERSION="${1}"
 NEW_VERSION="${2}"
@@ -920,6 +931,41 @@ NEW_VERSION="${2}"
 # Do not tag and commit changes made by "npm version"
 export npm_config_git_tag_version=false
 npm version "${NEW_VERSION}"
+```
+
+## Post-release Script: Conventions
+
+Among other actions, `craft publish` runs an external, project-specific command
+or script that can do things like bumping the development version. By default,
+this script should be located at: `./scripts/bump-version.sh`. Unlike the
+pre-release command, this script is not mandatory so if the file does not exist,
+`craft` will report this fact and then move along as usual. This command can be
+configured by specifying `postReleaseCommand` configuration option in `craft.yml`.
+
+The following requirements are on the script interface and functionality:
+
+- The script should accept at least two arguments. Craft will pass the old ("from")
+  version and the new ("to") version as the last two arguments, respectively.
+- The script is responsible for any and all `git` state management as `craft` will
+  simply exit after running this script as the final step. This means the script
+  is responsible for committing and pushing any changes that it may have made.
+
+**Example**
+
+```bash
+#!/bin/bash
+### Example of a dev-version-bumping script for a Python project
+### Located at: ./scripts/post-release.sh
+set -eux
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+# Ensure master branch
+git checkout master
+# Advance the CalVer release by one-month and add the `.dev0` suffix
+./scripts/bump-version.sh '' $(date -d "$(echo $NEW_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
+# Only commit if there are changes, make sure to `pull --rebase` before pushing to avoid conflicts
+git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull --rebase && git push
 ```
 
 ## Development

--- a/src/commands/__tests__/publish.test.ts
+++ b/src/commands/__tests__/publish.test.ts
@@ -1,0 +1,66 @@
+import { join as pathJoin } from 'path';
+import { spawnProcess, hasExecutable } from '../../utils/system';
+import { runPostReleaseCommand } from '../publish';
+
+jest.mock('../../utils/system');
+
+describe('runPostReleaseCommand', () => {
+  const newVersion = '2.3.4';
+  const mockedSpawnProcess = spawnProcess as jest.Mock;
+  const mockedHasExecutable = hasExecutable as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('default script', () => {
+    test('runs when script exists', async () => {
+      mockedHasExecutable.mockReturnValue(true);
+      expect.assertions(1);
+
+      await runPostReleaseCommand(newVersion);
+
+      expect(mockedSpawnProcess).toBeCalledWith(
+        '/bin/bash',
+        [pathJoin('scripts', 'post-release.sh'), '', newVersion],
+        {
+          env: {
+            ...process.env,
+            CRAFT_NEW_VERSION: newVersion,
+            CRAFT_OLD_VERSION: '',
+          },
+        }
+      );
+    });
+
+    test('skips when script does not exist', async () => {
+      mockedHasExecutable.mockReturnValue(false);
+      expect.assertions(1);
+
+      await runPostReleaseCommand(newVersion);
+
+      expect(mockedSpawnProcess).not.toBeCalled();
+    });
+  });
+
+  test('runs with custom command', async () => {
+    expect.assertions(1);
+
+    await runPostReleaseCommand(
+      newVersion,
+      'python ./increase_version.py "argument 1"'
+    );
+
+    expect(mockedSpawnProcess).toBeCalledWith(
+      'python',
+      ['./increase_version.py', 'argument 1', '', newVersion],
+      {
+        env: {
+          ...process.env,
+          CRAFT_NEW_VERSION: newVersion,
+          CRAFT_OLD_VERSION: '',
+        },
+      }
+    );
+  });
+});

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -419,7 +419,7 @@ export async function runPostReleaseCommand(
   let args: string[];
   if (postReleaseCommand !== undefined && postReleaseCommand.length === 0) {
     // Not running post-release command
-    logger.warn('Not running the pre-release command: no command specified');
+    logger.info('Not running the post-release command: no command specified');
     return false;
   } else if (postReleaseCommand) {
     [sysCommand, ...args] = shellQuote.parse(postReleaseCommand);
@@ -428,7 +428,7 @@ export async function runPostReleaseCommand(
     args = [DEFAULT_POST_RELEASE_SCRIPT_PATH];
   } else {
     // Not running post-release command
-    logger.warn(
+    logger.info(
       `Not running the post-release command: '${DEFAULT_POST_RELEASE_SCRIPT_PATH}' not found`
     );
     return false;

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -2,7 +2,6 @@ import * as Github from '@octokit/rest';
 import * as inquirer from 'inquirer';
 import { Arguments, Argv, CommandBuilder } from 'yargs';
 import chalk from 'chalk';
-import { existsSync } from 'fs';
 import { join } from 'path';
 import * as shellQuote from 'shell-quote';
 import * as stringLength from 'string-length';
@@ -30,7 +29,11 @@ import { getGithubClient, mergeReleaseBranch } from '../utils/githubApi';
 import { isDryRun } from '../utils/helpers';
 import { hasInput } from '../utils/noInput';
 import { formatSize, formatJson } from '../utils/strings';
-import { catchKeyboardInterrupt, spawnProcess } from '../utils/system';
+import {
+  catchKeyboardInterrupt,
+  hasExecutable,
+  spawnProcess,
+} from '../utils/system';
 import { isValidVersion } from '../utils/version';
 import { BaseStatusProvider } from '../status_providers/base';
 import { BaseArtifactProvider } from '../artifact_providers/base';
@@ -423,7 +426,7 @@ export async function runPostReleaseCommand(
     return false;
   } else if (postReleaseCommand) {
     [sysCommand, ...args] = shellQuote.parse(postReleaseCommand);
-  } else if (existsSync(DEFAULT_POST_RELEASE_SCRIPT_PATH)) {
+  } else if (hasExecutable(DEFAULT_POST_RELEASE_SCRIPT_PATH)) {
     sysCommand = '/bin/bash';
     args = [DEFAULT_POST_RELEASE_SCRIPT_PATH];
   } else {

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -28,6 +28,7 @@ const projectConfigJsonSchema = {
       items: { $ref: '#/definitions/targetConfig' },
     },
     preReleaseCommand: { type: 'string' },
+    postReleaseCommand: { type: 'string' },
     releaseBranchPrefix: { type: 'string' },
     changelog: { type: 'string' },
     changelogPolicy: {

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -11,6 +11,7 @@ export interface CraftProjectConfig {
   github: GithubGlobalConfig;
   targets?: TargetConfig[];
   preReleaseCommand?: string;
+  postReleaseCommand?: string;
   releaseBranchPrefix?: string;
   changelog?: string;
   changelogPolicy?: ChangelogPolicy;


### PR DESCRIPTION
This PR adds an optional post-release script which is needed for
projects like [getsentry/sentry](https://git.io/JIs4n) and
[getsentry/onpremise](https://git.io/JIs4l). This would help keeping
the common publish/release repo and its downstream project independent.
