### PR TITLE
ci(release): Upgrade action-prepare-release to latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
       - name: Prepare release
-        uses: getsentry/action-prepare-release@2cfce9ae4b4ef7bf34e0b7f32869128e7c903e51
+        uses: getsentry/action-prepare-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:


### PR DESCRIPTION
This version reduces the boilerplate needed and offers much better publish request issue context.
