### PR TITLE
ci(release): Add GH_RELEASE_PAT as we need a PAT to trigger builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: 'Cut a new release'
+    name: 'Release a new version'
     steps:
       - name: Prepare release
         uses: getsentry/action-prepare-release@main
@@ -19,6 +19,8 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
       - uses: getsentry/craft@master
         name: Craft Prepare
         with:


### PR DESCRIPTION
This essentially reverts commit 8aab991e96c929285d9de5048d21efa74d211e0f.

Reason is GitHub preventing triggering more actions form inside another
action using the default `GITHUB_TOKEN`:

- https://stackoverflow.com/a/64078507/90297
- https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
