### PR TITLE
fix(logging): Fix scoped loggers not respecting log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.2
+
+- fix(logging): Fix scoped loggers not respecting log level (#236)
+
 ## 0.22.1
 
 - fix(cli): Fix global flag parsing interference (#235)

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -10,9 +10,6 @@ import {
   ArtifactProviderConfig,
 } from '../artifact_providers/base';
 import { checkEnvForPrerequisite } from '../utils/env';
-import { logger as loggerRaw } from '../logger';
-
-const logger = loggerRaw.withScope(`[artifact-provider/zeus]`);
 
 // TODO (kmclb) once `craft upload` is a thing, add an upload method here (and change the docstring below)
 
@@ -39,7 +36,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
     }
     this.client = new ZeusClient({
       defaultDirectory: config.downloadDirectory,
-      logger,
+      logger: this.logger,
     });
   }
 
@@ -124,7 +121,7 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
     revision: string
   ): Promise<RemoteArtifact[]> {
     const { repoName, repoOwner } = this.config;
-    logger.debug(
+    this.logger.debug(
       `Fetching Zeus artifacts for ${repoOwner}/${repoName}, revision ${revision}`
     );
     let zeusArtifacts;
@@ -143,14 +140,14 @@ export class ZeusArtifactProvider extends BaseArtifactProvider {
       // those two situations.
       const errorMessage: string = e.message || '';
       if (errorMessage.match(/404 not found|resource not found/i)) {
-        logger.debug(`Revision \`${revision}\` not found!`);
+        this.logger.debug(`Revision \`${revision}\` not found!`);
       }
       throw e;
     }
 
     // see comment above
     if (zeusArtifacts.length === 0) {
-      logger.debug(`Revision \`${revision}\` found.`);
+      this.logger.debug(`Revision \`${revision}\` found.`);
     }
 
     // Zeus stores multiple copies of the same file for a given revision,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -34,6 +34,14 @@ class SentryBreadcrumbReporter extends BasicReporter {
   }
 }
 
+export function setLevel(level: LogLevel): void {
+  logger.level = level;
+  // @ts-ignore We know _defaults exists, and this is the only way
+  // to modify the default level after creation.
+  logger._defaults.level = level;
+  logger.resume();
+}
+
 export const logger = consola.create({});
 // Pause until we set the logging level from helpers#setGlobals
 // This allows us to enqueue debug logging even before we set the

--- a/src/targets/base.ts
+++ b/src/targets/base.ts
@@ -1,4 +1,4 @@
-import { logger } from '../logger';
+import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { FilterOptions } from '../stores/zeus';
 import { stringToRegexp } from '../utils/filters';
