### PR TITLE
feat(registry): Allow colons as separators in canonical names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+- feat(registry): Allow colons as separators in canonical names (#183)
 - feat(github): Retry on 404s (#177)
 - ref(aws-lambda): Catch potential exceptions when publishing AWS Lambda layers to new regions (#178)
 - feat(aws-lambda): Add runtime names on commit message (#181)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 # Unreleased
 
-- feat(registry): Allow colons as separators in canonical names (#183)
 - feat(github): Retry on 404s (#177)
 - ref(aws-lambda): Catch potential exceptions when publishing AWS Lambda layers to new regions (#178)
 - feat(aws-lambda): Add runtime names on commit message (#181)
+- feat(registry): Allow colons as separators in canonical names (#183)
 
 ## 0.17.2
 

--- a/src/utils/__tests__/packagePath.test.ts
+++ b/src/utils/__tests__/packagePath.test.ts
@@ -16,6 +16,14 @@ describe('parseCanonical', () => {
     ]);
   });
 
+  test('allows colons as path separators', async () => {
+    expect(parseCanonical('maven:io.sentry:sentry')).toEqual([
+      'maven',
+      'io.sentry',
+      'sentry',
+    ]);
+  });
+
   test('throws an error for invalid canonical names', async () => {
     function expectRaisesError(name: string): void {
       try {

--- a/src/utils/packagePath.ts
+++ b/src/utils/packagePath.ts
@@ -57,13 +57,22 @@ export function getPackageDirPath(
 /**
  * Parses registry canonical name to a list of registry directories
  *
- * Example: "npm:@sentry/browser" -> ["npm", "@sentry", "browser"]
+ * Colons can be used as separators in addition to forward slashes.
+ *
+ * Examples:
+ *    "npm:@sentry/browser" -> ["npm", "@sentry", "browser"]
+ *    "maven:io.sentry:sentry" -> ["maven", "io.sentry", "sentry"]
  *
  * @param canonicalName Registry canonical name
  * @returns A list of directories
  */
 export function parseCanonical(canonicalName: string): string[] {
-  const [registry, packageName] = canonicalName.split(':');
+  const [registry, ...splitPackageName] = canonicalName.split(':');
+
+  // This essentially replaces colons with forward slashes for the package name
+  // of the initial canonical name
+  const packageName = splitPackageName.join('/');
+
   if (!registry || !packageName) {
     throw new ConfigurationError(
       `Cannot parse canonical name for the package: ${canonicalName}`

--- a/src/utils/packagePath.ts
+++ b/src/utils/packagePath.ts
@@ -84,5 +84,5 @@ export function parseCanonical(canonicalName: string): string[] {
       `Cannot parse canonical name for the package: ${canonicalName}`
     );
   }
-  return [registry].concat(packageName.split('/'));
+  return [registry].concat(packageDirs);
 }


### PR DESCRIPTION
Companion to https://github.com/getsentry/sentry-release-registry/pull/45

We decided to allow colons as canonical name separators, in addition to slashes.