### PR TITLE
ref(aws-lambda): Catch potential exceptions when publishing AWS Lambda layers to new regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - feat(github): Retry on 404s (#177)
+- ref(aws-lambda): Catch potential exceptions when publishing AWS Lambda layers to new regions (#178)
 
 ## 0.17.2
 

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -141,8 +141,8 @@ export class AwsLambdaLayerTarget extends BaseTarget {
       await this.artifactProvider.downloadArtifact(packageFiles[0])
     );
 
-    logger.debug('Fetching AWS regions...');
     const awsRegions = extractRegionNames(await getRegionsFromAws());
+    logger.debug('AWS regions: ' + awsRegions);
 
     const remote = this.awsLambdaConfig.registryRemote;
     const username = await getAuthUsername(this.github);
@@ -161,6 +161,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
             awsRegions,
             artifactBuffer
           );
+          logger.debug('Finished publishing runtimes.');
         } else {
           logger.info('[dry-run] Not publishing new layers.');
         }
@@ -198,6 +199,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
   ): Promise<void> {
     await Promise.all(
       this.config.compatibleRuntimes.map(async (runtime: CompatibleRuntime) => {
+        logger.debug(`Publishing runtime ${runtime.name}...`);
         const layerManager = new AwsLambdaLayerManager(
           runtime,
           this.config.layerName,
@@ -209,6 +211,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
         let publishedLayers = [];
         try {
           publishedLayers = await layerManager.publishToAllRegions();
+          logger.debug('Finished publishing to all regions.');
         } catch (error) {
           logger.error(
             `Did not publish layers for ${runtime.name}. ` +
@@ -294,6 +297,7 @@ function createVersionSymlinks(
   version: string,
   versionFilepath: string
 ): void {
+  logger.debug(`Creating symlinks...`);
   const latestVersionPath = path.posix.join(directory, 'latest.json');
   if (fs.existsSync(latestVersionPath)) {
     const previousVersion = fs

--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -66,6 +66,7 @@ export class AwsLambdaLayerManager {
    * @returns Information about the published layer: region, arn and version.
    */
   public async publishLayerToRegion(region: string): Promise<PublishedLayer> {
+    logger.debug(`Publishing layer to ${region}...`);
     const lambda = new Lambda({ region: region });
     const publishedLayer = await lambda.publishLayerVersion({
       Content: {
@@ -101,11 +102,21 @@ export class AwsLambdaLayerManager {
    * @returns Array of the published layers.
    */
   public async publishToAllRegions(): Promise<PublishedLayer[]> {
-    return await Promise.all(
-      this.awsRegions.map(region => {
-        return this.publishLayerToRegion(region);
+    const publishedLayers = await Promise.all(
+      this.awsRegions.map(async region => {
+        try {
+          return await this.publishLayerToRegion(region);
+        } catch (error) {
+          logger.warn(
+            `Something went wrong with AWS trying to publish to region ${region}`
+          );
+          return undefined;
+        }
       })
     );
+    return publishedLayers.filter(layer => {
+      return layer !== undefined;
+    }) as PublishedLayer[];
   }
 
   /**

--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -108,7 +108,8 @@ export class AwsLambdaLayerManager {
           return await this.publishLayerToRegion(region);
         } catch (error) {
           logger.warn(
-            `Something went wrong with AWS trying to publish to region ${region}`
+            'Something went wrong with AWS trying to publish to region ' +
+              `${region}: ${error.message}`
           );
           return undefined;
         }


### PR DESCRIPTION
AWS regions are requested using the EC2 client, and Lambda layers are published to these regions using the Lambda client. However, it may be possible that an exception is raised (such as a timeout exception). With this PR these exceptions are catched and warned, without stopping Craft. Note that even if there's an exception, layers may be created.