### PR TITLE
feat: Add projectPath config option to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+- feat(config): Automatically detect GitHub config when missing (#208)
+- feat: Add upm target (#209)
 - ci: Fix our build matrix, add Node 14 & 16 (#211)
 - build: Fix and simplify jest and TS configs (#210)
 - upgrade(ts-jest): Upgrade ts-jest to latest version (#212)
+- feat: Add projectPath config option to GitHub (#220)
+- feat: Add config CLI command (#221)
 
 ## 0.21.1
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ github:
 ```
 
 If you are using Craft in a monorepo where each project has their own `.craft.yml`
-configuration, you need o set the `github` information with the inclusion of
+configuration, you need to set the `github` information with the inclusion of
 `projectPath`. Although Craft can infer the relative path of your project, it
 cannot do this on sparse checkouts or when `.git` directory does not exist:
 

--- a/README.md
+++ b/README.md
@@ -242,13 +242,31 @@ located in the project root.
 
 ### GitHub project
 
-One of the required settings you need to specify is GitHub project parameters. For example:
+Craft tries to determine the GitHub repo information from the local git repo and
+its remotes configuration. However, since `publish` command does not require a
+local git checkout, you may want to hard-code this information into the
+configuration itself:
 
 ```yaml
 github:
   owner: getsentry
   repo: sentry-javascript
 ```
+
+If you are using Craft in a monorepo where each project has their own `.craft.yml`
+configuration, you need o set the `github` information with the inclusion of
+`projectPath`. Although Craft can infer the relative path of your project, it
+cannot do this on sparse checkouts or when `.git` directory does not exist:
+
+```yaml
+github:
+  owner: getsentry
+  repo: sentry-ruby
+  projectPath: sentry-rails
+```
+
+This is used to determine the repo-relative location of the changelog in your
+project.
 
 ### Pre-release Command
 

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -19,6 +19,9 @@ const projectConfigJsonSchema = {
         repo: {
           type: 'string',
         },
+        projectPath: {
+          type: 'string',
+        },
       },
       additionalProperties: false,
       required: ['owner', 'repo'],

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -26,6 +26,7 @@ export interface CraftProjectConfig {
 export interface GithubGlobalConfig {
   owner: string;
   repo: string;
+  projectPath?: string;
 }
 /**
  * Generic target configuration

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -1,6 +1,6 @@
 import * as Github from '@octokit/rest';
 import { createReadStream, statSync } from 'fs';
-import { basename } from 'path';
+import { basename, posix } from 'path';
 
 import { getConfiguration } from '../config';
 import { logger as loggerRaw } from '../logger';
@@ -83,13 +83,18 @@ export class GithubTarget extends BaseTarget {
     this.githubRepo = githubRepo;
     const owner = config.owner || githubRepo.owner;
     const repo = config.repo || githubRepo.repo;
+    const projectPath = githubRepo.projectPath || '.';
+    const changelogPath =
+      getConfiguration().changelog || DEFAULT_CHANGELOG_PATH;
+
+    const changelog = posix.join(projectPath, changelogPath);
 
     this.githubConfig = {
       owner,
       repo,
+      changelog,
       annotatedTag:
         this.config.annotatedTag === undefined || !!this.config.annotatedTag,
-      changelog: getConfiguration().changelog || DEFAULT_CHANGELOG_PATH,
       previewReleases:
         this.config.previewReleases === undefined ||
         !!this.config.previewReleases,


### PR DESCRIPTION
In monorepos like getsentry/sentry-ruby, Craft cannot determine and fetch the remote changelog because it assumes `.craft.yml` is always at git root. This patch adds this optional config and automatically fills it when a `.git` root is found so we can have changelogs in monorepos.

This is to fix https://github.com/getsentry/sentry-ruby/pull/1435#issuecomment-834465195
