### PR TITLE
ref(maven): Improve logging for `maven` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,6 +994,8 @@ targets:
 
 PGP signs and publishes packages to Maven Central.
 
+Note: in order to see the output of the commands, set the [logging level](#logging-level) to `trace`.
+
 **Environment**
 
 | Name             | Description                      |

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -160,7 +160,7 @@ describe('publish', () => {
       typeof retrySpawnProcess
     >).mock.calls[0];
 
-    expect(callArgs).toHaveLength(2);
+    expect(callArgs).toHaveLength(4);
     expect(callArgs[0]).toEqual(DEFAULT_OPTION_VALUE);
 
     const cmdArgs = callArgs[1] as string[];
@@ -181,6 +181,9 @@ describe('publish', () => {
     expect(cmdArgs[7]).toBe(`-Durl=${DEFAULT_OPTION_VALUE}`);
     expect(cmdArgs[8]).toBe('--settings');
     expect(cmdArgs[9]).toBe(DEFAULT_OPTION_VALUE);
+    expect(callArgs[2]).toEqual({});
+    // log level isn't >= debug on tests
+    expect(callArgs[3]).toEqual({ showStdout: false });
   });
 
   test('upload BOM', async () => {
@@ -208,7 +211,7 @@ describe('publish', () => {
       typeof retrySpawnProcess
     >).mock.calls[0];
 
-    expect(callArgs).toHaveLength(2);
+    expect(callArgs).toHaveLength(4);
     expect(callArgs[0]).toEqual(DEFAULT_OPTION_VALUE);
 
     const cmdArgs = callArgs[1] as string[];
@@ -224,6 +227,9 @@ describe('publish', () => {
     expect(cmdArgs[4]).toBe(`-Durl=${DEFAULT_OPTION_VALUE}`);
     expect(cmdArgs[5]).toBe('--settings');
     expect(cmdArgs[6]).toBe(DEFAULT_OPTION_VALUE);
+    expect(callArgs[2]).toEqual({});
+    // log level isn't >= debug on tests
+    expect(callArgs[3]).toEqual({ showStdout: false });
   });
 });
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -160,7 +160,7 @@ describe('publish', () => {
       typeof retrySpawnProcess
     >).mock.calls[0];
 
-    expect(callArgs).toHaveLength(4);
+    expect(callArgs).toHaveLength(2);
     expect(callArgs[0]).toEqual(DEFAULT_OPTION_VALUE);
 
     const cmdArgs = callArgs[1] as string[];
@@ -181,9 +181,6 @@ describe('publish', () => {
     expect(cmdArgs[7]).toBe(`-Durl=${DEFAULT_OPTION_VALUE}`);
     expect(cmdArgs[8]).toBe('--settings');
     expect(cmdArgs[9]).toBe(DEFAULT_OPTION_VALUE);
-    expect(callArgs[2]).toEqual({});
-    // log level isn't >= debug on tests
-    expect(callArgs[3]).toEqual({ showStdout: false });
   });
 
   test('upload BOM', async () => {
@@ -211,7 +208,7 @@ describe('publish', () => {
       typeof retrySpawnProcess
     >).mock.calls[0];
 
-    expect(callArgs).toHaveLength(4);
+    expect(callArgs).toHaveLength(2);
     expect(callArgs[0]).toEqual(DEFAULT_OPTION_VALUE);
 
     const cmdArgs = callArgs[1] as string[];
@@ -227,9 +224,6 @@ describe('publish', () => {
     expect(cmdArgs[4]).toBe(`-Durl=${DEFAULT_OPTION_VALUE}`);
     expect(cmdArgs[5]).toBe('--settings');
     expect(cmdArgs[6]).toBe(DEFAULT_OPTION_VALUE);
-    expect(callArgs[2]).toEqual({});
-    // log level isn't >= debug on tests
-    expect(callArgs[3]).toEqual({ showStdout: false });
   });
 });
 

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -13,7 +13,6 @@ import { withTempDir } from '../utils/files';
 import { ConfigurationError } from '../utils/errors';
 import { stringToRegexp } from '../utils/filters';
 import { checkEnvForPrerequisite } from '../utils/env';
-import { LogLevel } from 'consola';
 
 const GRADLE_PROPERTIES_FILENAME = 'gradle.properties';
 
@@ -332,20 +331,15 @@ export class MavenTarget extends BaseTarget {
   }
 
   private async uploadBomDistribution(bomFile: string): Promise<void> {
-    await retrySpawnProcess(
-      this.mavenConfig.mavenCliPath,
-      [
-        'gpg:sign-and-deploy-file',
-        `-Dfile=${bomFile}`,
-        `-DpomFile=${bomFile}`,
-        `-DrepositoryId=${this.mavenConfig.mavenRepoId}`,
-        `-Durl=${this.mavenConfig.mavenRepoUrl}`,
-        '--settings',
-        this.mavenConfig.mavenSettingsPath,
-      ],
-      {},
-      { showStdout: this.logger.level >= LogLevel.Debug }
-    );
+    await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
+      'gpg:sign-and-deploy-file',
+      `-Dfile=${bomFile}`,
+      `-DpomFile=${bomFile}`,
+      `-DrepositoryId=${this.mavenConfig.mavenRepoId}`,
+      `-Durl=${this.mavenConfig.mavenRepoUrl}`,
+      '--settings',
+      this.mavenConfig.mavenSettingsPath,
+    ]);
   }
 
   private async uploadPomDistribution(distDir: string): Promise<void> {
@@ -358,23 +352,18 @@ export class MavenTarget extends BaseTarget {
 
     // Maven central is very flaky, so retrying with an exponential delay in
     // in case it fails.
-    await retrySpawnProcess(
-      this.mavenConfig.mavenCliPath,
-      [
-        'gpg:sign-and-deploy-file',
-        `-Dfile=${targetFile}`,
-        `-Dfiles=${javadocFile},${sourcesFile}`,
-        `-Dclassifiers=javadoc,sources`,
-        `-Dtypes=jar,jar`,
-        `-DpomFile=${pomFile}`,
-        `-DrepositoryId=${this.mavenConfig.mavenRepoId}`,
-        `-Durl=${this.mavenConfig.mavenRepoUrl}`,
-        `--settings`,
-        `${this.mavenConfig.mavenSettingsPath}`,
-      ],
-      {},
-      { showStdout: this.logger.level >= LogLevel.Debug }
-    );
+    await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
+      'gpg:sign-and-deploy-file',
+      `-Dfile=${targetFile}`,
+      `-Dfiles=${javadocFile},${sourcesFile}`,
+      `-Dclassifiers=javadoc,sources`,
+      `-Dtypes=jar,jar`,
+      `-DpomFile=${pomFile}`,
+      `-DrepositoryId=${this.mavenConfig.mavenRepoId}`,
+      `-Durl=${this.mavenConfig.mavenRepoUrl}`,
+      `--settings`,
+      `${this.mavenConfig.mavenSettingsPath}`,
+    ]);
   }
 
   /**

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -266,7 +266,6 @@ export class MavenTarget extends BaseTarget {
       this.logger.debug('Found BOM: ', bomFile);
       await this.uploadBomDistribution(bomFile);
     } else {
-      this.logger.debug('Did not find a BOM.');
       await this.uploadPomDistribution(distDir);
     }
   }

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -331,7 +331,7 @@ export class MavenTarget extends BaseTarget {
   }
 
   private async uploadBomDistribution(bomFile: string): Promise<void> {
-    await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
+    const cmdOutput = await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
       'gpg:sign-and-deploy-file',
       `-Dfile=${bomFile}`,
       `-DpomFile=${bomFile}`,
@@ -340,6 +340,7 @@ export class MavenTarget extends BaseTarget {
       '--settings',
       this.mavenConfig.mavenSettingsPath,
     ]);
+    this.logCmdOutput(cmdOutput);
   }
 
   private async uploadPomDistribution(distDir: string): Promise<void> {
@@ -352,7 +353,7 @@ export class MavenTarget extends BaseTarget {
 
     // Maven central is very flaky, so retrying with an exponential delay in
     // in case it fails.
-    await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
+    const cmdOutput = await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
       'gpg:sign-and-deploy-file',
       `-Dfile=${targetFile}`,
       `-Dfiles=${javadocFile},${sourcesFile}`,
@@ -364,6 +365,7 @@ export class MavenTarget extends BaseTarget {
       `--settings`,
       `${this.mavenConfig.mavenSettingsPath}`,
     ]);
+    this.logCmdOutput(cmdOutput);
   }
 
   /**
@@ -409,5 +411,15 @@ export class MavenTarget extends BaseTarget {
           this.mavenConfig.android.fileReplacerStr
         )
       : `${moduleName}.jar`;
+  }
+
+  private logCmdOutput(output: Buffer | undefined): void {
+    if (output) {
+      if (output.length === 0) {
+        this.logger.debug(`The command didn't have any output.`);
+      } else {
+        this.logger.debug('Command output:\n', output.toString());
+      }
+    }
   }
 }


### PR DESCRIPTION
- Don't log when not finding BOMs. Most of the packages aren't supposed to be BOM files, and logging this may give the impression that something is missing when it's not.
- Add a note to the target's docs to show command output when the log level is `trace`. 