### PR TITLE
feat(github): Retry on 404s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+- feat(github): Retry on 404s (#177)
+
 ## 0.17.2
 
 - fix(registry): `undefined` handling when there's no `checksums` in `.craft.yml` (#175)

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -146,6 +146,12 @@ export function getGithubClient(token = ''): Github {
     };
   }
 
+  attrs.retry = {
+    // Omit 404 as sometimes GitHub takes a while to make resources
+    // available on the API (such as artifacts or check runs)
+    doNotRetry: [400, 401, 403, 422],
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { retry } = require('@octokit/plugin-retry');
   const octokitWithRetries = Github.plugin(retry);


### PR DESCRIPTION
Allows retries on `404` responses from GitHub as their API may lag occassionally when making artifacts or check runs available.
