### PR TITLE
fix(github-artifacts): Better pagination and retry on missing artifacts

### DIFF
--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -127,6 +127,12 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
           commit_sha: revision
         })).data.committer.date;
       }
+      // XXX(BYK): The assumption here is that the artifact created_at date
+      // should always be greater than or equal to the associated revision date
+      // ** AND **
+      // the artifacts are listed in descending date order on this endpoint.
+      // There is no public documentation on this but the observed data and
+      // common-sense logic suggests that this is a reasonably safe assumption.
       const lastArtifact = allArtifacts[allArtifacts.length-1];
       checkNextPage = lastArtifact.created_at >= revisionDate;
     }


### PR DESCRIPTION
GitHub sometimes takes a few minutes until it lists freshly uploaded artifacts on its API. This PR adds a retry mechanism when we cannot find any artifacts for the given revision. It also improves the pagination mechanism to no scan artifacts beyond the revision's commit date to shorten lookup times.

Fixes #182.
