### PR TITLE
ref: Upgrade Typescript to latest (^4.1.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prettier": "^1.19.1",
     "prettier-check": "^2.0.0",
     "ts-jest": "^26.4.1",
-    "typescript": "^3.9.3"
+    "typescript": "^4.1.3"
   },
   "scripts": {
     "build": "yarn run compile-config-schema && tsc -p tsconfig.build.json",

--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -199,7 +199,7 @@ export abstract class BaseArtifactProvider {
    * @param downloadDirectory Directory where downloaded artifact is stored
    * @returns Absolute path to the saved file
    */
-  protected abstract async doDownloadArtifact(
+  protected abstract doDownloadArtifact(
     artifact: RemoteArtifact,
     downloadDirectory: string
   ): Promise<string>;
@@ -277,7 +277,7 @@ export abstract class BaseArtifactProvider {
    * @returns Filtered list of artifacts, or "undefined" if the revision cannot
    * be found
    */
-  protected abstract async doListArtifactsForRevision(
+  protected abstract doListArtifactsForRevision(
     revision: string
   ): Promise<RemoteArtifact[]>;
 

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -134,7 +134,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     await withTempFile(async tempFilepath => {
       const file = fs.createWriteStream(tempFilepath);
 
-      await new Promise((resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         // we need any here since our github api client doesn't have support for artifacts requests yet
         request({ uri: archiveResponse.url })
           .pipe(file)

--- a/src/status_providers/base.ts
+++ b/src/status_providers/base.ts
@@ -41,14 +41,12 @@ export abstract class BaseStatusProvider {
    *
    * @param revision Revision SHA
    */
-  public abstract async getRevisionStatus(
-    revision: string
-  ): Promise<CommitStatus>;
+  public abstract getRevisionStatus(revision: string): Promise<CommitStatus>;
 
   /**
    * Gets repository information (as seen by the provider)
    */
-  public abstract async getRepositoryInfo(): Promise<RepositoryInfo>;
+  public abstract getRepositoryInfo(): Promise<RepositoryInfo>;
 
   /**
    * Waits for the builds to finish for the revision

--- a/src/utils/__tests__/changes.test.ts
+++ b/src/utils/__tests__/changes.test.ts
@@ -73,7 +73,7 @@ describe('findChangeset', () => {
       `;
 
     expect(findChangeset(markdown, 'v1.0.0')).toEqual(changeset);
-  })
+  });
 
   test.each([
     ['changeset cannot be found', 'v1.0.0'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5907,10 +5907,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.9.3:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Upgrades Typescript version to the latest currently available. This upgrade is a requirement in order to use the AWS SDK v3.