### PR TITLE
fix(registry): Specify correct rebase flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- fix(registry): Ensure up-to-date remote before pushing (#186)
+- fix(registry): Ensure up-to-date remote before pushing (#186, #188)
+
 ## 0.18.0
 
 - feat(github): Retry on 404s (#177)

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -374,7 +374,7 @@ export class RegistryTarget extends BaseTarget {
     await git.commit(`craft: release "${canonicalName}", version "${version}"`);
 
     // Ensure we are still up to date with upstream
-    await git.pull('origin', 'master', { rebase: true });
+    await git.pull('origin', 'master', ['--rebase']);
 
     // Push!
     if (!isDryRun()) {


### PR DESCRIPTION
Passes `--rebase` as option, instead of a literal `rebase` which git interprets as a remote. Additionally, I'm opting for the array-based syntax as it's more concise and in line with other git invocations in the same file. See [how to specify options](https://www.npmjs.com/package/simple-git#how-to-specify-options).

Disclaimer: I did not test this branch. Please test before merging.