### PR TITLE
feat: Add upm target

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,18 +943,18 @@ _none_
 
 **Configuration**
 
-| Option         | Description                             |
-| -------------- | --------------------------------------- |
-| `releaseOwner` | Name of the owner of the release target |
-| `releaseRepo`  | Name of the repo of the release target  |
+| Option             | Description                             |
+| ------------------ | --------------------------------------- |
+| `releaseRepoOwner` | Name of the owner of the release target |
+| `releaseRepoName`  | Name of the repo of the release target  |
 
 **Example**
 
 ```yaml
 targets:
   - name: upm
-    releaseOwner: 'getsentry'
-    releaseRepo: 'unity'
+    releaseRepoOwner: 'getsentry'
+    releaseRepoName: 'unity'
 ```
 
 ## Integrating Your Project with `craft`

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ then enforces a specific workflow for managing release branches, changelogs, art
   - [Docker (`docker`)](#docker-docker)
   - [Ruby Gems Index (`gem`)](#ruby-gems-index-gem)
   - [AWS Lambda Layer (`aws-lambda-layer`)](#aws-lambda-layer-aws-lambda-layer)
+  - [Unity Package Manager (`upm`)](#unity-package-manager-upm)
 - [Integrating Your Project with `craft`](#integrating-your-project-with-craft)
 - [Pre-release (Version-bumping) Script: Conventions](#pre-release-version-bumping-script-conventions)
 - [Post-release Script: Conventions](#post-release-script-conventions)
@@ -928,6 +929,32 @@ targets:
           - nodejs10.x
           - nodejs12.x
     license: MIT
+```
+
+### Unity Package Manager (`upm`)
+
+Pulls the package as a zipped artefact and pushes the unzipped content to the target repository, tagging it with the provided version.
+
+_WARNING!_ The destination repository will be completely overwritten.
+
+**Environment**
+
+_none_
+
+**Configuration**
+
+| Option         | Description                             |
+| -------------- | --------------------------------------- |
+| `releaseOwner` | Name of the owner of the release target |
+| `releaseRepo`  | Name of the repo of the release target  |
+
+**Example**
+
+```yaml
+targets:
+  - name: upm
+    releaseOwner: 'getsentry'
+    releaseRepo: 'unity'
 ```
 
 ## Integrating Your Project with `craft`

--- a/README.md
+++ b/README.md
@@ -933,7 +933,7 @@ targets:
 
 ### Unity Package Manager (`upm`)
 
-Pulls the package as a zipped artefact and pushes the unzipped content to the target repository, tagging it with the provided version.
+Pulls the package as a zipped artifact and pushes the unzipped content to the target repository, tagging it with the provided version.
 
 _WARNING!_ The destination repository will be completely overwritten.
 

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -6,16 +6,16 @@ jest.mock('fs');
 
 /** Returns a new UpmTarget test instance. */
 function getUpmTarget(): UpmTarget {
-    return new UpmTarget(
-      {
-        name: 'upm-test',
-        ['releaseOwner']: 'getsentry-test',
-        ['releaseRepo']: 'unity-test',
-      },
-      new NoneArtifactProvider(),
-      { owner: 'testSourceOwner', repo: 'testSourceRepo' }
-    );
-  }
+  return new UpmTarget(
+    {
+      name: 'upm-test',
+      ['releaseOwner']: 'getsentry-test',
+      ['releaseRepo']: 'unity-test',
+    },
+    new NoneArtifactProvider(),
+    { owner: 'testSourceOwner', repo: 'testSourceRepo' }
+  );
+}
 
 /** Returns a new UpmTarget test instance without configs. */
 function getUpmTargetWithoutConfig(): UpmTarget {
@@ -72,7 +72,7 @@ describe('UPM config parameters', () => {
   });
 
   test('success on config parameters', async () => {
-    getUpmTarget();      
+    getUpmTarget();
   });
 });
 
@@ -83,13 +83,11 @@ describe('publish', () => {
 
   test('error on missing artifact', async () => {
     const upmTarget = getUpmTarget();
-    upmTarget.getArtifactsForRevision = noArtifactsForRevision.bind(
-      UpmTarget
-    );
+    upmTarget.getArtifactsForRevision = noArtifactsForRevision.bind(UpmTarget);
 
-    expect(upmTarget.publish('version', 'revision'))
-      .rejects
-      .toThrowErrorMatchingInlineSnapshot();
+    expect(
+      upmTarget.publish('version', 'revision')
+    ).rejects.toThrowErrorMatchingInlineSnapshot();
 
     // try {
     //   const publishResult = await upmTarget.publish('version', 'revision');
@@ -98,7 +96,7 @@ describe('publish', () => {
     //   // expect(error instanceof Error).toBe(true);
     //   // const noPackagePattern = /No release artifact found/;
     //   // expect(noPackagePattern.test(error.message)).toBe(true);
-      
+
     // }
   });
 

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -31,7 +31,7 @@ describe('UPM Target', () => {
     test.each`
       artifacts             | error
       ${[]}                 | ${'Cannot publish UPM: No release artifact found.'}
-      ${['file1', 'file2']} | ${'Cannot publish UPM: Too many release artifacts found:file1\nfile2'}
+      ${['file1', 'file2']} | ${'Cannot publish UPM: Too many release artifacts found:\nfile1\nfile2'}
     `(
       'error with artifact count $artifacts.length',
       async ({ artifacts, error }) => {

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -1,0 +1,124 @@
+import { NoneArtifactProvider } from '../../artifact_providers/none';
+import { UpmTarget } from '../upm';
+import { ConfigurationError } from '../../utils/errors';
+
+jest.mock('fs');
+
+/** Returns a new UpmTarget test instance. */
+function getUpmTarget(): UpmTarget {
+    return new UpmTarget(
+      {
+        name: 'upm-test',
+        ['releaseOwner']: 'getsentry-test',
+        ['releaseRepo']: 'unity-test',
+      },
+      new NoneArtifactProvider(),
+      { owner: 'testSourceOwner', repo: 'testSourceRepo' }
+    );
+  }
+
+/** Returns a new UpmTarget test instance without configs. */
+function getUpmTargetWithoutConfig(): UpmTarget {
+  return new UpmTarget(
+    {
+      name: 'upm-test',
+    },
+    new NoneArtifactProvider(),
+    { owner: 'testSourceOwner', repo: 'testSourceRepo' }
+  );
+}
+
+describe('UPM evironment variables', () => {
+  const oldEnvVariables = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // Clear the cache.
+    process.env = { ...oldEnvVariables }; // Restore environment
+  });
+
+  afterAll(() => {
+    process.env = { ...oldEnvVariables }; // Restore environment
+  });
+
+  test('error on missing environment variables', async () => {
+    if ('GITHUB_TOKEN' in process.env) {
+      delete process.env.GITHUB_TOKEN;
+    }
+    try {
+      getUpmTarget();
+    } catch (error) {
+      expect(error instanceof ConfigurationError).toBe(true);
+      // const missingConfigPattern = /Missing environment variable/;
+      // expect(missingConfigPattern.test(error.message)).toBe(true);
+    }
+  });
+
+  test('success on environment variables', () => {
+    process.env.GITHUB_TOKEN = 'test github token';
+    process.env.GITHUB_API_TOKEN = 'test github api token';
+    getUpmTarget();
+  });
+});
+
+describe('UPM config parameters', () => {
+  test('error on missing config parameters', async () => {
+    try {
+      getUpmTargetWithoutConfig();
+    } catch (error) {
+      expect(error instanceof ConfigurationError).toBe(true);
+      // const missingConfigPattern = /Missing project configuration parameter/;
+      // expect(missingConfigPattern.test(error.message)).toBe(true);
+    }
+  });
+
+  test('success on config parameters', async () => {
+    getUpmTarget();      
+  });
+});
+
+describe('publish', () => {
+  const noArtifactsForRevision = jest.fn().mockImplementation(function () {
+    return [];
+  });
+
+  test('error on missing artifact', async () => {
+    const upmTarget = getUpmTarget();
+    upmTarget.getArtifactsForRevision = noArtifactsForRevision.bind(
+      UpmTarget
+    );
+
+    expect(upmTarget.publish('version', 'revision'))
+      .rejects
+      .toThrowErrorMatchingInlineSnapshot();
+
+    // try {
+    //   const publishResult = await upmTarget.publish('version', 'revision');
+    //   expect(publishResult).toBe(undefined);
+    // } catch (error) {
+    //   // expect(error instanceof Error).toBe(true);
+    //   // const noPackagePattern = /No release artifact found/;
+    //   // expect(noPackagePattern.test(error.message)).toBe(true);
+      
+    // }
+  });
+
+  const tooManyArtifactsForRevision = jest.fn().mockImplementation(function () {
+    return ['file1', 'file2'];
+  });
+
+  test('error on too many artifacts', async () => {
+    const upmTarget = getUpmTarget();
+    upmTarget.getArtifactsForRevision = tooManyArtifactsForRevision.bind(
+      UpmTarget
+    );
+
+    try {
+      const publishResult = await upmTarget.publish('version', 'revision');
+      expect(publishResult).toBe(undefined);
+    } catch (error) {
+      expect(error instanceof Error).toBe(true);
+      // const tooManyPackagesPattern = /Too many release artifacts found/;
+      // expect(tooManyPackagesPattern.test(error.message)).toBe(true);
+    }
+  });
+});

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -1,42 +1,66 @@
 import { NoneArtifactProvider } from '../../artifact_providers/none';
 import { UpmTarget } from '../upm';
 
-/** Returns a new UpmTarget test instance. */
-const getUpmTarget = () =>
-  new UpmTarget(
-    {
-      name: 'upm-test',
-      releaseOwner: 'getsentry-test',
-      releaseRepo: 'unity-test',
-    },
-    new NoneArtifactProvider(),
-    { owner: 'testSourceOwner', repo: 'testSourceRepo' }
-  );
-
-describe('artifacts', () => {
+describe('UPM Target', () => {
   const cleanEnv = { ...process.env };
+  let upmTarget: UpmTarget;
 
   beforeEach(() => {
     process.env = {
       ...cleanEnv,
       GITHUB_TOKEN: 'ghp_TAN21WJQkLtYVdHCh5eQJ8hTWoYvNh47gGWH',
+      DRY_RUN: '',
     };
     jest.resetAllMocks();
+
+    upmTarget = new UpmTarget(
+      {
+        name: 'upm-test',
+        releaseOwner: 'getsentry-test',
+        releaseRepo: 'unity-test',
+      },
+      new NoneArtifactProvider(),
+      { owner: 'testSourceOwner', repo: 'testSourceRepo' }
+    );
   });
 
-  test.each`
-    artifacts             | error
-    ${[]}                 | ${'Cannot publish UPM: No release artifact found.'}
-    ${['file1', 'file2']} | ${'Cannot publish UPM: Too many release artifacts found:file1\nfile2'}
-  `(
-    'error with artifact count $artifacts.length',
-    async ({ artifacts, error }) => {
-      const upmTarget = getUpmTarget();
-      upmTarget.getArtifactsForRevision = jest
-        .fn()
-        .mockReturnValueOnce(artifacts);
+  describe('artifacts', () => {
+    beforeEach(() => {
+      process.env.DRY_RUN = '';
+    });
+    test.each`
+      artifacts             | error
+      ${[]}                 | ${'Cannot publish UPM: No release artifact found.'}
+      ${['file1', 'file2']} | ${'Cannot publish UPM: Too many release artifacts found:file1\nfile2'}
+    `(
+      'error with artifact count $artifacts.length',
+      async ({ artifacts, error }) => {
+        upmTarget.getArtifactsForRevision = jest
+          .fn()
+          .mockResolvedValueOnce(artifacts);
 
-      expect(upmTarget.fetchArtifact('revision')).rejects.toThrow(error);
-    }
-  );
+        await expect(upmTarget.fetchArtifact('revision')).rejects.toThrow(
+          error
+        );
+      }
+    );
+  });
+
+  // TODO(byk): Add more tests for this
+  describe.skip('publish', () => {
+    beforeEach(() => {
+      upmTarget.fetchArtifact = jest
+        .fn()
+        .mockResolvedValueOnce({ filename: 'artifact.zip' });
+      upmTarget.artifactProvider.downloadArtifact = jest
+        .fn()
+        .mockResolvedValueOnce('some/test/path');
+    });
+
+    test('publish', () => {
+      return expect(
+        upmTarget.publish('version', 'revision')
+      ).resolves.not.toThrow();
+    });
+  });
 });

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -16,8 +16,8 @@ describe('UPM Target', () => {
     upmTarget = new UpmTarget(
       {
         name: 'upm-test',
-        releaseOwner: 'getsentry-test',
-        releaseRepo: 'unity-test',
+        releaseRepoOwner: 'getsentry-test',
+        releaseRepoName: 'unity-test',
       },
       new NoneArtifactProvider(),
       { owner: 'testSourceOwner', repo: 'testSourceRepo' }

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -1,122 +1,50 @@
 import { NoneArtifactProvider } from '../../artifact_providers/none';
 import { UpmTarget } from '../upm';
-import { ConfigurationError } from '../../utils/errors';
-
-jest.mock('fs');
 
 /** Returns a new UpmTarget test instance. */
-function getUpmTarget(): UpmTarget {
-  return new UpmTarget(
+const getUpmTarget = () =>
+  new UpmTarget(
     {
       name: 'upm-test',
-      ['releaseOwner']: 'getsentry-test',
-      ['releaseRepo']: 'unity-test',
+      releaseOwner: 'getsentry-test',
+      releaseRepo: 'unity-test',
     },
     new NoneArtifactProvider(),
     { owner: 'testSourceOwner', repo: 'testSourceRepo' }
   );
-}
-
-/** Returns a new UpmTarget test instance without configs. */
-function getUpmTargetWithoutConfig(): UpmTarget {
-  return new UpmTarget(
-    {
-      name: 'upm-test',
-    },
-    new NoneArtifactProvider(),
-    { owner: 'testSourceOwner', repo: 'testSourceRepo' }
-  );
-}
-
-describe('UPM evironment variables', () => {
-  const oldEnvVariables = process.env;
-
-  beforeEach(() => {
-    jest.resetModules(); // Clear the cache.
-    process.env = { ...oldEnvVariables }; // Restore environment
-  });
-
-  afterAll(() => {
-    process.env = { ...oldEnvVariables }; // Restore environment
-  });
-
-  test('error on missing environment variables', async () => {
-    if ('GITHUB_TOKEN' in process.env) {
-      delete process.env.GITHUB_TOKEN;
-    }
-    try {
-      getUpmTarget();
-    } catch (error) {
-      expect(error instanceof ConfigurationError).toBe(true);
-      // const missingConfigPattern = /Missing environment variable/;
-      // expect(missingConfigPattern.test(error.message)).toBe(true);
-    }
-  });
-
-  test('success on environment variables', () => {
-    process.env.GITHUB_TOKEN = 'test github token';
-    process.env.GITHUB_API_TOKEN = 'test github api token';
-    getUpmTarget();
-  });
-});
-
-describe('UPM config parameters', () => {
-  test('error on missing config parameters', async () => {
-    try {
-      getUpmTargetWithoutConfig();
-    } catch (error) {
-      expect(error instanceof ConfigurationError).toBe(true);
-      // const missingConfigPattern = /Missing project configuration parameter/;
-      // expect(missingConfigPattern.test(error.message)).toBe(true);
-    }
-  });
-
-  test('success on config parameters', async () => {
-    getUpmTarget();
-  });
-});
 
 describe('publish', () => {
-  const noArtifactsForRevision = jest.fn().mockImplementation(function () {
-    return [];
+  const cleanEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = {
+      ...cleanEnv,
+      GITHUB_TOKEN: 'ghp_TAN21WJQkLtYVdHCh5eQJ8hTWoYvNh47gGWH',
+    };
+    jest.resetAllMocks();
   });
 
   test('error on missing artifact', async () => {
     const upmTarget = getUpmTarget();
-    upmTarget.getArtifactsForRevision = noArtifactsForRevision.bind(UpmTarget);
+    upmTarget.getArtifactsForRevision = jest.fn().mockReturnValueOnce([]);
 
     expect(
       upmTarget.publish('version', 'revision')
-    ).rejects.toThrowErrorMatchingInlineSnapshot();
-
-    // try {
-    //   const publishResult = await upmTarget.publish('version', 'revision');
-    //   expect(publishResult).toBe(undefined);
-    // } catch (error) {
-    //   // expect(error instanceof Error).toBe(true);
-    //   // const noPackagePattern = /No release artifact found/;
-    //   // expect(noPackagePattern.test(error.message)).toBe(true);
-
-    // }
-  });
-
-  const tooManyArtifactsForRevision = jest.fn().mockImplementation(function () {
-    return ['file1', 'file2'];
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Cannot publish UPM: No release artifact found."`
+    );
   });
 
   test('error on too many artifacts', async () => {
     const upmTarget = getUpmTarget();
-    upmTarget.getArtifactsForRevision = tooManyArtifactsForRevision.bind(
-      UpmTarget
-    );
+    upmTarget.getArtifactsForRevision = jest
+      .fn()
+      .mockReturnValueOnce(['file1', 'file2']);
 
-    try {
-      const publishResult = await upmTarget.publish('version', 'revision');
-      expect(publishResult).toBe(undefined);
-    } catch (error) {
-      expect(error instanceof Error).toBe(true);
-      // const tooManyPackagesPattern = /Too many release artifacts found/;
-      // expect(tooManyPackagesPattern.test(error.message)).toBe(true);
-    }
+    expect(upmTarget.publish('version', 'revision')).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Cannot publish UPM: Too many release artifacts found:file1
+      file2"
+    `);
   });
 });

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -36,7 +36,7 @@ describe('artifacts', () => {
         .fn()
         .mockReturnValueOnce(artifacts);
 
-      expect(upmTarget.publish('version', 'revision')).rejects.toThrow(error);
+      expect(upmTarget.fetchArtifact('revision')).rejects.toThrow(error);
     }
   );
 });

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -9,7 +9,7 @@ describe('UPM Target', () => {
     process.env = {
       ...cleanEnv,
       GITHUB_TOKEN: 'ghp_TAN21WJQkLtYVdHCh5eQJ8hTWoYvNh47gGWH',
-      DRY_RUN: '',
+      DRY_RUN: 'false',
     };
     jest.resetAllMocks();
 
@@ -26,7 +26,7 @@ describe('UPM Target', () => {
 
   describe('artifacts', () => {
     beforeEach(() => {
-      process.env.DRY_RUN = '';
+      process.env.DRY_RUN = 'false';
     });
     test.each`
       artifacts             | error

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -149,12 +149,13 @@ export class GithubTarget extends BaseTarget {
   /**
    * Gets an existing or creates a new release for the given version
    *
-   * The release name and description body is loaded from CHANGELOG.md in the
+   * The release name and description body is brought in from `changes`
    * respective tag, if present. Otherwise, the release name defaults to the
    * tag and the body to the commit it points to.
    *
    * @param version The version to release
    * @param revision Git commit SHA to be published
+   * @param changes The changeset information for this release
    * @returns The newly created release
    */
   public async getOrCreateRelease(

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -185,9 +185,9 @@ export class GithubTarget extends BaseTarget {
     const createReleaseParams = {
       draft: false,
       name: tag,
-      owner: this.githubRepo.owner,
+      owner: this.githubConfig.owner,
       prerelease: isPreview,
-      repo: this.githubRepo.repo,
+      repo: this.githubConfig.repo,
       tag_name: tag,
       target_commitish: revision,
       ...changes,

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -5,7 +5,11 @@ import { basename } from 'path';
 import { getConfiguration } from '../config';
 import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
-import { DEFAULT_CHANGELOG_PATH, findChangeset } from '../utils/changes';
+import {
+  Changeset,
+  DEFAULT_CHANGELOG_PATH,
+  findChangeset,
+} from '../utils/changes';
 import {
   getFile,
   getGithubClient,
@@ -67,6 +71,8 @@ export class GithubTarget extends BaseTarget {
   public readonly githubConfig: GithubTargetConfig;
   /** Github client */
   public readonly github: Github;
+  /** Github repo configuration */
+  public readonly githubRepo: GithubGlobalConfig;
 
   public constructor(
     config: TargetConfig,
@@ -74,11 +80,16 @@ export class GithubTarget extends BaseTarget {
     githubRepo: GithubGlobalConfig
   ) {
     super(config, artifactProvider, githubRepo);
+    this.githubRepo = githubRepo;
+    const owner = config.owner || githubRepo.owner;
+    const repo = config.repo || githubRepo.repo;
+
     this.githubConfig = {
-      ...githubRepo,
+      owner,
+      repo,
       annotatedTag:
         this.config.annotatedTag === undefined || !!this.config.annotatedTag,
-      changelog: getConfiguration().changelog || '',
+      changelog: getConfiguration().changelog || DEFAULT_CHANGELOG_PATH,
       previewReleases:
         this.config.previewReleases === undefined ||
         !!this.config.previewReleases,
@@ -148,7 +159,8 @@ export class GithubTarget extends BaseTarget {
    */
   public async getOrCreateRelease(
     version: string,
-    revision: string
+    revision: string,
+    changes?: Changeset
   ): Promise<GithubRelease> {
     const tag = versionToTag(version, this.githubConfig.tagPrefix);
     logger.info(`Git tag: "${tag}"`);
@@ -170,23 +182,12 @@ export class GithubTarget extends BaseTarget {
       logger.debug(`Release for tag "${tag}" not found.`);
     }
 
-    // Release hasn't been found, so create one
-    const changelog = await getFile(
-      this.github,
-      this.githubConfig.owner,
-      this.githubConfig.repo,
-      this.githubConfig.changelog || DEFAULT_CHANGELOG_PATH,
-      revision
-    );
-    const changes = (changelog && findChangeset(changelog, tag)) || {};
-    logger.debug('Changes extracted from changelog: ', JSON.stringify(changes));
-
     const createReleaseParams = {
       draft: false,
       name: tag,
-      owner: this.githubConfig.owner,
+      owner: this.githubRepo.owner,
       prerelease: isPreview,
-      repo: this.githubConfig.repo,
+      repo: this.githubRepo.repo,
       tag_name: tag,
       target_commitish: revision,
       ...changes,
@@ -217,6 +218,25 @@ export class GithubTarget extends BaseTarget {
         upload_url: '',
       };
     }
+  }
+
+  public async getRevisionChanges(
+    version: string,
+    revision: string
+  ): Promise<Changeset> {
+    const changelog = await getFile(
+      this.github,
+      this.githubRepo.owner,
+      this.githubRepo.repo,
+      this.githubConfig.changelog,
+      revision
+    );
+    const changes = (changelog && findChangeset(changelog, version)) || {
+      name: version,
+      body: '',
+    };
+    logger.debug('Changes extracted from changelog: ', JSON.stringify(changes));
+    return changes;
   }
 
   /**
@@ -360,9 +380,8 @@ export class GithubTarget extends BaseTarget {
    * @param revision Git commit SHA to be published
    */
   public async publish(version: string, revision: string): Promise<any> {
-    logger.info(`Target "${this.name}": publishing version "${version}"...`);
-    logger.debug(`Revision: ${revision}`);
-    const release = await this.getOrCreateRelease(version, revision);
+    const changes = await this.getRevisionChanges(version, revision);
+    const release = await this.getOrCreateRelease(version, revision, changes);
 
     if (isDryRun()) {
       logger.info(

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -13,6 +13,7 @@ import { NugetTarget } from './nuget';
 import { PypiTarget } from './pypi';
 import { RegistryTarget } from './registry';
 import { AwsLambdaLayerTarget } from './awsLambdaLayer';
+import { UpmTarget } from './upm';
 
 export const TARGET_MAP: { [key: string]: typeof BaseTarget } = {
   brew: BrewTarget,
@@ -28,6 +29,7 @@ export const TARGET_MAP: { [key: string]: typeof BaseTarget } = {
   pypi: PypiTarget,
   registry: RegistryTarget,
   'aws-lambda-layer': AwsLambdaLayerTarget,
+  upm: UpmTarget,
 };
 
 /** Targets that are treated specially */

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -50,17 +50,20 @@ export class UpmTarget extends BaseTarget {
   }
 
   protected getGithubTargetConfig(): TargetConfig {
-    if(!process.env.GITHUB_TOKEN) {
-      throw new ConfigurationError('Missing environment variable '
-        + 'GITHUB_TOKEN');
+    if (!process.env.GITHUB_TOKEN) {
+      throw new ConfigurationError(
+        'Missing environment variable ' + 'GITHUB_TOKEN'
+      );
     }
     if (!('releaseOwner' in this.config)) {
-      throw new ConfigurationError('Missing project configuration parameter '
-       + 'releaseOwner');
+      throw new ConfigurationError(
+        'Missing project configuration parameter ' + 'releaseOwner'
+      );
     }
     if (!('releaseRepo' in this.config)) {
-      throw new ConfigurationError('Missing project configuration parameter '
-       + 'releaseRepo');
+      throw new ConfigurationError(
+        'Missing project configuration parameter ' + 'releaseRepo'
+      );
     }
 
     return {
@@ -70,7 +73,7 @@ export class UpmTarget extends BaseTarget {
       annotatedTag: true,
       owner: this.config.releaseOwner,
       repo: this.config.releaseRepo,
-    }
+    };
   }
 
   /**

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -76,7 +76,7 @@ export class UpmTarget extends BaseTarget {
     }
     if (packageFiles.length > 1) {
       reportError(
-        `Cannot publish UPM: Too many release artifacts found:${packageFiles.join(
+        `Cannot publish UPM: Too many release artifacts found:\n${packageFiles.join(
           '\n'
         )}`
       );

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -66,7 +66,7 @@ export class UpmTarget extends BaseTarget {
    * @returns The requested artifact, undefined of no or multiple artifacts
    * have been found.
    */
-  protected async fetchArtifact(
+  public async fetchArtifact(
     revision: string
   ): Promise<RemoteArtifact | undefined> {
     const packageFiles = await this.getArtifactsForRevision(revision);

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -62,9 +62,10 @@ export class UpmTarget extends BaseTarget {
   /**
    * Fetches the artifact for the provided revision.
    *
-   * @param revision Git commit SHA for the to be published artifact.
-   * @returns The requested artifact, undefined of no or multiple artifacts
-   * have been found.
+   * @param revision Git commit SHA for the artifact to be published.
+   * @returns The requested artifact. When no artifacts found or multiple
+   *          artifacts have been found, returns undefined in dry-run mode and
+   *          throws an exception in "normal" mode.
    */
   public async fetchArtifact(
     revision: string

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -111,15 +111,13 @@ export class UpmTarget extends BaseTarget {
       username,
       getGithubApiToken()
     );
-    logger.debug(
-      `Target release repository: ` +
-        `"${this.config.releaseTarget.getRemoteString}"`
-    );
+    const remoteAddr = remote.getRemoteString();
+    logger.debug(`Target release repository: ` + `"${remoteAddr}"`);
 
     await withTempDir(
       async directory => {
         const git = simpleGit(directory);
-        logger.info(`Cloning ${remote.getRemoteString()} to ${directory}...`);
+        logger.info(`Cloning ${remoteAddr} to ${directory}...`);
         await git.clone(remote.getRemoteStringWithAuth(), directory);
 
         logger.info('Clearing the repository.');

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -1,0 +1,156 @@
+import * as Github from '@octokit/rest';
+import simpleGit from 'simple-git';
+import {
+  getAuthUsername,
+  getGithubApiToken,
+  getGithubClient,
+  GithubRemote,
+} from '../utils/githubApi';
+
+import { GithubTarget } from './github';
+import { logger as loggerRaw } from '../logger';
+import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
+import { BaseTarget } from './base';
+import {
+  BaseArtifactProvider,
+  RemoteArtifact,
+} from '../artifact_providers/base';
+import { reportError } from '../utils/errors';
+import { extractZipArchive } from '../utils/system';
+import { withTempDir } from '../utils/files';
+import { isDryRun } from '../utils/helpers';
+import { NoneArtifactProvider } from '../artifact_providers/none';
+
+const logger = loggerRaw.withScope('[upm]');
+
+/**
+ * Target responsible for publishing to upm registry
+ */
+export class UpmTarget extends BaseTarget {
+  /** Target name */
+  public readonly name: string = 'upm';
+  /** Github client */
+  public readonly github: Github;
+  /** Internal GitHub Target */
+  private readonly githubTarget: GithubTarget;
+
+  public constructor(
+    config: TargetConfig,
+    artifactProvider: BaseArtifactProvider,
+    githubRepo: GithubGlobalConfig
+  ) {
+    super(config, artifactProvider, githubRepo);
+
+    this.github = getGithubClient();
+
+    const githubTargetConfig = {
+      name: 'github',
+      tagPrefix: config.tagPrefix,
+      previewReleases: false,
+      annotatedTag: true,
+      owner: config.releaseOwner,
+      repo: config.releaseRepo,
+    };
+
+    this.githubTarget = new GithubTarget(
+      githubTargetConfig,
+      new NoneArtifactProvider(),
+      githubRepo
+    );
+  }
+
+  /**
+   * Fetches the artifact for the provided revision.
+   *
+   * @param revision Git commit SHA for the to be published artifact.
+   * @returns The requested artifact, undefined of no or multiple artifacts
+   * have been found.
+   */
+  protected async fetchArtifact(
+    revision: string
+  ): Promise<RemoteArtifact | undefined> {
+    const packageFiles = await this.getArtifactsForRevision(revision);
+    if (packageFiles.length === 0) {
+      reportError('Cannot publish UPM: No release artifact found.');
+      return;
+    }
+    if (packageFiles.length > 1) {
+      reportError(
+        `Cannot publish UPM: Too many release artifacts found:${packageFiles.join(
+          '\n'
+        )}`
+      );
+      return;
+    }
+
+    return packageFiles[0];
+  }
+
+  /**
+   * Performs a release to upm
+   *
+   * @param version New version to be released
+   * @param revision Git commit SHA to be published
+   */
+  public async publish(version: string, revision: string): Promise<any> {
+    logger.info('Fetching artifact...');
+    const packageFile = await this.fetchArtifact(revision);
+    if (!packageFile) {
+      return;
+    }
+
+    logger.info(`Found artifact: "${packageFile.filename}", downloading...`);
+    const artifactPath = await this.artifactProvider.downloadArtifact(
+      packageFile
+    );
+
+    const username = await getAuthUsername(this.github);
+    const remote = new GithubRemote(
+      this.config.relaeseOwner,
+      this.config.releaseRepo,
+      username,
+      getGithubApiToken()
+    );
+    logger.debug(
+      `Target release repository: ` +
+        `"${this.config.releaseTarget.getRemoteString}"`
+    );
+
+    await withTempDir(
+      async directory => {
+        const git = simpleGit(directory);
+        logger.info(`Cloning ${remote.getRemoteString()} to ${directory}...`);
+        await git.clone(remote.getRemoteStringWithAuth(), directory);
+
+        logger.info('Clearing the repository.');
+        await git.rm(['-r', '-f', '.']);
+
+        logger.info(`Extracting "${packageFile.filename}".`);
+        await extractZipArchive(artifactPath, directory);
+
+        logger.info('Adding files to repository.');
+        await git.add(['.']);
+        const targetRevision = (await git.commit(`release ${version}`)).commit;
+
+        if (isDryRun()) {
+          logger.info('[dry-run]: git push origin main');
+        } else {
+          await git.push(['origin', 'main']);
+          const changes = await this.githubTarget.getRevisionChanges(
+            version,
+            revision
+          );
+          await this.githubTarget.getOrCreateRelease(
+            version,
+            targetRevision,
+            changes
+          );
+        }
+      },
+      true,
+      '_craft-release-upm-'
+    );
+
+    logger.info('UPM release complete');
+  }
+}

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -106,7 +106,7 @@ export class UpmTarget extends BaseTarget {
 
     const username = await getAuthUsername(this.github);
     const remote = new GithubRemote(
-      this.config.relaeseOwner,
+      this.config.releaseOwner,
       this.config.releaseRepo,
       username,
       getGithubApiToken()

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -48,8 +48,8 @@ export class UpmTarget extends BaseTarget {
       tagPrefix: config.tagPrefix,
       previewReleases: false,
       annotatedTag: true,
-      owner: config.releaseOwner,
-      repo: config.releaseRepo,
+      owner: config.releaseRepoOwner,
+      repo: config.releaseRepoName,
     };
 
     this.githubTarget = new GithubTarget(
@@ -106,8 +106,8 @@ export class UpmTarget extends BaseTarget {
 
     const username = await getAuthUsername(this.github);
     const remote = new GithubRemote(
-      this.config.releaseOwner,
-      this.config.releaseRepo,
+      this.config.releaseRepoOwner,
+      this.config.releaseRepoName,
       username,
       getGithubApiToken()
     );

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -130,6 +130,11 @@ export class UpmTarget extends BaseTarget {
         logger.info('Adding files to repository.');
         await git.add(['.']);
         const commitResult = await git.commit(`release ${version}`);
+        if (!commitResult.commit) {
+          throw new Error(
+            'Commit on target repository failed. Maybe there were no changes at all?'
+          );
+        }
         const targetRevision = await git.revparse([commitResult.commit]);
 
         if (isDryRun()) {

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -128,7 +128,8 @@ export class UpmTarget extends BaseTarget {
 
         logger.info('Adding files to repository.');
         await git.add(['.']);
-        const targetRevision = (await git.commit(`release ${version}`)).commit;
+        const commitResult = await git.commit(`release ${version}`);
+        const targetRevision = await git.revparse([commitResult.commit]);
 
         if (isDryRun()) {
           logger.info('[dry-run]: git push origin main');

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -15,7 +15,7 @@ import {
   BaseArtifactProvider,
   RemoteArtifact,
 } from '../artifact_providers/base';
-import { reportError } from '../utils/errors';
+import { ConfigurationError, reportError } from '../utils/errors';
 import { extractZipArchive } from '../utils/system';
 import { withTempDir } from '../utils/files';
 import { isDryRun } from '../utils/helpers';
@@ -40,23 +40,37 @@ export class UpmTarget extends BaseTarget {
     githubRepo: GithubGlobalConfig
   ) {
     super(config, artifactProvider, githubRepo);
-
     this.github = getGithubClient();
 
-    const githubTargetConfig = {
-      name: 'github',
-      tagPrefix: config.tagPrefix,
-      previewReleases: false,
-      annotatedTag: true,
-      owner: config.releaseOwner,
-      repo: config.releaseRepo,
-    };
-
     this.githubTarget = new GithubTarget(
-      githubTargetConfig,
+      this.getGithubTargetConfig(),
       new NoneArtifactProvider(),
       githubRepo
     );
+  }
+
+  protected getGithubTargetConfig(): TargetConfig {
+    if(!process.env.GITHUB_TOKEN) {
+      throw new ConfigurationError('Missing environment variable '
+        + 'GITHUB_TOKEN');
+    }
+    if (!('releaseOwner' in this.config)) {
+      throw new ConfigurationError('Missing project configuration parameter '
+       + 'releaseOwner');
+    }
+    if (!('releaseRepo' in this.config)) {
+      throw new ConfigurationError('Missing project configuration parameter '
+       + 'releaseRepo');
+    }
+
+    return {
+      name: 'github',
+      tagPrefix: this.config.tagPrefix,
+      previewReleases: false,
+      annotatedTag: true,
+      owner: this.config.releaseOwner,
+      repo: this.config.releaseRepo,
+    }
   }
 
   /**
@@ -71,7 +85,7 @@ export class UpmTarget extends BaseTarget {
   ): Promise<RemoteArtifact | undefined> {
     const packageFiles = await this.getArtifactsForRevision(revision);
     if (packageFiles.length === 0) {
-      reportError('Cannot publish UPM: No release artifact found.');
+      reportError('Cannot publish UPM: No release artifact found');
       return;
     }
     if (packageFiles.length > 1) {
@@ -96,7 +110,7 @@ export class UpmTarget extends BaseTarget {
     logger.info('Fetching artifact...');
     const packageFile = await this.fetchArtifact(revision);
     if (!packageFile) {
-      return;
+      return undefined;
     }
 
     logger.info(`Found artifact: "${packageFile.filename}", downloading...`);


### PR DESCRIPTION
Unity SDK works in two repositories:

https://github.com/getsentry/sentry-unity <- SDK
https://github.com/getsentry/unity <- release repo for the user
Unity users add our package by providing a git URL to their package manager. Versioning and potential rollbacks for them are made available via tags (i.e. https://github.com/getsentry/unity.git#x.x.x).

Release steps:

1. Get the prepared artifact (a single .zip containing the package)
2. Pull the release repository
3. Replace everything in that repo with the contents of the .zip
4. Update tag & push