### PR TITLE
feat(aws-lambda): Add runtime names on commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(github): Retry on 404s (#177)
 - ref(aws-lambda): Catch potential exceptions when publishing AWS Lambda layers to new regions (#178)
+- ref(aws-lambda): Add runtime names on commit message (#181)
 
 ## 0.17.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - feat(github): Retry on 404s (#177)
 - ref(aws-lambda): Catch potential exceptions when publishing AWS Lambda layers to new regions (#178)
-- ref(aws-lambda): Add runtime names on commit message (#181)
+- feat(aws-lambda): Add runtime names on commit message (#181)
 
 ## 0.17.2
 

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -168,8 +168,14 @@ export class AwsLambdaLayerTarget extends BaseTarget {
 
         await git.add(['.']);
         await git.checkout('master');
+        const runtimeNames = this.config.compatibleRuntimes.map(
+          (runtime: CompatibleRuntime) => {
+            return runtime.name;
+          }
+        );
         await git.commit(
-          `craft: AWS Lambda layers published, version ${version}`
+          'craft(aws-lambda): AWS Lambda layers published\n\n' +
+            `v${version} for ${runtimeNames}`
         );
 
         if (

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -169,9 +169,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
         await git.add(['.']);
         await git.checkout('master');
         const runtimeNames = this.config.compatibleRuntimes.map(
-          (runtime: CompatibleRuntime) => {
-            return runtime.name;
-          }
+          (runtime: CompatibleRuntime) => runtime.name
         );
         await git.commit(
           'craft(aws-lambda): AWS Lambda layers published\n\n' +


### PR DESCRIPTION
Craft can create AWS Lambda layers for multiple runtimes. This PR adds the runtime names in the commit message, instead of just having the version. 