### PR TITLE
fix(github-artifacts): Allow multiple artifacts on the SHA, use latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - feat: Add config CLI command (#221)
 - feat(prepare): Add rev option to base a release on (#223)
 - ref: Unify global flags (#224)
+- fix(github-artifacts): Allow multiple artifacts on the SHA, use latest (#226)
 
 ## 0.21.1
 

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -97,7 +97,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
 
     // We need to find the most recent archive where name matches the revision.
     const foundArtifact = allArtifacts.reduce((result, artifact) =>
-      artifact.name === revision && result?.created_at < artifact.created_at
+      artifact.name === revision && result.created_at < artifact.created_at
         ? artifact
         : result
     );

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -95,7 +95,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
 
     const allArtifacts = artifactResponse.artifacts;
 
-    // We need to find the most recent archive where name maches the revision
+    // We need to find the most recent archive where name matches the revision.
     const foundArtifact = allArtifacts.reduce((result, artifact) =>
       artifact.name === revision && result?.created_at < artifact.created_at
         ? artifact

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -137,7 +137,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
       // Zeus may know about a commit (from its role as a status provider) but
       // not have any files associated with that commit. In the former case
       // (known commit, no files), Zeus will return an empty list, whereas in
-      // the latter case(unknown commit), it will error.
+      // the latter case (unknown commit), it will error.
       // This error message check and the length check below are to disambiguate
       // those two situations.
       const errorMessage: string = e.message || '';
@@ -153,7 +153,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
     }
 
     // Zeus stores multiple copies of the same file for a given revision,
-    // take the one with the most recent update time
+    // take the one with the most recent update time.
     return Object.values(
       zeusArtifacts.reduce((dict, artifact) => {
         const updatedAt = Date.parse(artifact.updated_at ?? '') || 0;

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -134,14 +134,12 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
         revision
       );
     } catch (e) {
-      // zeus is the only artifact provider which could know about a commit
-      // (from its role as a status provider) but not have any files associated
-      // with that commit. (For all other artifact providers, not knowing about
-      // the commit and having no files associated with the commit are one and
-      // the same.) In the former case (known commit, no files), zeus will
-      // return an empty list, whereas in the latter case (unknown commit), it
-      // will error. This error message check and the length check below are
-      // here to disambiguate those two situations.
+      // Zeus may know about a commit (from its role as a status provider) but
+      // not have any files associated with that commit. In the former case
+      // (known commit, no files), Zeus will return an empty list, whereas in
+      // the latter case(unknown commit), it will error.
+      // This error message check and the length check below are to disambiguate
+      // those two situations.
       const errorMessage: string = e.message || '';
       if (errorMessage.match(/404 not found|resource not found/i)) {
         logger.debug(`Revision \`${revision}\` not found!`);
@@ -154,12 +152,8 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
       logger.debug(`Revision \`${revision}\` found.`);
     }
 
-    // similarly, zeus is the only artifact provider which will store multiple
-    // copies of the same file for a given revision, so to mimic the behavior of
-    // the other providers (which overwrite pre-existing, identically-named
-    // files within the same commit), for each filename, take the one with the
-    // most recent update time
-
+    // Zeus stores multiple copies of the same file for a given revision,
+    // take the one with the most recent update time
     return Object.values(
       zeusArtifacts.reduce((dict, artifact) => {
         const updatedAt = Date.parse(artifact.updated_at ?? '') || 0;


### PR DESCRIPTION
For some reason we did not allow more than one artifact tied to a commit SHA (which may happen with branches etc). Now we allow this and pick the most recent one.
