### PR TITLE
feat: Add config CLI command

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,7 +1,4 @@
 minVersion: '0.21.0'
-github:
-  owner: getsentry
-  repo: craft
 changelogPolicy: auto
 requireNames:
   - /^sentry-craft.*\.tgz$/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
   # Smoke tests
   - name: 'us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA'
     args:
-      - '--help'
+      - 'config'
     timeout: 60s
   - name: 'gcr.io/cloud-builders/docker'
     secretEnv: ['DOCKER_PASSWORD']

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,14 @@
+import { getConfiguration, getGlobalGithubConfig } from '../config';
+import { formatJson } from '../utils/strings';
+
+export const command = ['config'];
+export const description = 'List defined targets as JSON array';
+
+export async function handler(): Promise<void> {
+  const github = await getGlobalGithubConfig();
+  const config = {
+    ...getConfiguration(),
+    github,
+  };
+  console.log(formatJson(config));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { getPackageVersion } from './utils/version';
 import * as prepare from './commands/prepare';
 import * as publish from './commands/publish';
 import * as targets from './commands/targets';
+import * as config from './commands/config';
 import * as artifacts from './commands/artifacts';
 
 /**
@@ -74,6 +75,7 @@ function main(): void {
     .command(prepare)
     .command(publish)
     .command(targets)
+    .command(config)
     .command(artifacts)
     .demandCommand()
     .version()


### PR DESCRIPTION
This command allows us to print the interpreted & validated config in pretty JSON format both for validation and consuming the Craft config.
