### PR TITLE
test(symcollector): Add tests for filter options

### DIFF
--- a/src/artifact_providers/__tests__/base.test.ts
+++ b/src/artifact_providers/__tests__/base.test.ts
@@ -11,13 +11,13 @@ describe('parseFilterOptions', () => {
   test.each([
     [undefined, undefined],
     [undefined, '/exclude/'],
-    [undefined, new RegExp('exclude')],
+    [undefined, /exclude/],
     ['/include/', undefined],
-    [new RegExp('include'), undefined],
+    [/include/, undefined],
     ['/include/', '/exclude/'],
-    ['/include/', new RegExp('exclude')],
-    [new RegExp('include'), '/exclude/'],
-    [new RegExp('include'), new RegExp('exclude')],
+    ['/include/', /exclude/],
+    [/include/, '/exclude/'],
+    [/include/, /exclude/],
   ])(
     'undefined, string and regexp properties',
     (includeNames, excludeNames) => {
@@ -27,25 +27,13 @@ describe('parseFilterOptions', () => {
       };
       const parsedFilters = parseFilterOptions(rawFilters);
 
-      if (includeNames) {
-        expect(parsedFilters.includeNames).toStrictEqual(
-          typeof includeNames === 'string'
-            ? new RegExp(includeNames.slice(1, -1))
-            : includeNames
-        );
-      } else {
-        expect(parsedFilters.includeNames).not.toBeDefined();
-      }
+      expect(parsedFilters.includeNames).toStrictEqual(
+        includeNames && /include/
+      );
 
-      if (excludeNames) {
-        expect(parsedFilters.excludeNames).toStrictEqual(
-          typeof excludeNames === 'string'
-            ? new RegExp(excludeNames.slice(1, -1))
-            : excludeNames
-        );
-      } else {
-        expect(parsedFilters.excludeNames).not.toBeDefined();
-      }
+      expect(parsedFilters.excludeNames).toStrictEqual(
+        excludeNames && /exclude/
+      );
     }
   );
 });

--- a/src/artifact_providers/__tests__/base.test.ts
+++ b/src/artifact_providers/__tests__/base.test.ts
@@ -9,33 +9,73 @@ describe('parseFilterOptions', () => {
     expect(parsedFilters).not.toHaveProperty('excludeNames');
   });
 
-  test('undefined properties', () => {
+  test.each([
+    [undefined, undefined],
+    [undefined, '/onlyExclude/'],
+    ['/onlyInclude/', undefined],
+    ['/include/', '/exclude/'],
+  ])('undefined and string properties', (includeNames, excludeNames) => {
     const rawFilters: RawFilterOptions = {
-      includeNames: undefined,
-      excludeNames: undefined,
+      includeNames: includeNames,
+      excludeNames: excludeNames,
     };
     const parsedFilters = parseFilterOptions(rawFilters);
-    expect(parsedFilters).not.toHaveProperty('includeNames');
-    expect(parsedFilters).not.toHaveProperty('excludeNames');
+
+    if (includeNames) {
+      expect(parsedFilters.includeNames).toStrictEqual(
+        stringToRegexp(includeNames)
+      );
+    } else {
+      expect(parsedFilters.includeNames).not.toBeDefined();
+    }
+    if (excludeNames) {
+      expect(parsedFilters.excludeNames).toStrictEqual(
+        stringToRegexp(excludeNames)
+      );
+    } else {
+      expect(parsedFilters.excludeNames).not.toBeDefined();
+    }
   });
 
-  test('string properties', () => {
-    const stringFilter = '/testFilter/';
+  test.each([
+    [undefined, undefined],
+    [undefined, new RegExp('onlyExclude')],
+    [new RegExp('onlyInclude'), undefined],
+    [new RegExp('include'), new RegExp('exclude')],
+  ])('undefined and regex properties', (includeNames, excludeNames) => {
     const rawFilters: RawFilterOptions = {
-      includeNames: stringFilter,
+      includeNames: includeNames,
+      excludeNames: excludeNames,
     };
     const parsedFilters = parseFilterOptions(rawFilters);
-    expect(parsedFilters.includeNames).toStrictEqual(
-      stringToRegexp(stringFilter)
-    );
+
+    if (includeNames) {
+      expect(parsedFilters.includeNames).toStrictEqual(includeNames);
+    } else {
+      expect(parsedFilters.includeNames).not.toBeDefined();
+    }
+    if (excludeNames) {
+      expect(parsedFilters.excludeNames).toStrictEqual(excludeNames);
+    } else {
+      expect(parsedFilters.excludeNames).not.toBeDefined();
+    }
   });
 
-  test('regex properties', () => {
-    const regexFilter = stringToRegexp('/testFilter/');
-    const rawFilters: RawFilterOptions = {
-      includeNames: regexFilter,
+  test('string and regex properties', () => {
+    const strIncNames: RawFilterOptions = {
+      includeNames: '/string/',
+      excludeNames: new RegExp('regexp'),
     };
-    const parsedFilters = parseFilterOptions(rawFilters);
-    expect(parsedFilters.includeNames).toStrictEqual(regexFilter);
+    const parsedStrInc = parseFilterOptions(strIncNames);
+    expect(parsedStrInc.includeNames).toStrictEqual(stringToRegexp('/string/'));
+    expect(parsedStrInc.excludeNames).toStrictEqual(new RegExp('regexp'));
+
+    const rgxIncNames: RawFilterOptions = {
+      includeNames: new RegExp('regexp'),
+      excludeNames: '/string/',
+    };
+    const parsedRgxInc = parseFilterOptions(rgxIncNames);
+    expect(parsedRgxInc.includeNames).toStrictEqual(new RegExp('regexp'));
+    expect(parsedRgxInc.excludeNames).toStrictEqual(stringToRegexp('/string/'));
   });
 });

--- a/src/artifact_providers/__tests__/base.test.ts
+++ b/src/artifact_providers/__tests__/base.test.ts
@@ -1,4 +1,3 @@
-import { stringToRegexp } from '../../utils/filters';
 import { parseFilterOptions, RawFilterOptions } from '../base';
 
 describe('parseFilterOptions', () => {
@@ -11,71 +10,42 @@ describe('parseFilterOptions', () => {
 
   test.each([
     [undefined, undefined],
-    [undefined, '/onlyExclude/'],
-    ['/onlyInclude/', undefined],
+    [undefined, '/exclude/'],
+    [undefined, new RegExp('exclude')],
+    ['/include/', undefined],
+    [new RegExp('include'), undefined],
     ['/include/', '/exclude/'],
-  ])('undefined and string properties', (includeNames, excludeNames) => {
-    const rawFilters: RawFilterOptions = {
-      includeNames: includeNames,
-      excludeNames: excludeNames,
-    };
-    const parsedFilters = parseFilterOptions(rawFilters);
-
-    if (includeNames) {
-      expect(parsedFilters.includeNames).toStrictEqual(
-        stringToRegexp(includeNames)
-      );
-    } else {
-      expect(parsedFilters.includeNames).not.toBeDefined();
-    }
-    if (excludeNames) {
-      expect(parsedFilters.excludeNames).toStrictEqual(
-        stringToRegexp(excludeNames)
-      );
-    } else {
-      expect(parsedFilters.excludeNames).not.toBeDefined();
-    }
-  });
-
-  test.each([
-    [undefined, undefined],
-    [undefined, new RegExp('onlyExclude')],
-    [new RegExp('onlyInclude'), undefined],
+    ['/include/', new RegExp('exclude')],
+    [new RegExp('include'), '/exclude/'],
     [new RegExp('include'), new RegExp('exclude')],
-  ])('undefined and regex properties', (includeNames, excludeNames) => {
-    const rawFilters: RawFilterOptions = {
-      includeNames: includeNames,
-      excludeNames: excludeNames,
-    };
-    const parsedFilters = parseFilterOptions(rawFilters);
+  ])(
+    'undefined, string and regexp properties',
+    (includeNames, excludeNames) => {
+      const rawFilters: RawFilterOptions = {
+        includeNames: includeNames,
+        excludeNames: excludeNames,
+      };
+      const parsedFilters = parseFilterOptions(rawFilters);
 
-    if (includeNames) {
-      expect(parsedFilters.includeNames).toStrictEqual(includeNames);
-    } else {
-      expect(parsedFilters.includeNames).not.toBeDefined();
+      if (includeNames) {
+        expect(parsedFilters.includeNames).toStrictEqual(
+          typeof includeNames === 'string'
+            ? new RegExp(includeNames.slice(1, -1))
+            : includeNames
+        );
+      } else {
+        expect(parsedFilters.includeNames).not.toBeDefined();
+      }
+
+      if (excludeNames) {
+        expect(parsedFilters.excludeNames).toStrictEqual(
+          typeof excludeNames === 'string'
+            ? new RegExp(excludeNames.slice(1, -1))
+            : excludeNames
+        );
+      } else {
+        expect(parsedFilters.excludeNames).not.toBeDefined();
+      }
     }
-    if (excludeNames) {
-      expect(parsedFilters.excludeNames).toStrictEqual(excludeNames);
-    } else {
-      expect(parsedFilters.excludeNames).not.toBeDefined();
-    }
-  });
-
-  test('string and regex properties', () => {
-    const strIncNames: RawFilterOptions = {
-      includeNames: '/string/',
-      excludeNames: new RegExp('regexp'),
-    };
-    const parsedStrInc = parseFilterOptions(strIncNames);
-    expect(parsedStrInc.includeNames).toStrictEqual(stringToRegexp('/string/'));
-    expect(parsedStrInc.excludeNames).toStrictEqual(new RegExp('regexp'));
-
-    const rgxIncNames: RawFilterOptions = {
-      includeNames: new RegExp('regexp'),
-      excludeNames: '/string/',
-    };
-    const parsedRgxInc = parseFilterOptions(rgxIncNames);
-    expect(parsedRgxInc.includeNames).toStrictEqual(new RegExp('regexp'));
-    expect(parsedRgxInc.excludeNames).toStrictEqual(stringToRegexp('/string/'));
-  });
+  );
 });

--- a/src/targets/__tests__/symbolCollector.test.ts
+++ b/src/targets/__tests__/symbolCollector.test.ts
@@ -60,10 +60,6 @@ describe('target config', () => {
       '"The required `batchType` parameter is missing in the configuration file. ' +
         'See the documentation for more details."'
     );
-    expect(checkExecutableIsPresent).toHaveBeenCalledTimes(1);
-    expect(checkExecutableIsPresent).toHaveBeenCalledWith(
-      SYM_COLLECTOR_BIN_NAME
-    );
   });
 
   test('symbol collector present and config ok', () => {

--- a/src/targets/symbolCollector.ts
+++ b/src/targets/symbolCollector.ts
@@ -36,12 +36,13 @@ export class SymbolCollector extends BaseTarget {
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);
-    // The Symbol Collector should be available in the path
-    checkExecutableIsPresent(SYM_COLLECTOR_BIN_NAME);
     this.symbolCollectorConfig = this.getSymbolCollectorConfig();
   }
 
   private getSymbolCollectorConfig(): SymbolCollectorTargetConfig {
+    // The Symbol Collector should be available in the path
+    checkExecutableIsPresent(SYM_COLLECTOR_BIN_NAME);
+
     if (!this.config.batchType) {
       throw new ConfigurationError(
         'The required `batchType` parameter is missing in the configuration file. ' +

--- a/src/targets/symbolCollector.ts
+++ b/src/targets/symbolCollector.ts
@@ -36,13 +36,12 @@ export class SymbolCollector extends BaseTarget {
     artifactProvider: BaseArtifactProvider
   ) {
     super(config, artifactProvider);
+    // The Symbol Collector should be available in the path
+    checkExecutableIsPresent(SYM_COLLECTOR_BIN_NAME);
     this.symbolCollectorConfig = this.getSymbolCollectorConfig();
   }
 
   private getSymbolCollectorConfig(): SymbolCollectorTargetConfig {
-    // The Symbol Collector should be available in the path
-    checkExecutableIsPresent(SYM_COLLECTOR_BIN_NAME);
-
     if (!this.config.batchType) {
       throw new ConfigurationError(
         'The required `batchType` parameter is missing in the configuration file. ' +
@@ -68,6 +67,7 @@ export class SymbolCollector extends BaseTarget {
     const bundleId = this.symbolCollectorConfig.bundleIdPrefix + version;
     const artifacts = await this.getArtifactsForRevision(revision, {
       includeNames: this.config.includeNames,
+      excludeNames: this.config.excludeNames,
     });
 
     if (artifacts.length === 0) {


### PR DESCRIPTION
- Clean up tests for the base artifact provider.
- Add tests to cover more edge-cases, such as having strings, regex, and undefined on the same call.
- Other minor changes.