@@ -14,6 +14,7 @@ import {
 export class BaseTarget {
   /** Target name */
   public readonly name: string = 'base';
+  protected readonly logger: typeof loggerRaw;
   /** Artifact provider */
   public readonly artifactProvider: BaseArtifactProvider;
   /** Unparsed target configuration */
@@ -28,6 +29,7 @@ export class BaseTarget {
     artifactProvider: BaseArtifactProvider,
     githubRepo?: GithubGlobalConfig
   ) {
+    this.logger = loggerRaw.withScope(`[artifact-provider/${this.name}]`);
     this.artifactProvider = artifactProvider;
     this.config = config;
     this.githubRepo = githubRepo;
@@ -78,12 +80,12 @@ export class BaseTarget {
     // This is a hacky legacy way of skipping artifact downloads.
     // Can be removed when we fully migrate from ZeusStore to artifact providers.
     if (filterOptions.includeNames?.source === 'none') {
-      logger.debug(
+      this.logger.debug(
         `target.includeNames is 'none', skipping artifacts downloads.`
       );
       return [];
     }
-    logger.debug(
+    this.logger.debug(
       `Getting artifact list for revision "${revision}", filtering options: {includeNames: ${String(
         filterOptions.includeNames
       )}, excludeNames:${String(filterOptions.excludeNames)}}`

--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import { basename, join } from 'path';
 import { promisify } from 'util';
 
-import { logger as loggerRaw } from '../logger';
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
@@ -12,8 +11,6 @@ import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
 import { BaseArtifactProvider } from '../artifact_providers/base';
 const writeFile = promisify(fs.writeFile);
-
-const logger = loggerRaw.withScope('[cocoapods]');
 
 const DEFAULT_COCOAPODS_BIN = 'pod';
 
@@ -77,7 +74,7 @@ export class CocoapodsTarget extends BaseTarget {
     const { owner, repo } = this.githubRepo;
     const specPath = this.cocoapodsConfig.specPath;
 
-    logger.info(`Loading podspec from ${owner}/${repo}:${specPath}`);
+    this.logger.info(`Loading podspec from ${owner}/${repo}:${specPath}`);
     const specContents = await getFile(
       this.github,
       owner,
@@ -98,7 +95,7 @@ export class CocoapodsTarget extends BaseTarget {
         const filePath = join(directory, fileName);
         await writeFile(filePath, specContents, 'utf8');
 
-        logger.info(`Pushing podspec "${fileName}" to cocoapods...`);
+        this.logger.info(`Pushing podspec "${fileName}" to cocoapods...`);
         await spawnProcess(COCOAPODS_BIN, ['setup']);
         await spawnProcess(
           COCOAPODS_BIN,
@@ -115,6 +112,6 @@ export class CocoapodsTarget extends BaseTarget {
       'craft-cocoapods-'
     );
 
-    logger.info('Cocoapods release complete');
+    this.logger.info('Cocoapods release complete');
   }
 }

--- a/src/targets/docker.ts
+++ b/src/targets/docker.ts
@@ -1,12 +1,9 @@
-import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
 import { BaseArtifactProvider } from '../artifact_providers/base';
 import { ConfigurationError } from '../utils/errors';
 import { renderTemplateSafe } from '../utils/strings';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
-
-const logger = loggerRaw.withScope('[docker]');
 
 const DEFAULT_DOCKER_BIN = 'docker';
 
@@ -90,7 +87,7 @@ export class DockerTarget extends BaseTarget {
    * @param revision Image tag, usually the git revision
    */
   public async pull(revision: string): Promise<any> {
-    logger.debug('Pulling source image...');
+    this.logger.debug('Pulling source image...');
     const sourceImage = renderTemplateSafe(this.dockerConfig.sourceTemplate, {
       ...this.dockerConfig,
       revision,
@@ -117,7 +114,7 @@ export class DockerTarget extends BaseTarget {
       ...this.dockerConfig,
       version,
     });
-    logger.debug('Tagging target image...');
+    this.logger.debug('Tagging target image...');
     await spawnProcess(DOCKER_BIN, ['tag', sourceImage, targetImage]);
     return spawnProcess(
       DOCKER_BIN,
@@ -138,6 +135,6 @@ export class DockerTarget extends BaseTarget {
     await this.pull(revision);
     await this.push(revision, version);
 
-    logger.info('Docker release complete');
+    this.logger.info('Docker release complete');
   }
 }

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -1,4 +1,3 @@
-import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
 import { forEachChained } from '../utils/async';
 import { ConfigurationError, reportError } from '../utils/errors';
@@ -15,8 +14,6 @@ import {
   BaseArtifactProvider,
   RemoteArtifact,
 } from '../artifact_providers/base';
-
-const logger = loggerRaw.withScope(`[gcs]`);
 
 /**
  * Adds templating to the BucketPath interface.
@@ -192,7 +189,7 @@ export class GcsTarget extends BaseTarget {
     if (realPath[0] !== '/') {
       realPath = `/${realPath}`;
     }
-    logger.debug(
+    this.logger.debug(
       `Processed path template \`${template}\` and got \`${realPath}\``
     );
     return { path: realPath, metadata };
@@ -217,7 +214,7 @@ export class GcsTarget extends BaseTarget {
 
     const { bucketName } = this.targetConfig;
 
-    logger.info(`Uploading to GCS bucket: "${bucketName}"`);
+    this.logger.info(`Uploading to GCS bucket: "${bucketName}"`);
 
     // before we can upload the artifacts to our target, we first need to
     // download them from the artifact provider
@@ -240,8 +237,8 @@ export class GcsTarget extends BaseTarget {
           revision
         );
 
-        logger.info(`Uploading files to ${bucketPath.path}.`);
-        logger.debug(
+        this.logger.info(`Uploading files to ${bucketPath.path}.`);
+        this.logger.debug(
           `Upload options: ${JSON.stringify({
             gzip: true,
             metadata: bucketPath.metadata || DEFAULT_UPLOAD_METADATA,
@@ -256,6 +253,6 @@ export class GcsTarget extends BaseTarget {
       }
     );
 
-    logger.info('Upload to GCS complete.');
+    this.logger.info('Upload to GCS complete.');
   }
 }

--- a/src/targets/gem.ts
+++ b/src/targets/gem.ts
@@ -1,4 +1,3 @@
-import { logger as loggerRaw } from '../logger';
 import {
   BaseArtifactProvider,
   RemoteArtifact,
@@ -7,8 +6,6 @@ import { reportError } from '../utils/errors';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
 import { TargetConfig } from '../schemas/project_config';
-
-const logger = loggerRaw.withScope('[gem]');
 
 const DEFAULT_GEM_BIN = 'gem';
 
@@ -54,7 +51,7 @@ export class GemTarget extends BaseTarget {
    * @param revision Git commit SHA to be published
    */
   public async publish(_version: string, revision: string): Promise<any> {
-    logger.debug('Fetching artifact list...');
+    this.logger.debug('Fetching artifact list...');
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_GEM_REGEX,
     });
@@ -67,11 +64,11 @@ export class GemTarget extends BaseTarget {
     await Promise.all(
       packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
-        logger.info(`Pushing gem "${file.filename}"`);
+        this.logger.info(`Pushing gem "${file.filename}"`);
         return this.pushGem(path);
       })
     );
 
-    logger.info('Successfully registered gem');
+    this.logger.info('Successfully registered gem');
   }
 }

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -1,4 +1,3 @@
-import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
@@ -7,8 +6,6 @@ import {
   BaseArtifactProvider,
   RemoteArtifact,
 } from '../artifact_providers/base';
-
-const logger = loggerRaw.withScope('[nuget]');
 
 /** Command to launch dotnet tools */
 export const NUGET_DOTNET_BIN = process.env.NUGET_DOTNET_BIN || 'dotnet';
@@ -86,7 +83,7 @@ export class NugetTarget extends BaseTarget {
    * @param revision Git commit SHA to be published
    */
   public async publish(_version: string, revision: string): Promise<any> {
-    logger.debug('Fetching artifact list...');
+    this.logger.debug('Fetching artifact list...');
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_NUGET_REGEX,
     });
@@ -100,11 +97,13 @@ export class NugetTarget extends BaseTarget {
     await Promise.all(
       packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
-        logger.info(`Uploading file "${file.filename}" via "dotnet nuget"`);
+        this.logger.info(
+          `Uploading file "${file.filename}" via "dotnet nuget"`
+        );
         return this.uploadAsset(path);
       })
     );
 
-    logger.info('Nuget release complete');
+    this.logger.info('Nuget release complete');
   }
 }

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -1,4 +1,3 @@
-import { logger as loggerRaw } from '../logger';
 import { TargetConfig } from '../schemas/project_config';
 import {
   BaseArtifactProvider,
@@ -7,8 +6,6 @@ import {
 import { ConfigurationError, reportError } from '../utils/errors';
 import { checkExecutableIsPresent, spawnProcess } from '../utils/system';
 import { BaseTarget } from './base';
-
-const logger = loggerRaw.withScope('[pypi]');
 
 const DEFAULT_TWINE_BIN = 'twine';
 
@@ -88,7 +85,7 @@ export class PypiTarget extends BaseTarget {
    * @param revision Git commit SHA to be published
    */
   public async publish(_version: string, revision: string): Promise<any> {
-    logger.debug('Fetching artifact list...');
+    this.logger.debug('Fetching artifact list...');
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_PYPI_REGEX,
     });
@@ -101,11 +98,11 @@ export class PypiTarget extends BaseTarget {
     await Promise.all(
       packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
-        logger.info(`Uploading file "${file.filename}" via twine`);
+        this.logger.info(`Uploading file "${file.filename}" via twine`);
         return this.uploadAsset(path);
       })
     );
 
-    logger.info('PyPI release complete');
+    this.logger.info('PyPI release complete');
   }
 }

--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -1,8 +1,6 @@
 import { DescribeRegionsCommandOutput, EC2 } from '@aws-sdk/client-ec2';
 import { Lambda } from '@aws-sdk/client-lambda';
-import { logger as loggerRaw } from '../logger';
-
-const logger = loggerRaw.withScope('[aws-lambda-layer]');
+import { logger } from 'src/logger';
 
 /** Prefix of the canonical name. */
 const RUNTIME_CANONICAL_PREFIX = 'aws-layer:';

--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -1,6 +1,6 @@
 import { DescribeRegionsCommandOutput, EC2 } from '@aws-sdk/client-ec2';
 import { Lambda } from '@aws-sdk/client-lambda';
-import { logger } from 'src/logger';
+import { logger } from '../logger';
 
 /** Prefix of the canonical name. */
 const RUNTIME_CANONICAL_PREFIX = 'aws-layer:';

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -9,7 +9,7 @@ import {
 } from '@google-cloud/storage';
 import { isDryRun } from './helpers';
 
-import { logger as loggerRaw } from '../logger';
+import { logger } from '../logger';
 import { reportError, ConfigurationError } from './errors';
 import { checkEnvForPrerequisite, RequiredConfigVar } from './env';
 import { detectContentType } from './files';
@@ -18,8 +18,6 @@ import { formatJson } from './strings';
 
 const DEFAULT_MAX_RETRIES = 5;
 export const DEFAULT_UPLOAD_METADATA = { cacheControl: `public, max-age=300` };
-
-const logger = loggerRaw.withScope(`[gcs client]`);
 
 /**
  * Configuration options for the GCS bucket

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import prompts from 'prompts';
-import { logger, LogLevel } from '../logger';
+import { logger, LogLevel, setLevel } from '../logger';
 
 const FALSY_ENV_VALUES = new Set(['', 'undefined', 'null', '0', 'false', 'no']);
 export function envToBool(envVar: unknown): boolean {
@@ -24,9 +24,8 @@ export function setGlobals(argv: GlobalFlags): void {
   for (const globalFlag of Object.keys(GLOBAL_FLAGS)) {
     GLOBAL_FLAGS[globalFlag] = argv[globalFlag];
   }
-  logger.level = LogLevel[GLOBAL_FLAGS['log-level']];
-  logger.debug('Argv: ', JSON.stringify(argv));
-  logger.resume();
+  setLevel(LogLevel[GLOBAL_FLAGS['log-level']]);
+  logger.debug('Argv: ', argv);
 }
 
 export function isDryRun(): boolean {


### PR DESCRIPTION
After the `consola` upgrade in #224, we stopped respecting the log level that is set further in execution in scoped logger which were created eagerly at module initialization time and not inheriting the log level that was changed afterwards. This patch moves these module-level loggers into base class constructors and standardizes them. This both fixes the issue and gives a common logging style for all artifact providers and targets.

