### PR TITLE
fix(logging): Proper scoping and log levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.23.0
 
 - feat(publish): Ability to merge to non-default (#245)
+- fix(logging): Proper scoping and log levels (#247)
 
 ## 0.22.2
 

--- a/src/artifact_providers/__tests__/github.test.ts
+++ b/src/artifact_providers/__tests__/github.test.ts
@@ -23,6 +23,7 @@ describe('GitHub Artifact Provider', () => {
     >).mockReturnValueOnce(mockClient);
 
     githubArtifactProvider = new TestGithubArtifactProvider({
+      name: 'github-test',
       repoOwner: 'getsentry',
       repoName: 'craft',
     });

--- a/src/artifact_providers/base.ts
+++ b/src/artifact_providers/base.ts
@@ -73,6 +73,7 @@ export interface FilterOptions {
  * Configuration options needed for all artifact providers
  */
 export interface ArtifactProviderConfig {
+  name: string;
   /** Name of the repo containing the code getting released */
   repoName: string;
   /** GitHub org to which the repo belongs */
@@ -87,7 +88,6 @@ export interface ArtifactProviderConfig {
  * Base interface for artifact providers.
  */
 export abstract class BaseArtifactProvider {
-  public readonly name: string = 'base';
   protected readonly logger: typeof loggerRaw;
   /** Cache for local paths to downloaded files */
   protected readonly downloadCache: {
@@ -111,7 +111,7 @@ export abstract class BaseArtifactProvider {
   protected defaultDownloadDirectory: string | undefined;
 
   public constructor(config: ArtifactProviderConfig) {
-    this.logger = loggerRaw.withScope(`[artifact-provider/${this.name}]`);
+    this.logger = loggerRaw.withScope(`[artifact-provider/${config.name}]`);
     this.clearCaches();
 
     this.config = config;

--- a/src/artifact_providers/gcs.ts
+++ b/src/artifact_providers/gcs.ts
@@ -18,7 +18,6 @@ export interface GCSArtifactProviderConfig extends ArtifactProviderConfig {
  * Google Cloud Storage artifact provider
  */
 export class GCSArtifactProvider extends BaseArtifactProvider {
-  public readonly name = 'gcs';
   /** Client for interacting with the GCS bucket */
   private readonly gcsClient: CraftGCSClient;
 

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -42,7 +42,6 @@ interface ArchiveResponse extends Github.AnyResponse {
  * Github artifact provider
  */
 export class GithubArtifactProvider extends BaseArtifactProvider {
-  public readonly name = 'github';
   /** Github client */
   public readonly github: Github;
 

--- a/src/artifact_providers/none.ts
+++ b/src/artifact_providers/none.ts
@@ -8,9 +8,12 @@ import {
  * Empty artifact provider that does nothing.
  */
 export class NoneArtifactProvider extends BaseArtifactProvider {
-  public readonly name = 'none';
   public constructor(
-    config: ArtifactProviderConfig = { repoName: 'none', repoOwner: 'none' }
+    config: ArtifactProviderConfig = {
+      repoName: 'none',
+      repoOwner: 'none',
+      name: 'none',
+    }
   ) {
     super(config);
   }

--- a/src/artifact_providers/zeus.ts
+++ b/src/artifact_providers/zeus.ts
@@ -20,7 +20,6 @@ import { checkEnvForPrerequisite } from '../utils/env';
  * line tool.
  */
 export class ZeusArtifactProvider extends BaseArtifactProvider {
-  public readonly name = 'zeus';
   /** Zeus API client */
   public readonly client: ZeusClient;
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -492,8 +492,6 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
 
   const statusProvider = await getStatusProviderFromConfig();
   const artifactProvider = await getArtifactProviderFromConfig();
-  logger.debug(`Using "${statusProvider.name}" for status checks`);
-  logger.debug(`Using "${artifactProvider.name}" for artifacts`);
 
   // Check status of all CI builds linked to the revision
   await checkRevisionStatus(statusProvider, revision, argv.noStatusCheck);

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,10 @@ import { GCSArtifactProvider } from './artifact_providers/gcs';
 
 import { ZeusStatusProvider } from './status_providers/zeus';
 import { GithubStatusProvider } from './status_providers/github';
-import { BaseStatusProvider } from './status_providers/base';
+import {
+  BaseStatusProvider,
+  StatusProviderConfig,
+} from './status_providers/base';
 
 // TODO support multiple configuration files (one per configuration)
 export const CONFIG_FILE_NAME = '.craft.yml';
@@ -308,11 +311,13 @@ export async function getArtifactProviderFromConfig(): Promise<BaseArtifactProvi
 
   const githubRepo = await getGlobalGithubConfig();
   const artifactProviderConfig = {
+    name: artifactProviderName,
     ...projectConfig.artifactProvider?.config,
     repoName: githubRepo.repo,
     repoOwner: githubRepo.owner,
   };
 
+  logger.debug(`Using "${artifactProviderName}" for artifacts`);
   switch (artifactProviderName) {
     case ArtifactProviderName.Zeus:
       return new ZeusArtifactProvider(artifactProviderConfig);
@@ -341,9 +346,8 @@ export async function getStatusProviderFromConfig(): Promise<BaseStatusProvider>
     config: undefined,
     name: undefined,
   };
-  const statusProviderConfig = rawStatusProvider.config;
-  let statusProviderName = rawStatusProvider.name;
 
+  let statusProviderName = rawStatusProvider.name;
   if (statusProviderName == null) {
     if (isAfterEpoch()) {
       statusProviderName = StatusProviderName.Github;
@@ -358,19 +362,17 @@ export async function getStatusProviderFromConfig(): Promise<BaseStatusProvider>
     }
   }
 
+  const statusProviderConfig: StatusProviderConfig = {
+    ...rawStatusProvider.config,
+    name: statusProviderName,
+  };
+
+  logger.debug(`Using "${statusProviderName}" for status checks`);
   switch (statusProviderName) {
     case StatusProviderName.Zeus:
-      return new ZeusStatusProvider(
-        githubConfig.owner,
-        githubConfig.repo,
-        statusProviderConfig
-      );
+      return new ZeusStatusProvider(statusProviderConfig, githubConfig);
     case StatusProviderName.Github:
-      return new GithubStatusProvider(
-        githubConfig.owner,
-        githubConfig.repo,
-        statusProviderConfig
-      );
+      return new GithubStatusProvider(statusProviderConfig, githubConfig);
     default: {
       throw new ConfigurationError('Invalid status provider');
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,7 @@ import { addBreadcrumb, Severity } from '@sentry/node';
 import Table from 'cli-table';
 import consola, {
   BasicReporter,
+  Consola,
   ConsolaReporterLogObject,
   LogLevel,
 } from 'consola';
@@ -21,8 +22,6 @@ export function formatTable(
   return table.toString();
 }
 
-export { LogLevel as LogLevel };
-
 /** Reporter that sends logs to Sentry */
 class SentryBreadcrumbReporter extends BasicReporter {
   public log(logObj: ConsolaReporterLogObject) {
@@ -34,17 +33,27 @@ class SentryBreadcrumbReporter extends BasicReporter {
   }
 }
 
-export function setLevel(level: LogLevel): void {
-  logger.level = level;
-  // @ts-ignore We know _defaults exists, and this is the only way
-  // to modify the default level after creation.
-  logger._defaults.level = level;
-  logger.resume();
+export { LogLevel as LogLevel };
+let level = LogLevel.Info;
+const loggers: Consola[] = [];
+function createLogger(tag?: string) {
+  const loggerInstance = consola.create({ defaults: { tag, level } });
+  loggerInstance.addReporter(new SentryBreadcrumbReporter());
+  loggerInstance.withScope = createLogger;
+  loggers.push(loggerInstance);
+  return loggerInstance;
 }
 
-export const logger = consola.create({});
+export const logger = createLogger();
 // Pause until we set the logging level from helpers#setGlobals
 // This allows us to enqueue debug logging even before we set the
 // logging level. These are flushed as soon as we run `logger.resume()`.
 logger.pause();
-logger.addReporter(new SentryBreadcrumbReporter());
+
+export function setLevel(logLevel: LogLevel): void {
+  level = logLevel;
+  for (const loggerInstance of loggers) {
+    loggerInstance.level = level;
+    loggerInstance.resume();
+  }
+}

--- a/src/status_providers/zeus.ts
+++ b/src/status_providers/zeus.ts
@@ -1,22 +1,25 @@
-import { BaseStatusProvider, CommitStatus, RepositoryInfo } from './base';
+import {
+  BaseStatusProvider,
+  CommitStatus,
+  RepositoryInfo,
+  StatusProviderConfig,
+} from './base';
 import { ZeusStore } from '../stores/zeus';
+import { GithubGlobalConfig } from 'src/schemas/project_config';
 
 /**
  * TODO
  */
 export class ZeusStatusProvider extends BaseStatusProvider {
-  public readonly name = 'zeus';
   /** Zeus API client */
   public readonly store: ZeusStore;
 
   public constructor(
-    repoOwner: string,
-    repoName: string,
-    config?: Record<string, any>
+    config: StatusProviderConfig,
+    githubConfig: GithubGlobalConfig
   ) {
-    super();
-    this.store = new ZeusStore(repoOwner, repoName);
-    this.config = config;
+    super(config, githubConfig);
+    this.store = new ZeusStore(this.githubConfig.owner, this.githubConfig.repo);
   }
 
   /**

--- a/src/targets/base.ts
+++ b/src/targets/base.ts
@@ -11,8 +11,6 @@ import {
  * Base class for all remote targets
  */
 export class BaseTarget {
-  /** Target name */
-  public readonly name: string = 'base';
   public readonly id: string;
   protected readonly logger: typeof loggerRaw;
   /** Artifact provider */
@@ -35,7 +33,7 @@ export class BaseTarget {
     artifactProvider: BaseArtifactProvider,
     githubRepo?: GithubGlobalConfig
   ) {
-    this.logger = loggerRaw.withScope(`[artifact-provider/${this.name}]`);
+    this.logger = loggerRaw.withScope(`[target/${config.name}]`);
     this.artifactProvider = artifactProvider;
     this.config = config;
     this.id = BaseTarget.getId(config);

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -57,7 +57,7 @@ type GithubCreateTagType = 'commit' | 'tree' | 'blob';
  */
 export class GithubTarget extends BaseTarget {
   /** Target name */
-  public readonly name: string = 'github';
+  public readonly name = 'github';
   /** Target options */
   public readonly githubConfig: GithubTargetConfig;
   /** Github client */


### PR DESCRIPTION
When looking at https://github.com/getsentry/publish/runs/2682656771?check_suite_focus=true#step:8:28
I noticed there were 2 issues with our logging:

1. The scope name was not correct (base vs github)
2. The logging level for the scoped logger was incorrect (debug vs info)

Issue no 1 stems from a quirk in ES6 classes where property initializers
are not run until after the `super()` call
which sets up the logging, failing to pick up the new `name` set in the
inherited class.

Issue no 2 stems from `Consola`'s `withScope` method not inheriting or
cascading the parent logging level to the new, scoped loggers.

This PR solves both issues.