### PR TITLE
fix(cli): Allow extra CRAFT_* env variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ts-jest": "^26.5.5",
     "typescript": "^4.1.3",
     "unzipper": "0.10.11",
-    "yargs": "15.1.0"
+    "yargs": "15.4.1"
   },
   "scripts": {
     "build:fat": "yarn run compile-config-schema && tsc -p tsconfig.build.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ function main(): void {
       describe: 'Logging level',
       global: true,
     })
-    .strict()
+    .strictCommands()
     .showHelpOnFail(true)
     .middleware(setGlobals)
     .parse();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6248,29 +6248,12 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@20.x, yargs-parser@>=18.1.2, yargs-parser@^16.1.0, yargs-parser@^18.1.2:
+yargs-parser@20.x, yargs-parser@>=18.1.2, yargs-parser@^18.1.2:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs@15.1.0:
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
-  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^16.1.0"
-
-yargs@^15.4.1:
+yargs@15.4.1, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
Since we used 'strict mode' in `yargs` and then enabled mapping of _any_ `CRAFT_*` env variables to CLI args, Craft now complains when it sees env variables like `CRAFT_GCS_STORE_CREDS_JSON` which are only directly used from specific targets and not available through the CLI. In an ideal world, either these wouldn't start with the `CRAFT_` prefix, or would be available as CLI args. Since we are not in that world, we are doing a compromise: converting one simple thing we acn into a CLI arg, and then relaxing the strictness by only being strict about the commands but not options. Since this feature (`strictCommands()` was added in a later version, we also upgrade `yargs` to `15.4.1` which is the canonical version being used by other tools in the repo.

Fix up to #224.
