### PR TITLE
fix(github-artifacts): Fix incorrect artifact resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.2
+
+- fix(github-artifacts): Fix incorrect artifact resolution (#237)
+
 ## 0.22.1
 
 - fix(cli): Fix global flag parsing interference (#235)

--- a/src/artifact_providers/__tests__/github.test.ts
+++ b/src/artifact_providers/__tests__/github.test.ts
@@ -1,0 +1,211 @@
+jest.mock('../../utils/githubApi.ts');
+import { getGithubClient } from '../../utils/githubApi';
+import { GithubArtifactProvider, ArtifactItem } from '../github';
+
+class TestGithubArtifactProvider extends GithubArtifactProvider {
+  public testGetRevisionArtifact(revision: string): Promise<ArtifactItem> {
+    return this.getRevisionArtifact(revision);
+  }
+}
+
+describe('GitHub Artifact Provider', () => {
+  let githubArtifactProvider: TestGithubArtifactProvider;
+  let mockClient: { request: jest.Mock };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockClient = {
+      request: jest.fn(),
+    };
+    (getGithubClient as jest.MockedFunction<
+      typeof getGithubClient
+      // @ts-ignore we only need to mock a subset
+    >).mockReturnValueOnce(mockClient);
+
+    githubArtifactProvider = new TestGithubArtifactProvider({
+      repoOwner: 'getsentry',
+      repoName: 'craft',
+    });
+  });
+
+  describe('listArtifactsForRevision', () => {
+    test('it should get the artifact with the revision name', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          total_count: 2,
+          artifacts: [
+            {
+              id: 60233710,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
+              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
+              expired: false,
+              created_at: '2021-05-12T21:50:35Z',
+              updated_at: '2021-05-12T21:50:38Z',
+              expires_at: '2021-08-10T21:50:31Z',
+            },
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      });
+      await expect(
+        githubArtifactProvider.testGetRevisionArtifact(
+          '1b843f2cbb20fdda99ef749e29e75e43e6e43b38'
+        )
+      ).resolves.toMatchInlineSnapshot(`
+              Object {
+                "archive_download_url": "https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip",
+                "created_at": "2021-05-12T21:50:35Z",
+                "expired": false,
+                "expires_at": "2021-08-10T21:50:31Z",
+                "id": 60233710,
+                "name": "1b843f2cbb20fdda99ef749e29e75e43e6e43b38",
+                "node_id": "MDg6QXJ0aWZhY3Q2MDIzMzcxMA==",
+                "size_in_bytes": 6511029,
+                "updated_at": "2021-05-12T21:50:38Z",
+                "url": "https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710",
+              }
+            `);
+    });
+
+    test('it should get the latest artifact with the same name ', async () => {
+      mockClient.request.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          total_count: 2,
+          artifacts: [
+            {
+              id: 60233710,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
+              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
+              expired: false,
+              created_at: '2021-05-12T21:50:35Z',
+              updated_at: '2021-05-12T21:50:38Z',
+              expires_at: '2021-08-10T21:50:31Z',
+            },
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      });
+      await expect(
+        githubArtifactProvider.testGetRevisionArtifact(
+          '1b843f2cbb20fdda99ef749e29e75e43e6e43b38'
+        )
+      ).resolves.toMatchInlineSnapshot(`
+              Object {
+                "archive_download_url": "https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip",
+                "created_at": "2021-05-12T21:50:35Z",
+                "expired": false,
+                "expires_at": "2021-08-10T21:50:31Z",
+                "id": 60233710,
+                "name": "1b843f2cbb20fdda99ef749e29e75e43e6e43b38",
+                "node_id": "MDg6QXJ0aWZhY3Q2MDIzMzcxMA==",
+                "size_in_bytes": 6511029,
+                "updated_at": "2021-05-12T21:50:38Z",
+                "url": "https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710",
+              }
+            `);
+    });
+
+    test('it should throw when no artifacts are found after 3 retries', async () => {
+      mockClient.request.mockResolvedValue({
+        status: 200,
+        data: {
+          total_count: 0,
+          artifacts: [],
+        },
+      });
+      await expect(
+        githubArtifactProvider.testGetRevisionArtifact(
+          '1b843f2cbb20fdda99ef749e29e75e43e6e43b38'
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Failed to discover any artifacts (tries: 3)"`
+      );
+
+      expect(mockClient.request).toBeCalledTimes(3);
+    });
+
+    test('it should throw when no artifacts with the name can be found', async () => {
+      mockClient.request.mockResolvedValue({
+        status: 200,
+        data: {
+          total_count: 2,
+          artifacts: [
+            {
+              id: 60233710,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
+              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
+              expired: false,
+              created_at: '2021-05-12T21:50:35Z',
+              updated_at: '2021-05-12T21:50:38Z',
+              expires_at: '2021-08-10T21:50:31Z',
+            },
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      });
+      await expect(
+        githubArtifactProvider.testGetRevisionArtifact(
+          '3c2e87573d3bd16f61cf08fece0638cc47a4fc22'
+        )
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Can't find any artifacts for revision \\"3c2e87573d3bd16f61cf08fece0638cc47a4fc22\\" (tries: 3)"`
+      );
+    });
+  });
+});

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -19,7 +19,7 @@ import { extractZipArchive } from '../utils/system';
 
 const MAX_TRIES = 3;
 
