### PR TITLE
ref(logging): Overhaul debug level logging

### DIFF
--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -91,7 +91,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
     ).data as unknown) as ArtifactList;
 
     const { artifacts } = artifactResponse;
-    this.logger.debug(`All available artifacts on page ${page}:`, artifacts);
+    this.logger.trace(`All available artifacts on page ${page}:`, artifacts);
 
     // We need to find the most recent archive where name matches the revision.
     // XXX(BYK): we assume the artifacts are listed in descending date order on
@@ -102,7 +102,7 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
       artifact => artifact.name === revision
     );
     if (foundArtifact) {
-      this.logger.debug(`Found artifact on page ${page}:`, foundArtifact);
+      this.logger.trace(`Found artifact on page ${page}:`, foundArtifact);
       return foundArtifact;
     }
 

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -208,8 +208,8 @@ async function commitNewVersion(
     reportError('Nothing to commit: has the pre-release command done its job?');
   }
 
-  logger.info('Committing the release changes...');
-  logger.debug(`Commit message: "${message}"`);
+  logger.debug('Committing the release changes...');
+  logger.trace(`Commit message: "${message}"`);
   if (!isDryRun()) {
     await git.commit(message, ['--all']);
   } else {
@@ -357,6 +357,7 @@ async function prepareChangelog(
   logger.debug(`Changelog policy: "${changelogPolicy}".`);
 
   const relativePath = relative('', changelogPath);
+  logger.debug(`Changelog path: ${relativePath}`);
   if (relativePath.startsWith('.')) {
     throw new ConfigurationError(`Invalid changelog path: "${changelogPath}"`);
   }
@@ -368,8 +369,6 @@ async function prepareChangelog(
   }
 
   let changelogString = (await fsPromises.readFile(relativePath)).toString();
-  logger.debug(`Changelog path: ${relativePath}`);
-
   let changeset = findChangeset(
     changelogString,
     newVersion,
@@ -402,7 +401,7 @@ async function prepareChangelog(
         await fsPromises.writeFile(relativePath, changelogString);
       } else {
         logger.info('[dry-run] Not updating changelog file.');
-        logger.debug(`New changelog:\n${changelogString}`);
+        logger.trace(`New changelog:\n${changelogString}`);
       }
 
       break;
@@ -414,7 +413,8 @@ async function prepareChangelog(
       }
   }
 
-  logger.debug(`Changelog entry found:\n"""\n${changeset.body}\n"""`);
+  logger.debug('Changelog entry found:', changeset.name);
+  logger.trace(changeset.body);
 }
 
 /**

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -25,7 +25,7 @@ import { handleGlobalError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import { stringToRegexp } from '../utils/filters';
 import { isDryRun, promptConfirmation } from '../utils/helpers';
-import { formatSize, formatJson } from '../utils/strings';
+import { formatSize } from '../utils/strings';
 import {
   catchKeyboardInterrupt,
   hasExecutable,
@@ -215,7 +215,7 @@ async function getTargetList(
   targetConfigList: TargetConfig[],
   artifactProvider: BaseArtifactProvider
 ): Promise<BaseTarget[]> {
-  logger.debug('Initializing targets');
+  logger.trace('Initializing targets');
   const githubRepo = await getGlobalGithubConfig();
   const targetList: BaseTarget[] = [];
   for (const targetConfig of targetConfigList) {
@@ -226,7 +226,8 @@ async function getTargetList(
       continue;
     }
     try {
-      logger.debug(`Creating target ${targetConfig.name}:`, targetConfig);
+      logger.debug(`Creating target ${targetDescriptor}`);
+      logger.trace(targetConfig);
       const target = new targetClass(
         targetConfig,
         artifactProvider,
@@ -317,7 +318,8 @@ async function checkRevisionStatus(
     logger.debug('Fetching repository information...');
     // This will additionally check that the user has proper permissions
     const repositoryInfo = await statusProvider.getRepositoryInfo();
-    logger.debug(`Repository info received: "${formatJson(repositoryInfo)}"`);
+    logger.debug('Repository info received');
+    logger.trace(repositoryInfo);
   } catch (e) {
     reportError(
       'Cannot get repository information from Zeus. Check your configuration and credentials. ' +
@@ -346,7 +348,7 @@ async function getMergeTarget(
     '--oneline'
   );
   logger.debug('Trying to find merge target:');
-  logger.debug(logOutput);
+  logger.trace(logOutput);
   const branchName =
     stripRemoteName(
       logOutput
@@ -613,7 +615,7 @@ export async function publishMain(argv: PublishOptions): Promise<any> {
       fsPromises
         .unlink(publishStateFile)
         .catch(err =>
-          logger.debug("Couldn't remove publish state file: ", err)
+          logger.trace("Couldn't remove publish state file: ", err)
         );
     }
     logger.success(`Version ${newVersion} has been published!`);

--- a/src/status_providers/github.ts
+++ b/src/status_providers/github.ts
@@ -280,9 +280,8 @@ export class GithubStatusProvider extends BaseStatusProvider {
       }
     );
     const revisionStatus = revisionStatusResponse.data;
-    logger.debug(
-      `Revision combined status received: "${formatJson(revisionStatus)}"`
-    );
+    logger.debug('Combined revision status received.');
+    logger.trace(revisionStatus);
     return revisionStatus;
   }
 
@@ -299,16 +298,15 @@ export class GithubStatusProvider extends BaseStatusProvider {
   protected async getRevisionCheckSuites(
     revision: string
   ): Promise<Github.ChecksListSuitesForRefResponse> {
-    logger.debug(`Fetching Checks API status...`);
+    logger.debug('Fetching Checks API status...');
     const revisionCheckSuites = (
       await this.github.checks.listSuitesForRef({
         ...this.githubConfig,
         ref: revision,
       })
     ).data;
-    logger.debug(
-      `Revision check suites received: "${formatJson(revisionCheckSuites)}"`
-    );
+    logger.debug('Revision check suites received.');
+    logger.trace(revisionCheckSuites);
 
     return revisionCheckSuites;
   }
@@ -326,13 +324,14 @@ export class GithubStatusProvider extends BaseStatusProvider {
   protected async getRevisionChecks(
     revision: string
   ): Promise<Github.ChecksListForRefResponse> {
-    logger.debug(`Fetching Checks API status...`);
+    logger.debug('Fetching Checks API status...');
     const revisionChecksResponse = await this.github.checks.listForRef({
       ...this.githubConfig,
       ref: revision,
     });
     const revisionChecks = revisionChecksResponse.data;
-    logger.debug(`Revision checks received: "${formatJson(revisionChecks)}"`);
+    logger.debug('Revision checks received.');
+    logger.trace(revisionChecks);
 
     return revisionChecks;
   }

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -136,7 +136,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
     );
 
     const awsRegions = await getRegionsFromAws();
-    this.logger.debug('AWS regions: ' + awsRegions);
+    this.logger.trace('AWS regions: ', awsRegions);
 
     const remote = this.awsLambdaConfig.registryRemote;
     const username = await getAuthUsername(this.github);
@@ -219,7 +219,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
     version: string,
     versionFilepath: string
   ): void {
-    this.logger.debug(`Creating symlinks...`);
+    this.logger.debug('Creating symlinks...');
     const latestVersionPath = path.posix.join(directory, 'latest.json');
     if (fs.existsSync(latestVersionPath)) {
       const previousVersion = fs

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -157,10 +157,8 @@ export class BrewTarget extends BaseTarget {
 
     // Format checksums and the tag version into the formula file
     const filesList = await this.getArtifactsForRevision(revision);
-    this.logger.debug(
-      'Downloading artifacts for the revision:',
-      JSON.stringify(filesList.map(file => file.filename))
-    );
+    this.logger.debug('Downloading artifacts for the revision');
+    this.logger.trace(filesList.map(file => file.filename));
 
     const checksums: any = {};
 

--- a/src/targets/gcs.ts
+++ b/src/targets/gcs.ts
@@ -238,12 +238,10 @@ export class GcsTarget extends BaseTarget {
         );
 
         this.logger.info(`Uploading files to ${bucketPath.path}.`);
-        this.logger.debug(
-          `Upload options: ${JSON.stringify({
-            gzip: true,
-            metadata: bucketPath.metadata || DEFAULT_UPLOAD_METADATA,
-          })}`
-        );
+        this.logger.debug('Upload options:', {
+          gzip: true,
+          metadata: bucketPath.metadata || DEFAULT_UPLOAD_METADATA,
+        });
 
         return Promise.all(
           localFilePaths.map(async localPath =>

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -231,10 +231,9 @@ export class GithubTarget extends BaseTarget {
       name: version,
       body: '',
     };
-    this.logger.debug(
-      'Changes extracted from changelog: ',
-      JSON.stringify(changes)
-    );
+    this.logger.debug('Changes extracted from changelog.');
+    this.logger.trace(changes);
+
     return changes;
   }
 
@@ -339,7 +338,7 @@ export class GithubTarget extends BaseTarget {
       name,
       url: release.upload_url,
     };
-    this.logger.debug('Upload parameters:', JSON.stringify(params));
+    this.logger.trace('Upload parameters:', params);
     this.logger.info(
       `Uploading asset "${name}" to ${this.githubConfig.owner}/${this.githubConfig.repo}:${release.tag_name}`
     );

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -112,7 +112,7 @@ export class UpmTarget extends BaseTarget {
       getGithubApiToken()
     );
     const remoteAddr = remote.getRemoteString();
-    this.logger.debug(`Target release repository: ` + `"${remoteAddr}"`);
+    this.logger.debug(`Target release repository: ${remoteAddr}`);
 
     await withTempDir(
       async directory => {

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -1,6 +1,8 @@
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-const os = require('os');
+// XXX(BYK): This is to be able to spy on `homedir()` in tests
+// TODO(BYK): Convert this to ES6 imports
+import os = require('os');
 
 import * as config from '../../config';
 import {

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -31,7 +31,8 @@ describe('env utils functions', () => {
       process.env.DOGS = 'RULE'; // just to prevent the function erroring
       checkEnvForPrerequisite({ name: 'DOGS' });
       expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining('Checking for environment variable DOGS')
+        'Checking for environment variable:',
+        'DOGS'
       );
     });
 
@@ -92,13 +93,16 @@ describe('env utils functions', () => {
           checkEnvForPrerequisite({ name: 'MAISEY' }, { name: 'CHARLIE' })
         ).toThrowError(ConfigurationError);
         expect(logger.debug).toHaveBeenCalledWith(
-          `Checking for environment variable(s) MAISEY or CHARLIE`
+          'Checking for environment variable(s):',
+          'MAISEY or CHARLIE'
         );
         expect(logger.debug).toHaveBeenCalledWith(
-          expect.stringContaining('Checking for environment variable MAISEY')
+          'Checking for environment variable:',
+          'MAISEY'
         );
         expect(logger.debug).toHaveBeenCalledWith(
-          expect.stringContaining('Checking for environment variable CHARLIE')
+          'Checking for environment variable:',
+          'CHARLIE'
         );
       });
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -40,7 +40,7 @@ export interface RequiredConfigVar {
 function envHasVar(envVar: RequiredConfigVar): boolean {
   const { name, legacyName } = envVar;
 
-  logger.debug(`Checking for environment variable ${name}`);
+  logger.debug('Checking for environment variable:', name);
 
   // not found, under either the current name or legacy name (if app.)
   if (!process.env[name] && !process.env[legacyName as string]) {
@@ -57,16 +57,13 @@ function envHasVar(envVar: RequiredConfigVar): boolean {
   // the less simple cases - only using legacy name or using both
   else if (process.env[legacyName] && !process.env[name]) {
     logger.warn(
-      `Usage of ${legacyName} is deprecated, and will be removed in ` +
-        `later versions. Please use ${name} instead.`
+      `Usage of ${legacyName} is deprecated, and will be removed in later versions. Please use ${name} instead.`
     );
     logger.debug(`Moving legacy environment variable ${legacyName} to ${name}`);
     process.env[name] = process.env[legacyName];
   } else if (process.env[legacyName] && process.env[name]) {
     logger.warn(
-      `When searching configuration files and your environment, found ` +
-        `${name} but also found legacy ${legacyName}. Do you mean ` +
-        `to be using both?`
+      `When searching configuration files and your environment, found ${name} but also found legacy ${legacyName}. Do you mean to be using both?`
     );
   }
 
@@ -89,8 +86,7 @@ function checkFileIsPrivate(path: string): boolean {
   if (mode & GROUP_MODE_MASK || mode & OTHER_MODE_MASK) {
     const perms = (mode & FULL_MODE_MASK).toString(8);
     logger.warn(
-      `Permissions 0${perms} for file "${path}" are too open. ` +
-        `Consider making it readable only for the user.`
+      `Permissions 0${perms} for file "${path}" are too open. Consider making it readable only for the user.`
     );
     return false;
   }
@@ -114,7 +110,8 @@ export function readEnvironmentConfig(overwriteExisting = false): void {
   const homedirEnvFile = join(os.homedir(), ENV_FILE_NAME);
   if (existsSync(homedirEnvFile)) {
     logger.debug(
-      `Found environment file in the home directory: ${homedirEnvFile}`
+      'Found environment file in the home directory:',
+      homedirEnvFile
     );
     checkFileIsPrivate(homedirEnvFile);
     const homedirEnv = {};
@@ -123,7 +120,8 @@ export function readEnvironmentConfig(overwriteExisting = false): void {
     logger.trace('Read the following variables from env file:', homedirEnv);
   } else {
     logger.debug(
-      `No environment file found in the home directory: ${homedirEnvFile}`
+      'No environment file found in the home directory:',
+      homedirEnvFile
     );
   }
 
@@ -132,10 +130,11 @@ export function readEnvironmentConfig(overwriteExisting = false): void {
   const configFileDir = getConfigFileDir();
   const configDirEnvFile = configFileDir && join(configFileDir, ENV_FILE_NAME);
   if (!configDirEnvFile) {
-    logger.debug(`No configuration file (${CONFIG_FILE_NAME}) found!`);
+    logger.debug('No configuration file found:', CONFIG_FILE_NAME);
   } else if (configDirEnvFile && existsSync(configDirEnvFile)) {
     logger.debug(
-      `Found environment file in the configuration directory: ${configDirEnvFile}`
+      'Found environment file in the configuration directory:',
+      configDirEnvFile
     );
     checkFileIsPrivate(configDirEnvFile);
     const configDirEnv = {};
@@ -144,7 +143,8 @@ export function readEnvironmentConfig(overwriteExisting = false): void {
     logger.trace('Read the following variables from env file:', configDirEnv);
   } else {
     logger.debug(
-      `No environment file found in the configuration directory: ${configDirEnvFile}`
+      'No environment file found in the configuration directory:',
+      configDirEnvFile
     );
   }
 
@@ -164,7 +164,7 @@ export function readEnvironmentConfig(overwriteExisting = false): void {
  */
 export function checkEnvForPrerequisite(...varList: RequiredConfigVar[]): void {
   const varNames = varList.map(v => v.name).join(' or ');
-  logger.debug(`Checking for environment variable(s) ${varNames}`);
+  logger.debug('Checking for environment variable(s):', varNames);
 
   if (!varList.some(envHasVar)) {
     // note: Technically this function only checks the environment, not any

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,6 +1,6 @@
 import { existsSync, statSync } from 'fs';
 import { join } from 'path';
-const os = require('os');
+import * as os from 'os';
 
 import nvar from 'nvar';
 
@@ -118,11 +118,7 @@ export function readEnvironmentConfig(overwriteExisting = false): void {
     const homedirEnv = {};
     nvar({ path: homedirEnvFile, target: homedirEnv });
     newEnv = { ...newEnv, ...homedirEnv };
-    logger.debug(
-      `Read the following variables from ${homedirEnvFile}: ${Object.keys(
-        homedirEnv
-      ).toString()}`
-    );
+    logger.trace('Read the following variables from env file:', homedirEnv);
   } else {
     logger.debug(
       `No environment file found in the home directory: ${homedirEnvFile}`
@@ -143,11 +139,7 @@ export function readEnvironmentConfig(overwriteExisting = false): void {
     const configDirEnv = {};
     nvar({ path: configDirEnvFile, target: configDirEnv });
     newEnv = { ...newEnv, ...configDirEnv };
-    logger.debug(
-      `Read the following variables from ${configDirEnvFile}: ${Object.keys(
-        configDirEnv
-      ).toString()}`
-    );
+    logger.trace('Read the following variables from env file:', configDirEnv);
   } else {
     logger.debug(
       `No environment file found in the configuration directory: ${configDirEnvFile}`

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,6 +1,8 @@
 import { existsSync, statSync } from 'fs';
 import { join } from 'path';
-const os = require('os');
+// XXX(BYK): This is to be able to spy on `homedir()` in tests
+// TODO(BYK): Convert this to ES6 imports
+import os = require('os');
 
 import nvar from 'nvar';
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,6 +1,6 @@
 import { existsSync, statSync } from 'fs';
 import { join } from 'path';
-import * as os from 'os';
+const os = require('os');
 
 import nvar from 'nvar';
 

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -90,7 +90,7 @@ export async function withTempDir<T>(
         // don't care as this is already a temporary file and will be removed
         // eventually by the OS. And it doesn't make sense to wait until this op
         // finishes then as nothing relies on the removal of this file.
-        logger.debug(`Couldn't remove temp dir ${directory}: `, err);
+        logger.trace(`Couldn't remove temp dir ${directory}: `, err);
       });
     }
   }

--- a/src/utils/gcsApi.ts
+++ b/src/utils/gcsApi.ts
@@ -211,7 +211,7 @@ export class CraftGCSClient {
       resumable: !process.env.CI,
     };
 
-    logger.debug(
+    logger.trace(
       `File \`${filename}\`, upload options: ${formatJson(uploadConfig)}`
     );
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -24,9 +24,9 @@ export function setGlobals(argv: GlobalFlags): void {
   for (const globalFlag of Object.keys(GLOBAL_FLAGS)) {
     GLOBAL_FLAGS[globalFlag] = argv[globalFlag];
   }
-  logger.debug('Global flags:', GLOBAL_FLAGS);
+  logger.trace('Global flags:', GLOBAL_FLAGS);
   setLevel(LogLevel[GLOBAL_FLAGS['log-level']]);
-  logger.debug('Argv: ', argv);
+  logger.trace('Argv: ', argv);
 }
 
 export function isDryRun(): boolean {

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -60,7 +60,7 @@ export async function updateManifestSymlinks(
   previousVersion: string
 ): Promise<void> {
   const manifestString = JSON.stringify(updatedManifest, undefined, 2) + '\n';
-  logger.debug('Updated manifest', manifestString);
+  logger.trace('Updated manifest', manifestString);
   logger.debug(`Writing updated manifest to "${versionFilePath}"...`);
   await fsPromises.writeFile(versionFilePath, manifestString);
   createSymlinks(versionFilePath, version, previousVersion);

--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -152,7 +152,7 @@ export async function spawnProcess(
       reject(processError(e.code, command, args, options, stdout, stderr));
 
     try {
-      logger.debug('Spawning process:', `${command} ${argsString}`);
+      logger.trace('Spawning process:', `${command} ${argsString}`);
 
       // Do a shell-like replacement of arguments that look like environment variables
       const processedArgs = args.map(arg =>
@@ -176,13 +176,13 @@ export async function spawnProcess(
         if (spawnProcessOptions.showStdout) {
           logger.info(output);
         } else {
-          logger.debug(output);
+          logger.trace(output);
         }
         stdout += `${output}\n`;
       });
       child.stderr.pipe(split()).on('data', (data: any) => {
         const output = `${command}: ${data}`;
-        logger.debug(output);
+        logger.trace(output);
         stderr += `${output}\n`;
       });
     } catch (e) {


### PR DESCRIPTION
We are planning to set logging level to `Debug` over at `getsentry/publish` but it tends to be too noisy. This PR goes over all `logger.debug()` calls, tidies them up, and moves some of them to `logger.trace()` level to make debug-logging more usable.
