### PR TITLE
ci: Fix our build matrix, add Node 14 & 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['10', '12']
+        node: ['10', '12', '14', '16']
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '${{ matrix.node }}'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -32,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: volta-cli/action@v1
       - uses: actions/cache@v2
         id: cache
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ci: Fix our build matrix, add Node 14 & 16 (#211)
+
 ## 0.21.1
 
 - fix: Upgrade simple-git to latest version (#207)

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "compile-config-schema": "node ./scripts/config-json-schema-to-ts.js"
   },
   "volta": {
-    "node": "12.17.0",
-    "yarn": "1.22.4"
+    "node": "12.22.1",
+    "yarn": "1.22.10"
   }
 }


### PR DESCRIPTION
We were not setting the node version on CI build matrix which means we were just testing everything with Node 12 but twice. This patch fixes that, adds Node 14 & 16 to the build matrix, switches our artifact builds to be on the 'blessed' Node and Yarn versions defined in our package.json `volta` config, and bumps Yarn and Node to their latest versions without breaking changes.
