### PR TITLE
fix(cli): Fix global flag parsing interference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.22.1
 
-- fix(cli): Fix global flag parsing interference (#234)
+- fix(cli): Fix global flag parsing interference (#235)
 
 ## 0.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.1
+
+- fix(cli): Fix global flag parsing interference (#234)
+
 ## 0.22.0
 
 - feat(config): Automatically detect GitHub config when missing (#208)

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,46 @@ function printVersion(): void {
   }
 }
 
+const GLOBAL_BOOLEAN_FLAGS = {
+  'no-input': {
+    coerce: envToBool,
+    default: isCI,
+    describe: 'Suppresses all user prompts',
+    global: true,
+  },
+  'dry-run': {
+    coerce: envToBool,
+    // TODO(byk): Deprecate this in favor of CRAFT_DRY_RUN
+    default: process.env.DRY_RUN,
+    global: true,
+    describe: 'Dry run mode: do not perform any real actions',
+  },
+};
+
+/**
+ * This function is to pre-process and fix one of yargs' shortcomings:
+ * We want to use some flags as booleans: just their existence on the CLI should
+ * set them to true. That said since we also allow setting them through
+ * environment variables, we need to parse many string values that would set
+ * them to false. Moreover, we want to be able to override already-set env
+ * variables with the `--flag=no` kind of notation (using the `=` symbol) but
+ * not via the positional argument notation (`--flag no`). The only way to do
+ * this is to define them as string arguments and then _inject_ a truthy string
+ * if we notice the flag is passed standalone (ie `--flag`).
+ * @param argv The raw process.argv array
+ * @returns The processed, injected version of the argv array to pass to yargs
+ */
+function fixGlobalBooleanFlags(argv: string[]): string[] {
+  const result = [];
+  for (const arg of argv) {
+    result.push(arg);
+    if (arg.slice(2) in GLOBAL_BOOLEAN_FLAGS) {
+      result.push('1');
+    }
+  }
+  return result;
+}
+
 /**
  * Main entrypoint
  */
@@ -31,6 +71,8 @@ function main(): void {
   readEnvironmentConfig();
 
   initSentrySdk();
+
+  const argv = fixGlobalBooleanFlags(process.argv.slice(2));
 
   yargs
     .parserConfiguration({
@@ -47,19 +89,7 @@ function main(): void {
     .alias('v', 'version')
     .help()
     .alias('h', 'help')
-    .option('no-input', {
-      coerce: envToBool,
-      default: isCI,
-      describe: 'Suppresses all user prompts',
-      global: true,
-    })
-    .option('dry-run', {
-      coerce: envToBool,
-      // TODO(byk): Deprecate this in favor of CRAFT_DRY_RUN
-      default: process.env.DRY_RUN,
-      global: true,
-      describe: 'Dry run mode: do not perform any real actions',
-    })
+    .options(GLOBAL_BOOLEAN_FLAGS)
     .option('log-level', {
       default: 'Info',
       choices: Object.keys(LogLevel).filter(level => isNaN(Number(level))),
@@ -70,7 +100,7 @@ function main(): void {
     .strictCommands()
     .showHelpOnFail(true)
     .middleware(setGlobals)
-    .parse();
+    .parse(argv);
 }
 
 main();


### PR DESCRIPTION
This fixes the release failures such as https://github.com/getsentry/sentry/runs/2591288014?check_suite_focus=true.
The culprit is #224 where we switched the global `--no-input` and
`--dry-run` flags from boolean to string args.
This now causes  `craft prepare --no-input "21.5.0"` to be interpreted
as `craft prepare --no-input=21.5.0`.

This patch fixes the issue.
