### PR TITLE
build: Fix and simplify jest and TS configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- build: Fix and simplify jest and TS configs (#210)
+
 ## 0.21.1
 
 - fix: Upgrade simple-git to latest version (#207)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,6 @@
 module.exports = {
-  collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts'],
-  transform: { '^.+\\.ts$': 'ts-jest' },
-  moduleFileExtensions: ['js', 'ts', 'json'],
+  preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/*.test.ts'],
-  globals: {
-    'ts-jest': {
-      tsConfig: './tsconfig.json',
-    },
-  },
+  testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
 };

--- a/src/utils/__tests__/strings.test.ts
+++ b/src/utils/__tests__/strings.test.ts
@@ -14,7 +14,7 @@ describe('sanitizeObject', () => {
     function expectRaisesError(value: any): void {
       try {
         sanitizeObject(value);
-        throw new Error(`Should fail for canonical name: ${name}`);
+        throw new Error(`Should fail for canonical name: ${value}`);
       } catch (e) {
         expect(e.message).toMatch(/cannot normalize/i);
       }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,15 +1,25 @@
 {
   "extends": "@sentry/typescript/tsconfig.json",
   "compilerOptions": {
-    "target": "es2017",
+    "lib": [
+      "es2018"
+    ],
+    "target": "es2018",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "src",
     "types": ["node"],
     "noImplicitThis": false,
     "esModuleInterop": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "noEmitHelpers": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["**/__mocks__/**", "**/__tests__/**"]
+  "exclude": [
+    "dist/**/*",
+    "**/__mocks__/**",
+    "**/__tests__/**"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,15 @@
 {
   "extends": "./tsconfig.build.json",
-  "include": ["src/**/*.ts"],
   "compilerOptions": {
-    "rootDir": ".",
     "types": ["node", "jest"],
     "plugins": []
-  }
+  },
+  "include": [
+    "src/**/*.ts",
+    "**/__mocks__/**/*.ts",
+    "**/__tests_/**/*.ts"
+  ],
+  "exclude": [
+    "dist/**/*"
+  ]
 }


### PR DESCRIPTION
Our Jest and TS configs were a bit convoluted and since our TS config was based off of a web-based base config, it was building for browsers and was shipping/adding DOM-related things into our builds. This even uncovered a bug in our tests which is fixed with this patch.
