### PR TITLE
fix(maven): Snapshot gradle props instead of deleting

### DIFF
--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -219,7 +219,7 @@ export class MavenTarget extends BaseTarget {
    * @returns The path to the snapshot in the given directory,
    *  or `undefined` if the snapshot wasn't created.
    */
-  private async makeGradlePropsSnapshot(
+  public async makeGradlePropsSnapshot(
     snapshotDir: string
   ): Promise<string | undefined> {
     const propsExpectedPath = this.getGradlePropsPath();
@@ -259,7 +259,7 @@ export class MavenTarget extends BaseTarget {
    *
    * @param snapshotPath Path to the snapshot of the gradle properties file.
    */
-  private async recoverGradlePropsSnapshot(
+  public async recoverGradlePropsSnapshot(
     snapshotPath: string | undefined
   ): Promise<void> {
     if (!snapshotPath) {


### PR DESCRIPTION
From https://github.com/getsentry/craft/pull/276 the gradle properties file was removed, causing the loss of any user config that may exist in that file. This PR makes a snapshot of the file at the beginning of the `maven` target execution and restores it at the end, so the user config shouldn't be affected.