### PR TITLE
ref(logger): Move some extra info to debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix(publish): Fix publishing when resuming from a state file (#197)
+- ref(logger): Move some extra info to debug level (#198)
 
 ## 0.19.0
 

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -183,9 +183,9 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
       });
 
       await withTempDir(async tmpDir => {
-        logger.info(`Extracting "${tempFilepath}" to "${tmpDir}"...`);
+        logger.debug(`Extracting "${tempFilepath}" to "${tmpDir}"...`);
         await extractZipArchive(tempFilepath, tmpDir);
-        await (await scan(tmpDir)).map(file => {
+        (await scan(tmpDir)).forEach(file => {
           artifacts.push({
             filename: path.basename(file),
             mimeType: detectContentType(file),
@@ -243,11 +243,11 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
 
     const foundArtifact = await this.listArtifact(revision);
 
-    logger.info(`Requesting archive URL from Github...`);
+    logger.debug(`Requesting archive URL from Github...`);
 
     const archiveResponse = await this.getArchiveDownloadUrl(foundArtifact);
 
-    logger.info(`Downloading ZIP from Github artifacts...`);
+    logger.debug(`Downloading ZIP from Github artifacts...`);
 
     return await this.downloadAndUnpackArtifacts(archiveResponse);
   }

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -534,7 +534,7 @@ export async function releaseMain(argv: ReleaseOptions): Promise<any> {
     // Commit the pending changes
     await commitNewVersion(git, newVersion);
   } else {
-    logger.debug('Not commiting anything since preReleaseCommand is empty.');
+    logger.debug('Not committing anything since preReleaseCommand is empty.');
   }
 
   // Push the release branch

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -371,7 +371,7 @@ async function prepareChangelog(
   changelogPath: string = DEFAULT_CHANGELOG_PATH
 ): Promise<void> {
   if (changelogPolicy === ChangelogPolicy.None) {
-    logger.info(
+    logger.debug(
       `Changelog policy is set to "${changelogPolicy}", nothing to do.`
     );
     return;
@@ -534,7 +534,7 @@ export async function releaseMain(argv: ReleaseOptions): Promise<any> {
     // Commit the pending changes
     await commitNewVersion(git, newVersion);
   } else {
-    logger.info('Not commiting anything since preReleaseCommand is empty.');
+    logger.debug('Not commiting anything since preReleaseCommand is empty.');
   }
 
   // Push the release branch

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -423,7 +423,7 @@ export async function runPostReleaseCommand(
   let args: shellQuote.ParseEntry[];
   if (postReleaseCommand !== undefined && postReleaseCommand.length === 0) {
     // Not running post-release command
-    logger.info('Not running the post-release command: no command specified');
+    logger.debug('Not running the post-release command: no command specified');
     return false;
   } else if (postReleaseCommand) {
     [sysCommand, ...args] = shellQuote.parse(postReleaseCommand);
@@ -498,8 +498,8 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
 
   const statusProvider = getStatusProviderFromConfig();
   const artifactProvider = getArtifactProviderFromConfig();
-  logger.info(`Using "${statusProvider.constructor.name}" for status checks`);
-  logger.info(`Using "${artifactProvider.constructor.name}" for artifacts`);
+  logger.debug(`Using "${statusProvider.constructor.name}" for status checks`);
+  logger.debug(`Using "${artifactProvider.constructor.name}" for artifacts`);
 
   // Check status of all CI builds linked to the revision
   await checkRevisionStatus(statusProvider, revision, argv.noStatusCheck);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ function processDryRun<T>(arg: T): T {
   }
 
   if (isDryRun()) {
-    logger.info('[dry-run] Dry-run mode is on!');
+    logger.debug('[dry-run] Dry-run mode is on!');
   }
 
   return arg;
@@ -34,7 +34,7 @@ function processNoInput<T>(arg: T): T {
     setNoInput(true);
   }
   if (hasNoInput()) {
-    logger.info('[no-input] The script will not accept any input!');
+    logger.debug('[no-input] The script will not accept any input!');
   }
   return arg;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ function processDryRun<T>(arg: T): T {
   }
 
   if (isDryRun()) {
-    logger.debug('[dry-run] Dry-run mode is on!');
+    logger.info('[dry-run] Dry-run mode is on!');
   }
 
   return arg;

--- a/src/status_providers/github.ts
+++ b/src/status_providers/github.ts
@@ -74,10 +74,10 @@ export class GithubStatusProvider extends BaseStatusProvider {
           return contextResult;
         }
       }
-      logger.debug('All contexts were build successfully!');
+      logger.debug('All contexts concluded successfully!');
       return CommitStatus.SUCCESS;
     } else {
-      logger.info(
+      logger.debug(
         'No config provided for Github status provider, calculating the combined status...'
       );
 


### PR DESCRIPTION
Our default info level logging is a bit too noisy and outputs redundant information that would only be useful when debugging. This also caused issues withe the new `targets` command on CI as we were always outputting `[no-input]` when we detected CI. This PR moves most of these messages to debug level.
