### PR TITLE
ref(maven): Support BOM files in `maven` target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat(maven): Add maven target to deploy to Maven Central (#258)
 - feat(symbol-collector): Add symbol-collector target (#266)
+- ref(maven): Support BOM files in `maven` target (#270)
 
 ## 0.24.4
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -151,7 +151,7 @@ describe('publish', () => {
     mvnTarget.artifactProvider.downloadArtifact = jest
       .fn()
       .mockResolvedValueOnce('artifact/download/path');
-    mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(undefined);
+    mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(false);
 
     await mvnTarget.upload('r3v1s10n');
 

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -12,6 +12,7 @@ import { retrySpawnProcess } from '../utils/async';
 import { withTempDir } from '../utils/files';
 import { ConfigurationError } from '../utils/errors';
 import { stringToRegexp } from '../utils/filters';
+import { checkEnvForPrerequisite } from '../utils/env';
 
 const GRADLE_PROPERTIES_FILENAME = 'gradle.properties';
 
@@ -20,7 +21,7 @@ const GRADLE_PROPERTIES_FILENAME = 'gradle.properties';
  * https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
  */
 const DEFAULT_GRADLE_USER_HOME = join(homedir(), '.gradle');
-const POM_DEFAULT_FILENAME = 'pom-default.xml';
+export const POM_DEFAULT_FILENAME = 'pom-default.xml';
 const POM_FILE_EXTNAME = '.xml'; // Must include the leading `.`
 const BOM_FILE_KEY_REGEXP = stringToRegexp('/<packaging>pom</packaging>/');
 
@@ -307,7 +308,7 @@ export class MavenTarget extends BaseTarget {
    * @param pomFilepath path to the POM.
    * @returns true if the POM is a BOM.
    */
-  private async isBomFile(pomFilepath: string): Promise<boolean> {
+  public async isBomFile(pomFilepath: string): Promise<boolean> {
     try {
       await fsPromises.access(pomFilepath, fsConstants.R_OK);
       const fileContents = await fsPromises.readFile(pomFilepath, {

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -286,6 +286,10 @@ export class MavenTarget extends BaseTarget {
     // renamed when extracting the ZIP, so the default name (`pom-default.xml`)
     // may not match. It's assumed that any renaming keeps the same extension,
     // so all files with the same extension are checked to identify the BOM.
+    // TODO: make sure all scenarios are considered and tested.
+    // Each file system may handle this case differently, and attended vs
+    // unattended mode also have different behaviours. It's not desired to get
+    // the BOM renamed in such a way that isn't handled by the target.
     const filesInDir = await fsPromises.readdir(distDir);
     const potentialPoms = filesInDir
       .filter(f => extname(f) === POM_FILE_EXT)
@@ -320,7 +324,7 @@ export class MavenTarget extends BaseTarget {
     } catch (error) {
       this.logger.warn(
         `Could not determine if path corresponds to a BOM file: ${pomFilepath}\n` +
-          `Error:\n`,
+          'Error:\n',
         error
       );
       return false;

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -5,12 +5,11 @@ import {
 } from '../artifact_providers/base';
 import { BaseTarget } from './base';
 import { homedir } from 'os';
-import { basename, join, parse } from 'path';
-import { promises as fsPromises } from 'fs';
+import { basename, extname, join, parse } from 'path';
+import { constants as fsConstants, promises as fsPromises } from 'fs';
 import { checkExecutableIsPresent, extractZipArchive } from '../utils/system';
 import { retrySpawnProcess } from '../utils/async';
 import { withTempDir } from '../utils/files';
-import { checkEnvForPrerequisite } from '../utils/env';
 import { ConfigurationError } from '../utils/errors';
 import { stringToRegexp } from '../utils/filters';
 
@@ -21,6 +20,9 @@ const GRADLE_PROPERTIES_FILENAME = 'gradle.properties';
  * https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
  */
 const DEFAULT_GRADLE_USER_HOME = join(homedir(), '.gradle');
+const POM_DEFAULT_FILENAME = 'pom-default.xml';
+const POM_FILE_EXTNAME = '.xml'; // Must include the leading `.`
+const BOM_FILE_KEY_REGEXP = stringToRegexp('/<packaging>pom</packaging>/');
 
 export const targetSecrets = ['OSSRH_USERNAME', 'OSSRH_PASSWORD'] as const;
 type SecretsType = typeof targetSecrets[number];
@@ -258,12 +260,92 @@ export class MavenTarget extends BaseTarget {
    * @param distDir directory of the distribution.
    */
   private async uploadDistribution(distDir: string): Promise<void> {
+    const bomFile = await this.getBomFileFomDist(distDir);
+    if (bomFile) {
+      this.logger.debug('Found BOM: ', bomFile);
+      await this.uploadBomDistribution(bomFile);
+    } else {
+      this.logger.debug('Did not find a BOM.');
+      await this.uploadPomDistribution(distDir);
+    }
+  }
+
+  private async getBomFileFomDist(
+    distDir: string
+  ): Promise<string | undefined> {
+    const pomFilepath = join(distDir, POM_DEFAULT_FILENAME);
+    if (await this.isBomFile(pomFilepath)) {
+      return pomFilepath;
+    }
+
+    // There may be several files in the ZIP-ed artifact with the same name,
+    // where the BOM may be one of them (there may not be a BOM). Files may be
+    // renamed when extracting the ZIP, so the default name (`pom-default.xml`)
+    // may not match. It's assumed that any renaming keeps the same extension,
+    // so all files with the same extension are checked to identify the BOM.
+    const filesInDir = await fsPromises.readdir(distDir);
+    const potentialPoms = filesInDir
+      .filter(f => extname(f) === POM_FILE_EXTNAME)
+      .filter(f => f !== POM_DEFAULT_FILENAME)
+      .map(f => join(distDir, f));
+
+    for (const f of potentialPoms) {
+      if (await this.isBomFile(f)) {
+        return f;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Returns whether the given POM is a BOM.
+   *
+   * A BOM file is a POM file with the following key:
+   * `<packaging>pom</packaging>`, usually named as `pom-default.xml`.
+   *
+   * @param pomFilepath path to the POM.
+   * @returns true if the POM is a BOM.
+   */
+  private async isBomFile(pomFilepath: string): Promise<boolean> {
+    try {
+      await fsPromises.access(pomFilepath, fsConstants.R_OK);
+      const fileContents = await fsPromises.readFile(pomFilepath, {
+        encoding: 'utf8',
+      });
+      const matchesRequiredKey = BOM_FILE_KEY_REGEXP.test(fileContents);
+      if (matchesRequiredKey) {
+        return true;
+      }
+      return false;
+    } catch (error) {
+      this.logger.warn(
+        `Error checking whether it's a BOM file: ${pomFilepath}\n`,
+        error
+      );
+      return false;
+    }
+  }
+
+  private async uploadBomDistribution(bomFile: string): Promise<void> {
+    await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
+      'gpg:sign-and-deploy-file',
+      `-Dfile=${bomFile}`,
+      `-DpomFile=${bomFile}`,
+      `-DrepositoryId=${this.mavenConfig.mavenRepoId}`,
+      `-Durl=${this.mavenConfig.mavenRepoUrl}`,
+      '--settings',
+      this.mavenConfig.mavenSettingsPath,
+    ]);
+  }
+
+  private async uploadPomDistribution(distDir: string): Promise<void> {
     const {
       targetFile,
       javadocFile,
       sourcesFile,
       pomFile,
-    } = this.getFilesForMavenCli(distDir);
+    } = this.getFilesForMavenPomDist(distDir);
 
     // Maven central is very flaky, so retrying with an exponential delay in
     // in case it fails.
@@ -288,7 +370,7 @@ export class MavenTarget extends BaseTarget {
    * @param distDir directory of the distribution.
    * @returns record of required files.
    */
-  private getFilesForMavenCli(distDir: string): Record<string, string> {
+  private getFilesForMavenPomDist(distDir: string): Record<string, string> {
     const moduleName = parse(distDir).base;
     return {
       targetFile: join(distDir, this.getTargetFilename(distDir)),

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -261,7 +261,7 @@ export class MavenTarget extends BaseTarget {
    * @param distDir directory of the distribution.
    */
   private async uploadDistribution(distDir: string): Promise<void> {
-    const bomFile = await this.getBomFileFomDist(distDir);
+    const bomFile = await this.getBomFileInDist(distDir);
     if (bomFile) {
       this.logger.debug('Found BOM: ', bomFile);
       await this.uploadBomDistribution(bomFile);
@@ -275,9 +275,7 @@ export class MavenTarget extends BaseTarget {
    * Returns the path to the BOM file in the given distribution directory, and
    * `undefined` if there isn't any.
    */
-  private async getBomFileFomDist(
-    distDir: string
-  ): Promise<string | undefined> {
+  private async getBomFileInDist(distDir: string): Promise<string | undefined> {
     const pomFilepath = join(distDir, POM_DEFAULT_FILENAME);
     if (await this.isBomFile(pomFilepath)) {
       return pomFilepath;


### PR DESCRIPTION
Add support for BOM files in the `maven` target.

This is based on [previous Kotlin code](https://github.com/getsentry/sentry-java/blob/bf425d511746782ee51a9ac475fa353997d6f34e/scripts/release.kts), but that's incomplete. A BOM file is a POM file with a `<packaging>pom</packaging>` key.

An artifact (the `zip` downloaded from GHA) may contain a POM and a BOM, both with the same name (`pom-default.xml` is the default name). In case both are present, unzipping the artifact may lead to having an unknown name for the BOM file (e.g. the POM is the `pom-default.xml`, and the BOM is ??). Thus, if the default file isn't a BOM, all `xml` files in the artifact are checked to not miss the BOM. If no BOM is found, the distribution is uploaded as it is now (without this PR); and if a BOM is found, a different command to upload files is run. Once artifacts have been uploaded, the registry is closed.