### PR TITLE
fix: No prod dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: No prod dependencies (#204)
+- build: Move to single-file builds for craft (#203)
 - fix(github): Revert retry on 404s (#199)
 - fix(gcs): Fix GCS artifact provider on Windows (#200)
 - feat(config): Use GitHub as default provider (#202)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "**/node-fetch": ">=2.6.1",
     "**/yargs-parser": ">=18.1.2"
   },
-  "dependencies": {
+  "devDependencies": {
     "@aws-sdk/client-ec2": "^3.2.0",
     "@aws-sdk/client-lambda": "^3.2.0",
     "@google-cloud/storage": "^5.7.0",
@@ -50,9 +50,7 @@
     "tar": "4.4.8",
     "tmp": "0.1.0",
     "unzipper": "0.9.7",
-    "yargs": "15.1.0"
-  },
-  "devDependencies": {
+    "yargs": "15.1.0",
     "@aws-sdk/types": "^3.1.0",
     "@sentry/typescript": "^5.17.0",
     "@types/async": "^3.0.1",


### PR DESCRIPTION
With the single-file builds now being used for npm package too, we do not have any non-dev dependencies. This PR fixes that so when you do `npm install craft` it doesn't download any dependencies, just craft
