### PR TITLE
ref(github): GitHub standardized on GITHUB_TOKEN so let's use that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix(publish): Fix fail on dry-run w/ github target (#152)
 - feat(docker): Support cocoapods in the docker container (#153)
+- ref(github): GitHub standardized on GITHUB_TOKEN so let's use that (#154)
 
 ## 0.14.0
 

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ contains any one of `preview`, `pre`, `rc`, `dev`,`alpha`, `beta`, `unstable`,
 
 | Name               | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
-| `GITHUB_TOKEN` | Personal GitHub API token (see https://github.com/settings/tokens) |
+| `GITHUB_TOKEN`     | Personal GitHub API token (see https://github.com/settings/tokens) |
 
 **Configuration**
 
@@ -580,7 +580,7 @@ contains the following variables:
 
 | Name               | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
-| `GITHUB_TOKEN` | Personal GitHub API token (seeh ttps://github.com/settings/tokens) |
+| `GITHUB_TOKEN`     | Personal GitHub API token (seeh ttps://github.com/settings/tokens) |
 
 **Configuration**
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ or by adding values to a configuration file (see below).
 In either case, at least the following two values must be configured in order
 for craft to function properly:
 
-- `GITHUB_API_TOKEN`
+- `GITHUB_TOKEN`
 
   Get your personal GitHub API token here: https://github.com/settings/tokens
 
@@ -139,7 +139,7 @@ Example:
 
 ```sh
 # ~/.craft.env
-GITHUB_API_TOKEN=token123
+GITHUB_TOKEN=token123
 export NUGET_API_TOKEN=abcdefgh
 ```
 
@@ -476,7 +476,7 @@ contains any one of `preview`, `pre`, `rc`, `dev`,`alpha`, `beta`, `unstable`,
 
 | Name               | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
-| `GITHUB_API_TOKEN` | Personal GitHub API token (see https://github.com/settings/tokens) |
+| `GITHUB_TOKEN` | Personal GitHub API token (see https://github.com/settings/tokens) |
 
 **Configuration**
 
@@ -580,7 +580,7 @@ contains the following variables:
 
 | Name               | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
-| `GITHUB_API_TOKEN` | Personal GitHub API token (seeh ttps://github.com/settings/tokens) |
+| `GITHUB_TOKEN` | Personal GitHub API token (seeh ttps://github.com/settings/tokens) |
 
 **Configuration**
 

--- a/action.yml
+++ b/action.yml
@@ -14,15 +14,9 @@ inputs:
   keep_branch:
     description: 'Do not remove release branch after merging it'
     required: false
-  github_api_token:
-    description: 'API token for accessing github'
-    required: true
-    default: ${{ github.token }}
 runs:
   using: 'docker'
   image: 'docker://getsentry/craft'
-  env:
-    GITHUB_API_TOKEN: ${{ inputs.github_api_token }}
   args:
     - ${{ inputs.action }}
     - ${{ inputs.version }}

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -113,10 +113,11 @@ export class GithubRemote {
  * @returns Github authentication token if found
  */
 export function getGithubApiToken(): string {
-  const githubApiToken = process.env.GITHUB_API_TOKEN;
+  const githubApiToken =
+    process.env.GITHUB_TOKEN || process.env.GITHUB_API_TOKEN;
   if (!githubApiToken) {
     throw new ConfigurationError(
-      'GitHub target: GITHUB_API_TOKEN not found in the environment'
+      'GitHub target: GITHUB_TOKEN not found in the environment'
     );
   }
   return githubApiToken;


### PR DESCRIPTION
This PR adds support for `GITHUB_TOKEN` env variable and prefers that over the old `GITHUB_API_TOKEN` without dropping support for the old one.
