### PR TITLE
feat(publish): Store and restore publish state

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -2,6 +2,12 @@ import * as Github from '@octokit/rest';
 import * as inquirer from 'inquirer';
 import { Arguments, Argv, CommandBuilder } from 'yargs';
 import chalk from 'chalk';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  promises as fsPromises,
+} from 'fs';
 import { join } from 'path';
 import * as shellQuote from 'shell-quote';
 import * as stringLength from 'string-length';
@@ -115,6 +121,12 @@ export interface PublishOptions {
   keepBranch: boolean;
 }
 
+export interface PublishState {
+  published: {
+    [targetId: string]: boolean;
+  };
+}
+
 /**
  * Checks that the passed version is a valid version string
  *
@@ -131,72 +143,29 @@ function checkVersion(argv: Arguments<any>, _opt: any): any {
 }
 
 /**
- * Publishes artifacts to the provided targets
+ * Publishes artifacts to the provided target
  *
- * @param githubConfig Github repository configuration
+ * @param target The target instance to publish
  * @param version New version to be released
  * @param revision Git commit SHA of the commit to be published
- * @param targetConfigList A list of parsed target configurations
- * @param keepDownloads If "true", downloaded files will not be removed
  */
-async function publishToTargets(
+async function publishToTarget(
+  target: BaseTarget,
   version: string,
-  revision: string,
-  targetConfigList: any[],
-  artifactProvider: BaseArtifactProvider,
-  keepDownloads = false
+  revision: string
 ): Promise<void> {
-  let downloadDirectoryPath;
-
-  await withTempDir(async (downloadDirectory: string) => {
-    downloadDirectoryPath = downloadDirectory;
-    artifactProvider.setDownloadDirectory(downloadDirectoryPath);
-    const targetList: BaseTarget[] = [];
-
-    // Initialize all targets first
-    // TODO(tonyo): initialize them earlier!
-    logger.debug('Initializing targets');
-    for (const targetConfig of targetConfigList) {
-      const targetClass = getTargetByName(targetConfig.name);
-      const targetDescriptor = getTargetId(targetConfig);
-      if (!targetClass) {
-        logger.warn(
-          `Target implementation for "${targetDescriptor}" not found.`
-        );
-        continue;
-      }
-      try {
-        const target = new targetClass(targetConfig, artifactProvider);
-        targetList.push(target);
-      } catch (e) {
-        logger.error('Error creating target instance!');
-        throw e;
-      }
-    }
-
-    // Publish to all targets
-    for (const target of targetList) {
-      const targetDescriptor = target.config.id
-        ? `${target.config.id}[${target.name}]`
-        : target.name;
-      const publishMessage = `=== Publishing to target: ${chalk.bold(
-        chalk.cyan(targetDescriptor)
-      )} ===`;
-      const delim = Array(stringLength(publishMessage) + 1).join('=');
-      logger.info(' ');
-      logger.info(delim);
-      logger.info(publishMessage);
-      logger.info(delim);
-      await target.publish(version, revision);
-    }
-  }, !keepDownloads);
-
-  if (keepDownloads) {
-    logger.info(
-      'Directory with the downloaded artifacts will not be removed',
-      `Path: ${downloadDirectoryPath}`
-    );
-  }
+  const targetDescriptor = target.config.id
+    ? `${target.config.id}[${target.name}]`
+    : target.name;
+  const publishMessage = `=== Publishing to target: ${chalk.bold(
+    chalk.cyan(targetDescriptor)
+  )} ===`;
+  const delim = Array(stringLength(publishMessage) + 1).join('=');
+  logger.info(' ');
+  logger.info(delim);
+  logger.info(publishMessage);
+  logger.info(delim);
+  await target.publish(version, revision);
 }
 
 /**
@@ -466,7 +435,7 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
 
   logger.info(`Publishing version: "${newVersion}"`);
 
-  let revision;
+  let revision: string;
   let branchName;
   if (argv.rev) {
     branchName = '';
@@ -503,8 +472,11 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
   // Check status of all CI builds linked to the revision
   await checkRevisionStatus(statusProvider, revision, argv.noStatusCheck);
 
+  await printRevisionSummary(artifactProvider, revision);
+  await checkRequiredArtifacts(artifactProvider, revision, config.requireNames);
+
   // Find targets
-  const targetList: Set<string> = new Set(
+  let targetList: Set<string> = new Set(
     (typeof argv.target === 'string' ? [argv.target] : argv.target) || [
       SpecialTarget.All,
     ]
@@ -520,6 +492,25 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
     }
   }
 
+  logger.info(`Looking for publish state file for ${newVersion}...`);
+  const publishStateFile = `.craft-publish-${newVersion}.json`;
+  const earlierStateExists = existsSync(publishStateFile);
+  let publishState: PublishState;
+  if (earlierStateExists) {
+    logger.info(`Found publish state file, resuming from there...`);
+    publishState = JSON.parse(readFileSync(publishStateFile).toString());
+    targetList = new Set(getAllTargetNames());
+  } else {
+    publishState = { published: Object.create(null) };
+  }
+
+  for (const published of Object.keys(publishState.published)) {
+    logger.info(
+      `Skipping target ${published} as it is marked as successful in state file.`
+    );
+    targetList.delete(published);
+  }
+
   let targetConfigList = config.targets || [];
 
   if (!targetList.has(SpecialTarget.All)) {
@@ -528,22 +519,34 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
     );
   }
 
-  if (!targetList.has(SpecialTarget.None)) {
+  if (!targetList.has(SpecialTarget.None) && !earlierStateExists) {
     if (targetConfigList.length === 0) {
       logger.warn('No valid targets detected! Exiting.');
       return undefined;
     }
 
-    await printRevisionSummary(artifactProvider, revision);
-    await checkRequiredArtifacts(
-      artifactProvider,
-      revision,
-      config.requireNames
-    );
+    logger.debug('Initializing targets');
+    const targetList: BaseTarget[] = [];
+    for (const targetConfig of targetConfigList) {
+      const targetClass = getTargetByName(targetConfig.name);
+      const targetDescriptor = getTargetId(targetConfig);
+      if (!targetClass) {
+        logger.warn(
+          `Target implementation for "${targetDescriptor}" not found.`
+        );
+        continue;
+      }
+      try {
+        const target = new targetClass(targetConfig, artifactProvider);
+        targetList.push(target);
+      } catch (err) {
+        logger.error(`Error creating target instance for ${targetDescriptor}!`);
+        throw err;
+      }
+    }
 
     logger.info('Publishing to targets:');
 
-    // TODO init all targets earlier
     targetConfigList
       .map(getTargetId)
       .forEach(target => logger.info(`  - ${target}`));
@@ -551,13 +554,26 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
 
     await promptConfirmation();
 
-    await publishToTargets(
-      newVersion,
-      revision,
-      targetConfigList,
-      artifactProvider,
-      argv.keepDownloads
-    );
+    await withTempDir(async (downloadDirectory: string) => {
+      artifactProvider.setDownloadDirectory(downloadDirectory);
+
+      // Publish to all targets
+      for (const target of targetList) {
+        await publishToTarget(target, newVersion, revision);
+        publishState.published[getTargetId(target.config)] = true;
+        if (!isDryRun()) {
+          writeFileSync(publishStateFile, JSON.stringify(publishState));
+        }
+      }
+
+      if (argv.keepDownloads) {
+        logger.info(
+          'Directory with the downloaded artifacts will not be removed',
+          `Path: ${downloadDirectory}`
+        );
+      }
+    }, !argv.keepDownloads);
+
     logger.info(' ');
   }
 
@@ -565,7 +581,8 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
     logger.info('Not merging any branches because revision was specified.');
   } else if (
     targetList.has(SpecialTarget.All) ||
-    targetList.has(SpecialTarget.None)
+    targetList.has(SpecialTarget.None) ||
+    earlierStateExists
   ) {
     // Publishing done, MERGE DAT BRANCH!
     await handleReleaseBranch(
@@ -575,6 +592,10 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
       argv.noMerge,
       argv.keepBranch
     );
+    if (!isDryRun()) {
+      // intentionally DO NOT await unlinking
+      fsPromises.unlink(publishStateFile);
+    }
     logger.success(`Version ${newVersion} has been published!`);
   } else {
     const msg = [

--- a/src/config.ts
+++ b/src/config.ts
@@ -225,8 +225,8 @@ export function getGlobalGithubConfig(): GithubGlobalConfig {
  */
 export function getGitTagPrefix(): string {
   const targets = getConfiguration().targets || [];
-  const githubTarget = targets.find(target => target.name === 'github') || {};
-  return githubTarget.tagPrefix || '';
+  const githubTarget = targets.find(target => target.name === 'github');
+  return githubTarget?.tagPrefix || '';
 }
 
 /**

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -107,6 +107,7 @@ const projectConfigJsonSchema = {
           type: 'string',
         },
       },
+      required: ['name'],
     },
 
     /**

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -31,7 +31,7 @@ export interface GithubGlobalConfig {
  * Generic target configuration
  */
 export interface TargetConfig {
-  name?: string;
+  name: string;
   id?: string;
   includeNames?: string;
   excludeNames?: string;

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -33,7 +33,7 @@ const logger = loggerRaw.withScope(`[aws-lambda-layer]`);
 const DEFAULT_REGISTRY_REMOTE: GithubRemote = getRegistryGithubRemote();
 
 /** Config options for the "aws-lambda-layer" target. */
-interface AwsLambdaTargetConfig extends TargetConfig {
+interface AwsLambdaTargetConfig {
   /** AWS access key ID, set as AWS_ACCESS_KEY_ID. */
   awsAccessKeyId: string;
   /** AWS secret access key, set as `AWS_SECRET_ACCESS_KEY`. */

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -31,7 +31,7 @@ export interface TapRepo {
 }
 
 /** Target options for "brew" */
-export interface BrewTargetOptions extends TargetConfig {
+export interface BrewTargetOptions {
   /** Brew tap repository */
   tapRepo: TapRepo;
   /** Template string that will be part of thew formula */
@@ -56,7 +56,7 @@ export class BrewTarget extends BaseTarget {
   public readonly githubRepo: GithubGlobalConfig;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);
@@ -126,7 +126,10 @@ export class BrewTarget extends BaseTarget {
     try {
       const tap = this.brewConfig.tapRepo;
       logger.debug(`Loading SHA for ${tap.owner}/${tap.repo}:${path}`);
-      const response = await this.github.repos.getContents({ ...tap, path });
+      const response = await this.github.repos.getContents({
+        ...tap,
+        path,
+      });
       if (response.data instanceof Array) {
         return undefined;
       }

--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -24,7 +24,7 @@ const DEFAULT_COCOAPODS_BIN = 'pod';
 const COCOAPODS_BIN = process.env.COCOAPODS_BIN || DEFAULT_COCOAPODS_BIN;
 
 /** Options for "cocoapods" target */
-export interface CocoapodsTargetOptions extends TargetConfig {
+export interface CocoapodsTargetOptions {
   /** Path to the spec file inside the repo */
   specPath: string;
 }
@@ -43,7 +43,7 @@ export class CocoapodsTarget extends BaseTarget {
   public readonly githubRepo: GithubGlobalConfig;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -52,7 +52,7 @@ const RETRY_DELAY_SECS = 2;
 const RETRY_EXP_FACTOR = 2;
 
 /** Options for "crates" target */
-export interface CratesTargetOptions extends TargetConfig {
+export interface CratesTargetOptions {
   /** Crates API token */
   apiToken: string;
   /** Whether to use `cargo-hack` and remove dev dependencies */
@@ -108,7 +108,7 @@ export class CratesTarget extends BaseTarget {
   public readonly cratesConfig: CratesTargetOptions;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/docker.ts
+++ b/src/targets/docker.ts
@@ -16,7 +16,7 @@ const DEFAULT_DOCKER_BIN = 'docker';
 const DOCKER_BIN = process.env.DOCKER_BIN || DEFAULT_DOCKER_BIN;
 
 /** Options for "docker" target */
-export interface DockerTargetOptions extends TargetConfig {
+export interface DockerTargetOptions {
   username: string;
   password: string;
   /** Source image path, like `us.gcr.io/sentryio/craft` */
@@ -39,7 +39,7 @@ export class DockerTarget extends BaseTarget {
   public readonly dockerConfig: DockerTargetOptions;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -34,7 +34,7 @@ interface PathTemplate extends Omit<BucketPath, 'path'> {
 /**
  * Configuration options for the GCS target
  */
-export interface GCSTargetConfig extends GCSBucketConfig, TargetConfig {
+export interface GCSTargetConfig extends GCSBucketConfig {
   /** A list of path templates with associated metadata */
   pathTemplates: PathTemplate[];
 }

--- a/src/targets/gem.ts
+++ b/src/targets/gem.ts
@@ -6,6 +6,7 @@ import {
 import { reportError } from '../utils/errors';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
+import { TargetConfig } from 'src/schemas/project_config';
 
 const logger = loggerRaw.withScope('[gem]');
 
@@ -29,7 +30,7 @@ export class GemTarget extends BaseTarget {
   public readonly name: string = 'gem';
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -30,7 +30,7 @@ const DEFAULT_DEPLOY_ARCHIVE_REGEX = /^(?:.+-)?gh-pages\.zip$/;
 const DEFAULT_DEPLOY_BRANCH = 'gh-pages';
 
 /** Target options for "gh-pages" */
-export interface GhPagesConfig extends TargetConfig {
+export interface GhPagesConfig {
   /** GitHub project owner */
   githubOwner: string;
   /** GitHub project name */
@@ -53,7 +53,7 @@ export class GhPagesTarget extends BaseTarget {
   public readonly githubRepo: GithubGlobalConfig;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -28,7 +28,7 @@ export const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 /**
  * Configuration options for the Github target
  */
-export interface GithubTargetConfig extends TargetConfig, GithubGlobalConfig {
+export interface GithubTargetConfig extends GithubGlobalConfig {
   /** Path to changelon inside the repository */
   changelog: string;
   /** Prefix that will be used to generate tag name */
@@ -69,7 +69,7 @@ export class GithubTarget extends BaseTarget {
   public readonly github: Github;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -40,7 +40,7 @@ export enum NpmPackageAccess {
 }
 
 /** NPM target configuration options */
-export interface NpmTargetOptions extends TargetConfig {
+export interface NpmTargetOptions {
   /** Package access specifier */
   access?: NpmPackageAccess;
   /** Do we use 2FA (via OTPs) for publishing? */
@@ -69,7 +69,7 @@ export class NpmTarget extends BaseTarget {
   public readonly npmConfig: NpmTargetOptions;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -20,7 +20,7 @@ export const DEFAULT_NUGET_SERVER_URL = 'https://api.nuget.org/v3/index.json';
 const DEFAULT_NUGET_REGEX = /^.*\d\.\d.*\.nupkg$/;
 
 /** Nuget target configuration options */
-export interface NugetTargetOptions extends TargetConfig {
+export interface NugetTargetOptions {
   /** Nuget API token */
   apiToken: string;
   /** Nuget server URL */
@@ -37,7 +37,7 @@ export class NugetTarget extends BaseTarget {
   public readonly nugetConfig: NugetTargetOptions;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -23,7 +23,7 @@ const TWINE_BIN = process.env.TWINE_BIN || DEFAULT_TWINE_BIN;
 const DEFAULT_PYPI_REGEX = /^.*\d\.\d.*(\.whl|\.gz|\.zip)$/;
 
 /** Options for "pypi" target */
-export interface PypiTargetOptions extends TargetConfig {
+export interface PypiTargetOptions {
   /** Twine username */
   twineUsername: string;
   /** Twine password */
@@ -40,7 +40,7 @@ export class PypiTarget extends BaseTarget {
   public readonly pypiConfig: PypiTargetOptions;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -46,7 +46,7 @@ export enum RegistryPackageType {
 }
 
 /** "registry" target options */
-export interface RegistryConfig extends TargetConfig {
+export interface RegistryConfig {
   /** Type of the registry package */
   type: RegistryPackageType;
   /** Unique package cannonical name, including type and/or registry name */
@@ -77,7 +77,7 @@ export class RegistryTarget extends BaseTarget {
   public readonly githubRepo: GithubGlobalConfig;
 
   public constructor(
-    config: Record<string, any>,
+    config: TargetConfig,
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -83,7 +83,8 @@ export async function withTempDir<T>(
     return await callback(directory);
   } finally {
     if (cleanup) {
-      await rimraf(directory);
+      // Intentionally DO NOT await removal
+      rimraf(directory);
     }
   }
 }


### PR DESCRIPTION
A very common occurance is publishing being inturrupted in the
middle by some error, causing the whole publish operation to stop
and the operator to resume by explicitly determining the unpublished
targets and then passing these via the `-t` argument.

This patch adds a simple JSON state file, keyed by the release version
that gets deleted after a successful publish. When the file exists, it is
automatically used to skip over already published targets.
