### PR TITLE
fix(registry): Fix error w/ simple registry config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.24.4
+
+- fix(registry): Fix error w/ simple registry config (#262)
+
 ## 0.24.3
 
 - upgrade(parse-url): Force parse-url>=5.0.3 for security (#261)

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -106,13 +106,13 @@ export class RegistryTarget extends BaseTarget {
   public getRegistryConfig(): RegistryConfig[] {
     const items = Object.entries(BATCH_KEYS).flatMap(([key, type]) =>
       Object.entries(this.config[key] || {}).map(([canonicalName, conf]) => {
-        const config = conf as Record<string, unknown>;
+        const config = conf as RegistryConfig | null;
         const result = Object.assign(Object.create(null), config, {
           type,
           canonicalName,
         });
 
-        if (typeof config.onlyIfPresent === 'string') {
+        if (typeof config?.onlyIfPresent === 'string') {
           result.onlyIfPresent = stringToRegexp(config.onlyIfPresent);
         }
 


### PR DESCRIPTION
Follow up to #259.

Fixes the `Cannot read property 'onlyIfPresent' of null` error
when using the new batch config for registry in without extra
config.

See
https://github.com/getsentry/publish/runs/2841903865?check_suite_focus=true#step:8:83

Unblocks getsentry/publish#400