-interface ArtifactItem {
+export interface ArtifactItem {
   id: number;
   name: string;
   size_in_bytes: number;
@@ -72,7 +72,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
    * @param revision
    * @param page
    */
-  private async listArtifact(
+  protected async getRevisionArtifact(
     revision: string,
     revisionDate?: string,
     page = 0,
@@ -135,7 +135,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     }
 
     if (tries < MAX_TRIES) {
-      return this.listArtifact(revision, revisionDate, page, tries);
+      return this.getRevisionArtifact(revision, revisionDate, page, tries);
     }
 
     if (artifactResponse.total_count === 0) {
@@ -230,7 +230,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
       `Fetching Github artifacts for ${repoOwner}/${repoName}, revision ${revision}`
     );
 
-    const foundArtifact = await this.listArtifact(revision);
+    const foundArtifact = await this.getRevisionArtifact(revision);
 
     this.logger.debug(`Requesting archive URL from Github...`);
 

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -94,14 +94,14 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
       })
     ).data as unknown) as ArtifactList;
 
-    const allArtifacts = artifactResponse.artifacts;
+    const { artifacts } = artifactResponse;
 
     // We need to find the most recent archive where name matches the revision.
-    const foundArtifact = allArtifacts.reduce((result, artifact) =>
-      artifact.name === revision && result.created_at < artifact.created_at
+    const foundArtifact = artifacts.reduce((result, artifact) =>
+      artifact.name === revision && (!result || result.created_at < artifact.created_at)
         ? artifact
         : result
-    );
+    , null as ArtifactItem | null);
 
     if (foundArtifact) {
       return foundArtifact;
@@ -124,7 +124,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
       // the artifacts are listed in descending date order on this endpoint.
       // There is no public documentation on this but the observed data and
       // common-sense logic suggests that this is a reasonably safe assumption.
-      const lastArtifact = allArtifacts[allArtifacts.length - 1];
+      const lastArtifact = artifacts[artifacts.length - 1];
       checkNextPage = lastArtifact.created_at >= revisionDate;
     }
 

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -97,16 +97,13 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     const { artifacts } = artifactResponse;
 
     // We need to find the most recent archive where name matches the revision.
-    let foundArtifact: ArtifactItem | undefined;
-    for (const artifact of artifacts) {
-      if (
-        artifact.name === revision &&
-        (!foundArtifact || foundArtifact.created_at < artifact.created_at)
-      ) {
-        foundArtifact = artifact;
-      }
-    }
-
+    // XXX(BYK): we assume the artifacts are listed in descending date order on
+    // this endpoint.
+    // There is no public documentation on this but the observed data and
+    // common-sense logic suggests that this is a reasonably safe assumption.
+    const foundArtifact = artifacts.find(
+      artifact => artifact.name === revision
+    );
     if (foundArtifact) {
       return foundArtifact;
     }

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -97,11 +97,14 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     const { artifacts } = artifactResponse;
 
     // We need to find the most recent archive where name matches the revision.
-    const foundArtifact = artifacts.reduce((result, artifact) =>
-      artifact.name === revision && (!result || result.created_at < artifact.created_at)
-        ? artifact
-        : result
-    , null as ArtifactItem | null);
+    const foundArtifact = artifacts.reduce(
+      (result, artifact) =>
+        artifact.name === revision &&
+        (!result || result.created_at < artifact.created_at)
+          ? artifact
+          : result,
+      null as ArtifactItem | null
+    );
 
     if (foundArtifact) {
       return foundArtifact;

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -122,9 +122,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
       // XXX(BYK): The assumption here is that the artifact created_at date
       // should always be greater than or equal to the associated revision date
       // ** AND **
-      // the artifacts are listed in descending date order on this endpoint.
-      // There is no public documentation on this but the observed data and
-      // common-sense logic suggests that this is a reasonably safe assumption.
+      // the descending date order. See the note above
       const lastArtifact = artifacts[artifacts.length - 1];
       checkNextPage = lastArtifact.created_at >= revisionDate;
     }

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -97,14 +97,15 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     const { artifacts } = artifactResponse;
 
     // We need to find the most recent archive where name matches the revision.
-    const foundArtifact = artifacts.reduce(
-      (result, artifact) =>
+    let foundArtifact: ArtifactItem | undefined;
+    for (const artifact of artifacts) {
+      if (
         artifact.name === revision &&
-        (!result || result.created_at < artifact.created_at)
-          ? artifact
-          : result,
-      null as ArtifactItem | null
-    );
+        (!foundArtifact || foundArtifact.created_at < artifact.created_at)
+      ) {
+        foundArtifact = artifact;
+      }
+    }
 
     if (foundArtifact) {
       return foundArtifact;

--- a/src/utils/__tests__/githubApi.test.ts
+++ b/src/utils/__tests__/githubApi.test.ts
@@ -13,7 +13,6 @@ const mockRepos = {
   getContents: jest.fn(),
 };
 
-// TODO rewrite with module mock, port github helpers from probot-release
 jest.mock('@octokit/rest', () =>
   jest.fn().mockImplementation(() => ({ repos: mockRepos }))
 );


### PR DESCRIPTION
Fixes #234. This is a follow up to #226. Although @chadwhitacre pointed out a logic issue in an earlier revision, we have failed to see that we were _always_ returning an artifact even if we don't have a proper name match as `reduce` without an initial value, starts with the first element of the array. This patch fixes the issue.
