### PR TITLE
fix(debug): Fix mangled provider names on debug/info logging

### DIFF
--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -89,6 +89,7 @@ export interface ArtifactProviderConfig {
  * Base interface for artifact providers.
  */
 export abstract class BaseArtifactProvider {
+  public abstract readonly name: string;
   /** Cache for local paths to downloaded files */
   protected readonly downloadCache: {
     [key: string]: Promise<string> | undefined;

--- a/src/artifact_providers/gcs.ts
+++ b/src/artifact_providers/gcs.ts
@@ -18,6 +18,7 @@ export interface GCSArtifactProviderConfig extends ArtifactProviderConfig {
  * Google Cloud Storage artifact provider
  */
 export class GCSArtifactProvider extends BaseArtifactProvider {
+  public readonly name = 'gcs';
   /** Client for interacting with the GCS bucket */
   private readonly gcsClient: CraftGCSClient;
 

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -45,6 +45,7 @@ interface ArchiveResponse extends Github.AnyResponse {
  * Github artifact provider
  */
 export class GithubArtifactProvider extends BaseArtifactProvider {
+  public readonly name = 'github';
   /** Github client */
   public readonly github: Github;
 

--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -8,6 +8,7 @@ import {
  * Empty artifact provider that does nothing.
  */
 export class NoneArtifactProvider extends BaseArtifactProvider {
+  public readonly name = 'none';
   public constructor(
     config: ArtifactProviderConfig = { repoName: 'none', repoOwner: 'none' }
   ) {

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -23,6 +23,7 @@ const logger = loggerRaw.withScope(`[artifact-provider/zeus]`);
  * line tool.
  */
 export class ZeusArtifactProvider extends BaseArtifactProvider {
+  public readonly name = 'zeus';
   /** Zeus API client */
   public readonly client: ZeusClient;
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -464,8 +464,8 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
 
   const statusProvider = await getStatusProviderFromConfig();
   const artifactProvider = await getArtifactProviderFromConfig();
-  logger.debug(`Using "${statusProvider.constructor.name}" for status checks`);
-  logger.debug(`Using "${artifactProvider.constructor.name}" for artifacts`);
+  logger.debug(`Using "${statusProvider.name}" for status checks`);
+  logger.debug(`Using "${artifactProvider.name}" for artifacts`);
 
   // Check status of all CI builds linked to the revision
   await checkRevisionStatus(statusProvider, revision, argv.noStatusCheck);

--- a/src/status_providers/base.ts
+++ b/src/status_providers/base.ts
@@ -34,6 +34,7 @@ export interface RepositoryInfo {}
  * Base class for commit status providers
  */
 export abstract class BaseStatusProvider {
+  public abstract readonly name: string;
   public config: any;
 
   /**
@@ -61,9 +62,7 @@ export abstract class BaseStatusProvider {
 
     while (true) {
       const status = await this.getRevisionStatus(revision);
-      logger.debug(
-        `Got status "${status}" from status provider: ${this.constructor.name}`
-      );
+      logger.debug(`Got status "${status}" from status provider: ${this.name}`);
 
       if (status === CommitStatus.SUCCESS) {
         if (spinner.isSpinning) {

--- a/src/status_providers/github.ts
+++ b/src/status_providers/github.ts
@@ -10,6 +10,7 @@ import { formatJson } from '../utils/strings';
  * Status provider that talks to GitHub to get commit checks (statuses)
  */
 export class GithubStatusProvider extends BaseStatusProvider {
+  public readonly name = 'github';
   /** Github client */
   private readonly github: Github;
 

--- a/src/status_providers/zeus.ts
+++ b/src/status_providers/zeus.ts
@@ -5,6 +5,7 @@ import { ZeusStore } from '../stores/zeus';
  * TODO
  */
 export class ZeusStatusProvider extends BaseStatusProvider {
+  public readonly name = 'zeus';
   /** Zeus API client */
   public readonly store: ZeusStore;
 


### PR DESCRIPTION
Since the single-file builds, we started to see log lines such as `Got status "success" from status provider: Vae`. This is because we minify the output, which changes function/class names for optimization and these lines rely on this `constructor.name` property. This patch adds explicit names to avoid using the `--keep-names` option in `esbuild` as that adds ~300kiB to the final file size just for this minor issue. This patch however is weightless*.
