### PR TITLE
fix(git): Ensure origin/HEAD is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.23.1
+
+- fix(git): Ensure origin/HEAD is set (#252)
+
 ## 0.23.0
 
 - feat(publish): Ability to merge to non-default (#245)

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -10,7 +10,9 @@ export async function getDefaultBranch(
 ): Promise<string> {
   // This part is courtesy of https://stackoverflow.com/a/62397081/90297
   return stripRemoteName(
-    await git.revparse(['--abbrev-ref', `${remoteName}/HEAD`]),
+    await git
+      .remote(['set-head', remoteName, '--auto'])
+      .revparse(['--abbrev-ref', `${remoteName}/HEAD`]),
     remoteName
   );
 }


### PR DESCRIPTION
When we query for the default branch, we assume `origin/HEAD` exists. That said this ref is only set and needed when you clone a repo and GitHub's `action/checkout` seems to be doing something weird that doesn't set this, causing issues like https://github.com/getsentry/sentry-javascript/runs/2730108174?check_suite_focus=true#step:3:10. This patch should fix the issue.
