### PR TITLE
fix(github): Revert retry on 404s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(github): Revert retry on 404s (#199)
+
 ## 0.20.0
 
 - fix(publish): Fix publishing when resuming from a state file (#197)

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -146,12 +146,6 @@ export function getGithubClient(token = ''): Github {
     };
   }
 
-  attrs.retry = {
-    // Omit 404 as sometimes GitHub takes a while to make resources
-    // available on the API (such as artifacts or check runs)
-    doNotRetry: [400, 401, 403, 422],
-  };
-
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { retry } = require('@octokit/plugin-retry');
   const octokitWithRetries = Github.plugin(retry);


### PR DESCRIPTION
This PR reverts #177 as not only it did not address the issue it
was intending to fix, it introduced delays in where we actually
expect a 404 response. It also caused a weird failure where we
threw an error due to a 404 response which should have been ignored:
https://github.com/getsentry/publish/runs/2281793805?check_suite_focus=true#step:8:59

The retry issue was resolved via #190.
