### PR TITLE
fix(changelog): Update unreleased marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# Unreleased
+## Unreleased
 
 - feat(github): Retry on 404s (#177)
 - ref(aws-lambda): Catch potential exceptions when publishing AWS Lambda layers to new regions (#178)


### PR DESCRIPTION
Ideally we should allow the original too, but let's unblock the release for now.
Without it, craft doesn't process this changelog properly.
