### PR TITLE
fix(gcs-target): Fix incorrect upload path to GCS when it has a leading slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.16.1
+
+- fix(gcs-target): Fix incorrect upload path to GCS when it has a leading slash (#170)
+
 ## 0.16.0
 
 - feat(aws-lambda): AWS Lambda layer target (#160)

--- a/src/utils/__fixtures__/gcsApi.ts
+++ b/src/utils/__fixtures__/gcsApi.ts
@@ -34,7 +34,7 @@ export const squirrelStatsArtifact: RemoteArtifact = {
 export const squirrelStatsLocalPath = './temp/march-2020-stats.csv';
 
 export const squirrelStatsBucketPath = {
-  path: '/stats/2020/',
+  path: 'stats/2020/',
 };
 
 export const squirrelSimulatorArtifact: RemoteArtifact = {

--- a/src/utils/__tests__/gcsAPI.test.ts
+++ b/src/utils/__tests__/gcsAPI.test.ts
@@ -172,6 +172,24 @@ describe('gcsApi module', () => {
         });
       });
 
+      it('removes leading slashes in upload destinations', async () => {
+        expect.assertions(1);
+
+        await client.uploadArtifact(squirrelStatsLocalPath, {
+          path: '/' + squirrelStatsBucketPath.path,
+        });
+
+        const { filename } = squirrelStatsArtifact;
+        const destinationPath = path.normalize(squirrelStatsBucketPath.path);
+
+        expect(mockGCSUpload).toHaveBeenCalledWith(squirrelStatsLocalPath, {
+          destination: `${destinationPath}${filename}`,
+          gzip: true,
+          metadata: DEFAULT_UPLOAD_METADATA,
+          resumable: !process.env.CI,
+        });
+      });
+
       it('detects content type correctly for JS and map files', async () => {
         expect.assertions(1);
 

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -175,7 +175,15 @@ export class CraftGCSClient {
     bucketPath: BucketPath
   ): Promise<void> {
     const filename = path.basename(artifactLocalPath);
-    const pathInBucket = bucketPath.path;
+    let pathInBucket = bucketPath.path;
+
+    // Remove any potential leading forward slashes as google-cloud/storage
+    // stopped normalizing paths. If you keep this, you'll end up with a path
+    // like `//your/dir/and/file` instead of `/your/dir/and/file`
+    // See #169 for more information.
+    if (pathInBucket[0] === '/') {
+      pathInBucket = pathInBucket.substring(1);
+    }
 
     if (!artifactLocalPath) {
       reportError(


### PR DESCRIPTION
Ideally we should fix all the Craft configs to not have this leading slash but that's hard and is also a breaking change so we normalize this ourselves like old times. Fixes #169.
