### PR TITLE
ci(release): Move on to the improved action-prepare-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Release a new version'
     steps:
-      - name: Prepare release
-        uses: getsentry/action-prepare-release@33507ed
-        with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
-      - uses: getsentry/craft@master
-        name: Craft Prepare
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@a5fd9725aee1bc34d15c5dadcacf359841e5c717
         with:
-          action: prepare
-          version: ${{ env.RELEASE_VERSION }}
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
Stats utilizing the latest niceties in getsentry/action-prepare-release#4.

#skip-changelog