### PR TITLE
fix: Replace actual versionFilePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.17.1
 
-- fix(registry): Replace actual versionFilePath (#174)
+- fix(registry): Replace actual the versionFilePath (#174)
 
 ## 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
-## 0.17.1
+## Unreleased
 
-- fix(registry): Replace actual the versionFilePath (#174)
-
+- fix(registry): Replace the actual versionFilePath (#174)
 ## 0.17.0
 
 - feat(aws-lambda): Update the sentry release registry with AWS Lambda layer versions (#172)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.1
+
+- fix(registry): Replace actual versionFilePath (#174)
+
 ## 0.17.0
 
 - feat(aws-lambda): Update the sentry release registry with AWS Lambda layer versions (#172)

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -2,6 +2,7 @@ import { mapLimit } from 'async';
 import * as Github from '@octokit/rest';
 import * as _ from 'lodash';
 import * as simpleGit from 'simple-git/promise';
+import * as path from 'path';
 
 import { getGlobalGithubConfig } from '../config';
 import { logger as loggerRaw } from '../logger';
@@ -340,10 +341,17 @@ export class RegistryTarget extends BaseTarget {
     logger.info(`Cloning "${remote.getRemoteString()}" to "${directory}"...`);
     await git.clone(remote.getRemoteStringWithAuth(), directory);
 
+    const packageDirPath = getPackageDirPath(
+      this.registryConfig.type,
+      directory,
+      canonicalName
+    );
     const packageManifest = await registryUtils.getPackageManifest(
-      getPackageDirPath(this.registryConfig.type, directory, canonicalName),
+      packageDirPath,
       version
     );
+
+    const versionFilePath = path.join(packageDirPath, `${version}.json`);
     registryUtils.updateManifestSymlinks(
       await this.getUpdatedManifest(
         packageManifest,
@@ -352,7 +360,7 @@ export class RegistryTarget extends BaseTarget {
         revision
       ),
       version,
-      'versionFilePath',
+      versionFilePath,
       packageManifest.version || undefined
     );
 


### PR DESCRIPTION
Fixes an issue where symlinks could not be created, since there's the `versionFilePath` string instead of the actual version file path.