### PR TITLE
feat(cli): Add a new `targets` command

### DIFF
--- a/src/commands/targets.ts
+++ b/src/commands/targets.ts
@@ -1,0 +1,17 @@
+import { Argv, CommandBuilder } from 'yargs';
+import { getConfiguration } from '../config';
+import { getAllTargetNames, getTargetId } from '../targets';
+
+export const builder: CommandBuilder = (yargs: Argv) => {
+  return yargs;
+};
+
+export function handler(): any {
+  const definedTargets = getConfiguration().targets || [];
+  const possibleTargetNames = new Set(getAllTargetNames());
+  const allowedTargetNames = definedTargets
+    .filter(target => target.name && possibleTargetNames.has(target.name))
+    .map(getTargetId);
+
+  console.log(JSON.stringify(allowedTargetNames));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,12 +43,9 @@ function processNoInput<T>(arg: T): T {
  * Prints the current version
  */
 function printVersion(): void {
-  if (
-    process.argv.indexOf('-v') === -1 &&
-    process.argv.indexOf('--version') === -1
-  ) {
+  if (process.argv.includes('-v') && process.argv.includes('--version')) {
     // Print the current version
-    logger.info(`craft ${getPackageVersion()}`);
+    logger.debug(`craft ${getPackageVersion()}`);
   }
 }
 


### PR DESCRIPTION
Adds a `targets` command to get a JSON list of available targets for a project. This is to be able to programmatically consume this informatino from places like getsentry/publish.
