### PR TITLE
meta: Changelog policty to "auto"

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,7 +2,7 @@ minVersion: '0.13.2'
 github:
   owner: getsentry
   repo: craft
-changelogPolicy: simple
+changelogPolicy: auto
 requireNames:
   - /^sentry-craft.*\.tgz$/
 statusProvider:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.16.2
+## auto
 
 - feat(aws-lambda): Update the sentry release registry with AWS Lambda layer versions (#172)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## auto
+## Unreleased
 
 - feat(aws-lambda): Update the sentry release registry with AWS Lambda layer versions (#172)
 


### PR DESCRIPTION
Changes the changelog policy to "auto" and updates the latest version of the changelog to "Unreleased"