### PR TITLE
feat(prepare): Output git repo status when dirty

### DIFF
--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -275,7 +275,9 @@ function checkGitStatus(repoStatus: StatusResult, rev: string) {
   ) {
     reportError(
       'Your repository is in a dirty state. ' +
-        'Please stash or commit the pending changes.',
+        'Please stash or commit the pending changes.' +
+        '\nRepo Status:\n' +
+        JSON.stringify(repoStatus),
       logger
     );
   }


### PR DESCRIPTION
To help with debugging, output the git repo status object if craft detects that a repo is in a dirty state.

This originally came up with https://github.com/getsentry/sentry-capacitor/ when there was an out-of-date `yarn.lock` file on main. Hopefully this will prevent the need to manually run `craft publish --dry-run` to check for errors locally.