### PR TITLE
feat(maven): Remove Gradle properties after publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(maven): Add maven target to deploy to Maven Central (#258)
 - feat(symbol-collector): Add symbol-collector target (#266)
 - ref(maven): Support BOM files in `maven` target (#270)
+- feat(maven): Remove Gradle properties after publishing (#276)
 
 ## 0.24.4
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -18,6 +18,7 @@ jest.mock('fs', () => ({
     writeFile: jest.fn(() => Promise.resolve()),
     readFile: jest.fn((file: string) => file),
     readdir: async () => Promise.resolve([]), // empty dir
+    unlink: jest.fn(),
   },
 }));
 
@@ -104,10 +105,14 @@ describe('publish', () => {
   test('main flow', async () => {
     const callOrder: string[] = [];
     const mvnTarget = createMavenTarget();
-    const gradlePropsMock = jest.fn(
-      async () => void callOrder.push('gradleProps')
+    const createGradlePropsMock = jest.fn(
+      async () => void callOrder.push('createGradleProps')
     );
-    mvnTarget.createUserGradlePropsFile = gradlePropsMock;
+    mvnTarget.createUserGradlePropsFile = createGradlePropsMock;
+    const deleteGradlePropsMock = jest.fn(
+      async () => void callOrder.push('deleteGradleProps')
+    );
+    mvnTarget.deleteUserGradlePropsFile = deleteGradlePropsMock;
     const uploadMock = jest.fn(async () => void callOrder.push('upload'));
     mvnTarget.upload = uploadMock;
     (retrySpawnProcess as jest.MockedFunction<
@@ -118,7 +123,7 @@ describe('publish', () => {
 
     const revision = 'r3v1s10n';
     await mvnTarget.publish('1.0.0', revision);
-    expect(gradlePropsMock).toHaveBeenCalledTimes(1);
+    expect(createGradlePropsMock).toHaveBeenCalledTimes(1);
     expect(uploadMock).toHaveBeenCalledTimes(1);
     expect(uploadMock).toHaveBeenLastCalledWith(revision);
     expect(retrySpawnProcess).toHaveBeenCalledTimes(1);
@@ -126,9 +131,10 @@ describe('publish', () => {
       'closeAndReleaseRepository',
     ]);
     expect(callOrder).toStrictEqual([
-      'gradleProps',
+      'createGradleProps',
       'upload',
       'closeAndRelease',
+      'deleteGradleProps',
     ]);
   });
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -18,9 +18,6 @@ jest.mock('fs', () => ({
     writeFile: jest.fn(() => Promise.resolve()),
     readFile: jest.fn((file: string) => file),
     readdir: async () => Promise.resolve([]), // empty dir
-    access: jest.fn().mockImplementation(() => {
-      // do nothing
-    }),
   },
 }));
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -126,6 +126,7 @@ describe('publish', () => {
     expect(createGradlePropsMock).toHaveBeenCalledTimes(1);
     expect(uploadMock).toHaveBeenCalledTimes(1);
     expect(uploadMock).toHaveBeenLastCalledWith(revision);
+    expect(deleteGradlePropsMock).toHaveBeenCalledTimes(1);
     expect(retrySpawnProcess).toHaveBeenCalledTimes(1);
     expect(retrySpawnProcess).toHaveBeenCalledWith(DEFAULT_OPTION_VALUE, [
       'closeAndReleaseRepository',

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -305,7 +305,7 @@ export class MavenTarget extends BaseTarget {
       .filter(f => f !== POM_DEFAULT_FILENAME && extname(f) === POM_FILE_EXT)
       .map(f => join(distDir, f));
 
-    return potentialPoms.find(async f => await this.isBomFile(f));
+    return potentialPoms.find(f => this.isBomFile(f));
   }
 
   /**

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -6,7 +6,7 @@ import {
 import { BaseTarget } from './base';
 import { homedir } from 'os';
 import { basename, extname, join, parse } from 'path';
-import { constants as fsConstants, promises as fsPromises } from 'fs';
+import { promises as fsPromises } from 'fs';
 import { checkExecutableIsPresent, extractZipArchive } from '../utils/system';
 import { retrySpawnProcess } from '../utils/async';
 import { withTempDir } from '../utils/files';
@@ -23,7 +23,7 @@ const GRADLE_PROPERTIES_FILENAME = 'gradle.properties';
 const DEFAULT_GRADLE_USER_HOME = join(homedir(), '.gradle');
 export const POM_DEFAULT_FILENAME = 'pom-default.xml';
 const POM_FILE_EXT = '.xml'; // Must include the leading `.`
-const BOM_FILE_KEY_REGEXP = stringToRegexp('/<packaging>pom</packaging>/');
+const BOM_FILE_KEY_REGEXP = new RegExp('<packaging>pom</packaging>');
 
 export const targetSecrets = ['OSSRH_USERNAME', 'OSSRH_PASSWORD'] as const;
 type SecretsType = typeof targetSecrets[number];
@@ -302,8 +302,7 @@ export class MavenTarget extends BaseTarget {
     // the BOM renamed in such a way that isn't handled by the target.
     const filesInDir = await fsPromises.readdir(distDir);
     const potentialPoms = filesInDir
-      .filter(f => extname(f) === POM_FILE_EXT)
-      .filter(f => f !== POM_DEFAULT_FILENAME)
+      .filter(f => f !== POM_DEFAULT_FILENAME && extname(f) === POM_FILE_EXT)
       .map(f => join(distDir, f));
 
     for (const f of potentialPoms) {
@@ -326,7 +325,6 @@ export class MavenTarget extends BaseTarget {
    */
   public async isBomFile(pomFilepath: string): Promise<boolean> {
     try {
-      await fsPromises.access(pomFilepath, fsConstants.R_OK);
       const fileContents = await fsPromises.readFile(pomFilepath, {
         encoding: 'utf8',
       });

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -305,13 +305,7 @@ export class MavenTarget extends BaseTarget {
       .filter(f => f !== POM_DEFAULT_FILENAME && extname(f) === POM_FILE_EXT)
       .map(f => join(distDir, f));
 
-    for (const f of potentialPoms) {
-      if (await this.isBomFile(f)) {
-        return f;
-      }
-    }
-
-    return undefined;
+    return potentialPoms.find(async f => await this.isBomFile(f));
   }
 
   /**

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -186,6 +186,7 @@ export class MavenTarget extends BaseTarget {
     await retrySpawnProcess(this.mavenConfig.gradleCliPath, [
       'closeAndReleaseRepository',
     ]);
+    await this.deleteUserGradlePropsFile();
   }
 
   /**
@@ -202,6 +203,15 @@ export class MavenTarget extends BaseTarget {
         `mavenCentralUsername=${this.mavenConfig.OSSRH_USERNAME}`,
         `mavenCentralPassword=${this.mavenConfig.OSSRH_PASSWORD}`,
       ].join('\n')
+    );
+  }
+
+  /**
+   * Deletes the user's `gradle.properties` file.
+   */
+  public deleteUserGradlePropsFile(): Promise<void> {
+    return fsPromises.unlink(
+      join(this.getGradleHomeDir(), GRADLE_PROPERTIES_FILENAME)
     );
   }
 


### PR DESCRIPTION
Removing the `gradle.properties` after running the maven target may prevent exposing it, which contains the OSSRH credentials (see https://github.com/getsentry/craft/issues/272). There also are minor changes to address some feedback in https://github.com/getsentry/craft/pull/270.