### PR TITLE
fix(publish): Fix fail on dry-run w/ github target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+
+- fix(publish): Fix fail on dry-run w/ github target (#152)
 ## 0.14.0
 
 - feat(publish): Add support for optional post-release script (#144)

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -362,11 +362,18 @@ export class GithubTarget extends BaseTarget {
     logger.info(`Target "${this.name}": publishing version "${version}"...`);
     logger.debug(`Revision: ${revision}`);
     const release = await this.getOrCreateRelease(version, revision);
-    const assets = await this.getAssetsForRelease(release);
-    if (assets.length > 0) {
-      logger.warn('Existing assets found for the release, deleting them...');
-      await this.deleteAssets(assets);
-      logger.debug(`Deleted ${assets.length} assets`);
+
+    if (isDryRun()) {
+      logger.info(
+        `[dry-run] Skipping check for existing assets for the release`
+      );
+    } else {
+      const assets = await this.getAssetsForRelease(release);
+      if (assets.length > 0) {
+        logger.warn('Existing assets found for the release, deleting them...');
+        await this.deleteAssets(assets);
+        logger.debug(`Deleted ${assets.length} assets`);
+      }
     }
 
     const artifacts = await this.getArtifactsForRevision(revision);


### PR DESCRIPTION
Fixes `publish` failing when running in dry-run mode as it skips creating a release but then tries to find the existing assents on that release. Since the release is not there, it was failing with a 404. This PR skips this step entirely in dry-run mode.
