### PR TITLE
fix(gcs): Fix GCS artifact provider on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix(github): Revert retry on 404s (#199)
+- fix(gcs): Fix GCS artifact provider on Windows (#200)
 
 ## 0.20.0
 

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -9,7 +9,7 @@ import {
 } from '@google-cloud/storage';
 import { isDryRun } from './helpers';
 
-import { Logger, logger as loggerRaw } from '../logger';
+import { logger, Logger, logger as loggerRaw } from '../logger';
 import { reportError, ConfigurationError } from './errors';
 import { checkEnvForPrerequisite, RequiredConfigVar } from './env';
 import { detectContentType } from './files';
@@ -345,10 +345,10 @@ export class CraftGCSClient {
     revision: string
   ): Promise<RemoteArtifact[]> {
     let filesResponse: GCSFile[][] = [[]];
+    const prefix = path.posix.join(repoOwner, repoName, revision);
+    logger.debug(`Looking for files starting with '${prefix}'`);
     try {
-      filesResponse = await this.bucket.getFiles({
-        prefix: path.join(repoOwner, repoName, revision),
-      });
+      filesResponse = await this.bucket.getFiles({ prefix });
     } catch (err) {
       reportError(
         `Error retrieving artifact list from GCS: ${formatJson(err)}`

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -214,7 +214,7 @@ export class CraftGCSClient {
       ...(contentType && { contentType }),
     };
     const uploadConfig: GCSUploadOptions = {
-      destination: path.join(pathInBucket, filename),
+      destination: path.posix.join(pathInBucket, filename),
       gzip: true,
       metadata,
       resumable: !process.env.CI,
@@ -226,7 +226,7 @@ export class CraftGCSClient {
 
     if (!isDryRun()) {
       this.logger.debug(
-        `Attempting to upload \`${filename}\` to \`${path.join(
+        `Attempting to upload \`${filename}\` to \`${path.posix.join(
           this.bucketName,
           pathInBucket
         )}\`.`
@@ -242,7 +242,7 @@ export class CraftGCSClient {
       // TODO (kmclb) replace this with a `craft download` command once that's a thing
       this.logger.debug(
         `Successfully uploaded \`${filename}\`. It can be downloaded by running ` +
-          `\`gsutil cp ${path.join(
+          `\`gsutil cp ${path.posix.join(
             'gs://',
             this.bucketName,
             pathInBucket,


### PR DESCRIPTION
Use `path.posix` instead of `path` when generating the `prefix` for GCS file listing so Craft works as expected on Windows too.
