### PR TITLE
feat(config): Use GitHub as default provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 - fix(github): Revert retry on 404s (#199)
 - fix(gcs): Fix GCS artifact provider on Windows (#200)
 - feat(config): Use GitHub as default provider (#202)
+  **Breaking Change:** This version changes the default configuration values for
+  `statusProvider` and `artifactProvider` to `github` if `minVersion` is greater
+  or equal to `0.21.0`. If your craft configuration file does not set these
+  providers explicitly, you can keep the old behavior by modifying your config:
+  ```yaml
+  minVersion: 0.21.0
+  artifactProvider:
+    name: zeus
+  statusProvider:
+    name: zeus
+  ```
+  Support for Zeus will be dropped in a future release and we highly recommend
+  updating your CI workflows to use GitHub.
 
 ## 0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix(github): Revert retry on 404s (#199)
 - fix(gcs): Fix GCS artifact provider on Windows (#200)
 - feat(config): Use GitHub as default provider (#202)
+
   **Breaking Change:** This version changes the default configuration values for
   `statusProvider` and `artifactProvider` to `github` if `minVersion` is greater
   or equal to `0.21.0`. If your craft configuration file does not set these
@@ -16,6 +17,7 @@
   statusProvider:
     name: zeus
   ```
+
   Support for Zeus will be dropped in a future release and we highly recommend
   updating your CI workflows to use GitHub.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix(github): Revert retry on 404s (#199)
 - fix(gcs): Fix GCS artifact provider on Windows (#200)
+- feat(config): Use GitHub as default provider (#202)
 
 ## 0.20.0
 

--- a/README.md
+++ b/README.md
@@ -940,21 +940,21 @@ Here is how you can integrate your GitHub project with `craft`:
 2. Use the official `actions/upload-artifact@v2` action to upload your assets.
    Here is an example config (step) of an archive job:
 
-    ```yaml
-    - name: Archive Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.sha }}
-        path: |
-          ${{ github.workspace }}/*.tgz
-          ${{ github.workspace }}/packages/tracing/build/**
-          ${{ github.workspace }}/packages/**/*.tgz
-    ```
+   ```yaml
+   - name: Archive Artifacts
+     uses: actions/upload-artifact@v2
+     with:
+       name: ${{ github.sha }}
+       path: |
+         ${{ github.workspace }}/*.tgz
+         ${{ github.workspace }}/packages/tracing/build/**
+         ${{ github.workspace }}/packages/**/*.tgz
+   ```
 
-    A few important things to note:
+   A few important things to note:
 
-    - The name of the artifacts is very important and needs to be `name: ${{ github.sha }}`. Craft uses this as a unique id to fetch the artifacts.
-    - Keep in mind that this action maintains the folder structure and zips everything together. Craft will download the zip and recursively walk it to find all assets.
+   - The name of the artifacts is very important and needs to be `name: ${{ github.sha }}`. Craft uses this as a unique id to fetch the artifacts.
+   - Keep in mind that this action maintains the folder structure and zips everything together. Craft will download the zip and recursively walk it to find all assets.
 3. Add `.craft.yml` configuration file to your project
   - List there all the targets you want to publish to
   - Configure additional options (changelog management policy, tag prefix, etc.)

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -8,6 +8,7 @@ import {
   checkMinimalConfigVersion,
   getConfigFilePath,
   getConfiguration,
+  getChangelogPolicyFromConfig,
   DEFAULT_RELEASE_BRANCH_NAME,
 } from '../config';
 import { logger } from '../logger';
@@ -367,7 +368,7 @@ async function checkForExistingTag(
  */
 async function prepareChangelog(
   newVersion: string,
-  changelogPolicy: ChangelogPolicy = ChangelogPolicy.None,
+  changelogPolicy: ChangelogPolicy,
   changelogPath: string = DEFAULT_CHANGELOG_PATH
 ): Promise<void> {
   if (changelogPolicy === ChangelogPolicy.None) {
@@ -510,7 +511,7 @@ export async function releaseMain(argv: ReleaseOptions): Promise<any> {
   // Check & update the changelog
   await prepareChangelog(
     newVersion,
-    argv.noChangelog ? ChangelogPolicy.None : config.changelogPolicy,
+    argv.noChangelog ? ChangelogPolicy.None : getChangelogPolicyFromConfig(),
     config.changelog
   );
 

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -8,7 +8,6 @@ import {
   checkMinimalConfigVersion,
   getConfigFilePath,
   getConfiguration,
-  getChangelogPolicyFromConfig,
   DEFAULT_RELEASE_BRANCH_NAME,
 } from '../config';
 import { logger } from '../logger';
@@ -368,7 +367,7 @@ async function checkForExistingTag(
  */
 async function prepareChangelog(
   newVersion: string,
-  changelogPolicy: ChangelogPolicy,
+  changelogPolicy: ChangelogPolicy = ChangelogPolicy.None,
   changelogPath: string = DEFAULT_CHANGELOG_PATH
 ): Promise<void> {
   if (changelogPolicy === ChangelogPolicy.None) {
@@ -511,7 +510,7 @@ export async function releaseMain(argv: ReleaseOptions): Promise<any> {
   // Check & update the changelog
   await prepareChangelog(
     newVersion,
-    argv.noChangelog ? ChangelogPolicy.None : getChangelogPolicyFromConfig(),
+    argv.noChangelog ? ChangelogPolicy.None : config.changelogPolicy,
     config.changelog
   );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -267,9 +267,17 @@ export function getArtifactProviderFromConfig(): BaseArtifactProvider {
 
   let artifactProviderName = projectConfig.artifactProvider?.name;
   if (artifactProviderName == null) {
-    artifactProviderName = isAfterEpoch()
-      ? ArtifactProviderName.Github
-      : ArtifactProviderName.Zeus;
+    if (isAfterEpoch()) {
+      artifactProviderName = ArtifactProviderName.Github;
+    } else {
+      logger.warn(
+        `You are relying on the default artifact provider, which has changed Craft v${DEFAULTS_EPOCH_VERSION}.`
+      );
+      logger.warn(
+        `This will affect you when you set your \`minVersion\` in your config to ${DEFAULTS_EPOCH_VERSION} or later.`
+      );
+      artifactProviderName = ArtifactProviderName.Zeus;
+    }
   }
 
   const artifactProviderConfig = {
@@ -310,9 +318,17 @@ export function getStatusProviderFromConfig(): BaseStatusProvider {
   let statusProviderName = rawStatusProvider.name;
 
   if (statusProviderName == null) {
-    statusProviderName = isAfterEpoch()
-      ? StatusProviderName.Github
-      : StatusProviderName.Zeus;
+    if (isAfterEpoch()) {
+      statusProviderName = StatusProviderName.Github;
+    } else {
+      logger.warn(
+        `You are relying on the default status provider, which has changed Craft v${DEFAULTS_EPOCH_VERSION}.`
+      );
+      logger.warn(
+        `This will affect you when you set your \`minVersion\` in your config to ${DEFAULTS_EPOCH_VERSION} or later.`
+      );
+      statusProviderName = StatusProviderName.Zeus;
+    }
   }
 
   switch (statusProviderName) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -300,7 +300,7 @@ export function getArtifactProviderFromConfig(): BaseArtifactProvider {
  * @returns An instance of status provider
  */
 export function getStatusProviderFromConfig(): BaseStatusProvider {
-  const config = getConfiguration() || {};
+  const config = getConfiguration();
   const githubConfig = config.github;
 
   const rawStatusProvider = config.statusProvider || {
@@ -336,7 +336,7 @@ export function getStatusProviderFromConfig(): BaseStatusProvider {
 }
 
 export function getChangelogPolicyFromConfig(): ChangelogPolicy {
-  const config = getConfiguration() || {};
+  const config = getConfiguration();
 
   return (
     config.changelogPolicy ??

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,6 @@ import {
   GithubGlobalConfig,
   ArtifactProviderName,
   StatusProviderName,
-  ChangelogPolicy,
 } from './schemas/project_config';
 import { ConfigurationError } from './utils/errors';
 import {

--- a/src/config.ts
+++ b/src/config.ts
@@ -334,12 +334,3 @@ export function getStatusProviderFromConfig(): BaseStatusProvider {
     }
   }
 }
-
-export function getChangelogPolicyFromConfig(): ChangelogPolicy {
-  const config = getConfiguration();
-
-  return (
-    config.changelogPolicy ??
-    (isAfterEpoch() ? ChangelogPolicy.Auto : ChangelogPolicy.None)
-  );
-}


### PR DESCRIPTION
This PR switches default artifact and status providers to GitHub if the minimum required Craft version is set to 0.21.0 or above. This is *not* a breaking change for older projects.
