### PR TITLE
feat(maven): Optional `android` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - feat(maven): Add maven target to deploy to Maven Central (#258)
 - feat(symbol-collector): Add symbol-collector target (#266)
-- ref(maven): Support BOM files in `maven` target (#270)
-- ref(maven): Optional `android` config (#271)
+- feat(maven): Support BOM files in `maven` target (#270)
+- feat(maven): Optional `android` config (#271)
 
 ## 0.24.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(maven): Add maven target to deploy to Maven Central (#258)
 - feat(symbol-collector): Add symbol-collector target (#266)
 - ref(maven): Support BOM files in `maven` target (#270)
+- ref(maven): Optional `android` config (#271)
 
 ## 0.24.4
 

--- a/README.md
+++ b/README.md
@@ -1010,15 +1010,29 @@ PGP signs and publishes packages to Maven Central.
 | `mavenSettingsPath` | Path to the Maven `settings.xml` file.                                |
 | `mavenRepoId`       | ID of the Maven server in the `settings.xml`.                         |
 | `mavenRepoUrl`      | URL of the Maven repository.                                          |
-| `android`           | **optional** Structure containing the data available below.           |
+| `android`           | Android configuration, see below.                                     |
 
-The `android` structure is optional, but not including it when required may result in failing the release or even releasing wrong files. It contains the following options:
+If your project isn't related to Android, you don't need this configuration and
+can set the option to `false`. If not, set the following nested elements:
 
 - `distDirRegex`: pattern of distribution directory names.
 - `fileReplaceeRegex`: pattern of substring of distribution module names to be replaced to get the Android distribution file.
 - `fileReplacerStr`: string to be replaced in the module names to get the Android distribution file.
 
-**Example**
+**Example (without Android config)**
+
+```yaml
+targets:
+  - name: maven
+    gradleCliPath: ./gradlew
+    mavenCliPath: scripts/mvnw.cmd
+    mavenSettingsPath: scripts/settings.xml
+    mavenRepoId: ossrh
+    mavenRepoUrl: https://oss.sonatype.org/service/local/staging/deploy/maven2/
+    android: false
+```
+
+**Example (with Android config)**
 
 ```yaml
 targets:

--- a/README.md
+++ b/README.md
@@ -1010,12 +1010,12 @@ PGP signs and publishes packages to Maven Central.
 | `mavenSettingsPath` | Path to the Maven `settings.xml` file.                                |
 | `mavenRepoId`       | ID of the Maven server in the `settings.xml`.                         |
 | `mavenRepoUrl`      | URL of the Maven repository.                                          |
-| `android`           | Structure containing the data available below.                        |
+| `android`           | **optional** Structure containing the data available below.           |
 
-The `android` structure contains the following options:
+The `android` structure is optional, but not including it when required may result in failing the release or even releasing wrong files. It contains the following options:
 
 - `distDirRegex`: pattern of distribution directory names.
-- `fileReplaceeRegex` :pattern of substring of distribution module names to be replaced to get the Android distribution file.
+- `fileReplaceeRegex`: pattern of substring of distribution module names to be replaced to get the Android distribution file.
 - `fileReplacerStr`: string to be replaced in the module names to get the Android distribution file.
 
 **Example**

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -98,7 +98,7 @@ describe('Maven target configuration', () => {
   });
 
   test('env vars without options', () => {
-    expect(createMavenTarget.bind(this, {})).toThrowErrorMatchingInlineSnapshot(
+    expect(() => createMavenTarget({})).toThrowErrorMatchingInlineSnapshot(
       `"Required configuration gradleCliPath not found in configuration file. See the documentation for more details."`
     );
   });
@@ -106,20 +106,16 @@ describe('Maven target configuration', () => {
   test('no android config', () => {
     const config = getRequiredTargetConfig();
     delete config.android;
-    expect(
-      createMavenTarget.bind(this, config)
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Required Android configuration is incorrect or was not found in the configuration file. See the documentation for more details."`
+    expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
+      `"Required Android configuration was not found in the configuration file. See the documentation for more details"`
     );
   });
 
   test('incorrect one-line android config', () => {
     const config = getRequiredTargetConfig();
     config.android = 'yes';
-    expect(
-      createMavenTarget.bind(this, config)
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Required Android configuration is incorrect or was not found in the configuration file. See the documentation for more details."`
+    expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
+      `"Required Android configuration is incorrect. See the documentation for more details."`
     );
   });
 
@@ -132,10 +128,8 @@ describe('Maven target configuration', () => {
   test('incorrect object android config, missing prop', () => {
     const config = getFullTargetConfig();
     delete config.android.distDirRegex;
-    expect(
-      createMavenTarget.bind(this, config)
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Required Android configuration is incorrect or was not found in the configuration file. See the documentation for more details."`
+    expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
+      `"Required Android configuration is incorrect. See the documentation for more details."`
     );
   });
 
@@ -143,10 +137,8 @@ describe('Maven target configuration', () => {
     const config = getFullTargetConfig();
     delete config.android.distDirRegex;
     config.android.anotherParam = 'unused';
-    expect(
-      createMavenTarget.bind(this, config)
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Required Android configuration is incorrect or was not found in the configuration file. See the documentation for more details."`
+    expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
+      `"Required Android configuration is incorrect. See the documentation for more details."`
     );
   });
 
@@ -155,9 +147,7 @@ describe('Maven target configuration', () => {
     config.android.additionalProp = 'not relevant';
     const mvnTarget = createMavenTarget(config);
     const androidConfig: any = mvnTarget.mavenConfig.android;
-    expect(androidConfig.distDirRegex).toBeDefined();
-    expect(androidConfig.fileReplaceeRegex).toBeDefined();
-    expect(androidConfig.fileReplacerStr).toBeDefined();
+    expect(config.android).toMatchObject(androidConfig);
     expect(androidConfig.additionalProp).not.toBeDefined();
   });
 
@@ -182,15 +172,9 @@ describe('Maven target configuration', () => {
         })
       )
     );
-    expect(mvnTarget.config.android.distDirRegex).toStrictEqual(
-      expect.any(String)
-    );
-    expect(mvnTarget.config.android.fileReplaceeRegex).toStrictEqual(
-      expect.any(String)
-    );
-    expect(mvnTarget.config.android.fileReplacerStr).toStrictEqual(
-      expect.any(String)
-    );
+    expect(typeof mvnTarget.config.android.distDirRegex).toBe('string');
+    expect(typeof mvnTarget.config.android.fileReplaceeRegex).toBe('string');
+    expect(typeof mvnTarget.config.android.fileReplacerStr).toBe('string');
   });
 });
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -46,7 +46,7 @@ function removeTargetSecretsFromEnv(): void {
   }
 }
 
-function getTargetOptions() {
+function getAllTargetOptions() {
   return {
     OSSRH_USERNAME: DEFAULT_OPTION_VALUE,
     OSSRH_PASSWORD: DEFAULT_OPTION_VALUE,
@@ -63,10 +63,24 @@ function getTargetOptions() {
   };
 }
 
+function getRequiredTargetOptions() {
+  return {
+    OSSRH_USERNAME: DEFAULT_OPTION_VALUE,
+    OSSRH_PASSWORD: DEFAULT_OPTION_VALUE,
+    gradleCliPath: DEFAULT_OPTION_VALUE,
+    mavenCliPath: DEFAULT_OPTION_VALUE,
+    mavenSettingsPath: DEFAULT_OPTION_VALUE,
+    mavenRepoId: DEFAULT_OPTION_VALUE,
+    mavenRepoUrl: DEFAULT_OPTION_VALUE,
+  };
+}
+
 function createMavenTarget(
   targetOptions?: Record<string, unknown>
 ): MavenTarget {
-  const finalOptions = targetOptions ? targetOptions : getTargetOptions();
+  const finalOptions = targetOptions
+    ? targetOptions
+    : getRequiredTargetOptions();
   const mergedOptions = {
     name: 'maven',
     ...finalOptions,
@@ -77,9 +91,9 @@ function createMavenTarget(
 describe('Maven target configuration', () => {
   beforeEach(() => removeTargetSecretsFromEnv());
 
-  test('with options', () => {
+  test('with only required options', () => {
     setTargetSecretsInEnv();
-    const mvnTarget = createMavenTarget(getTargetOptions());
+    const mvnTarget = createMavenTarget(getRequiredTargetOptions());
     targetOptions.map(secret =>
       expect(mvnTarget.config).toEqual(
         expect.objectContaining({
@@ -89,7 +103,28 @@ describe('Maven target configuration', () => {
     );
   });
 
-  test('without options', () =>
+  test('with all options', () => {
+    setTargetSecretsInEnv();
+    const mvnTarget = createMavenTarget(getAllTargetOptions());
+    targetOptions.map(secret =>
+      expect(mvnTarget.config).toEqual(
+        expect.objectContaining({
+          [secret]: DEFAULT_OPTION_VALUE,
+        })
+      )
+    );
+    expect(mvnTarget.config.android.distDirRegex).toStrictEqual(
+      expect.any(String)
+    );
+    expect(mvnTarget.config.android.fileReplaceeRegex).toStrictEqual(
+      expect.any(String)
+    );
+    expect(mvnTarget.config.android.fileReplacerStr).toStrictEqual(
+      expect.any(String)
+    );
+  });
+
+  test('without any options', () =>
     expect(createMavenTarget).toThrowErrorMatchingInlineSnapshot(
       `"Required value(s) OSSRH_USERNAME not found in configuration files or the environment. See the documentation for more details."`
     ));

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -140,7 +140,7 @@ export class MavenTarget extends BaseTarget {
       !this.config.android.fileReplacerStr
     ) {
       throw new ConfigurationError(
-        'Required Android configuration not found in configuration file. ' +
+        'Required Android configuration is incorrect or was not found in the configuration file. ' +
           'See the documentation for more details.'
       );
     }

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -133,15 +133,20 @@ export class MavenTarget extends BaseTarget {
       };
     }
 
+    if (!this.config.android) {
+      throw new ConfigurationError(
+        'Required Android configuration was not found in the configuration file. ' +
+          'See the documentation for more details'
+      );
+    }
+
     if (
-      !this.config.android ||
       !this.config.android.distDirRegex ||
       !this.config.android.fileReplaceeRegex ||
       !this.config.android.fileReplacerStr
     ) {
       throw new ConfigurationError(
-        'Required Android configuration is incorrect or was not found in the configuration file. ' +
-          'See the documentation for more details.'
+        'Required Android configuration is incorrect. See the documentation for more details.'
       );
     }
 


### PR DESCRIPTION
The `maven` target is responsible for releases related to Maven. Currently, the Android configuration is required, but there are scenarios where it isn't used (e.g. https://github.com/getsentry/sentry-android-gradle-plugin). This PR makes the android configuration optional.