### PR TITLE
fix: `undefined` handling when there's no `checksums` in `.craft.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(registry): `undefined` handling when there's no `checksums` in `.craft.yml` (#175)
+
 ## 0.17.1
 
 - fix(registry): Replace the actual versionFilePath (#174)

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -224,11 +224,13 @@ export class RegistryTarget extends BaseTarget {
       });
     }
 
-    artifactData.checksums = await getArtifactChecksums(
-      this.registryConfig.checksums,
-      artifact,
-      this.artifactProvider
-    );
+    if (this.registryConfig.checksums.length > 0) {
+      artifactData.checksums = await getArtifactChecksums(
+        this.registryConfig.checksums,
+        artifact,
+        this.artifactProvider
+      );
+    }
 
     return artifactData;
   }

--- a/src/utils/checksum.ts
+++ b/src/utils/checksum.ts
@@ -62,10 +62,9 @@ export async function getArtifactChecksums(
   checksums: ChecksumEntry[],
   artifact: RemoteArtifact,
   artifactProvider: BaseArtifactProvider
-): Promise<any> {
-  if (checksums.length == 0) {
-    return undefined;
-  }
+): Promise<{
+  [key: string]: string;
+}> {
   const fileChecksums: { [key: string]: string } = {};
   for (const checksumType of checksums) {
     const { algorithm, format } = checksumType;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/pull/3024