### PR TITLE
feat(prepare): Pass old version to bump-version

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -12,4 +12,5 @@ export npm_config_git_tag_version=false
 
 NPM_VERSION=$(npm version $NEW_VERSION)
 VERSION=${NPM_VERSION:1}
+echo "Previous version: $OLD_VERSION"
 echo "New version: $VERSION"

--- a/src/commands/__tests__/prepare.test.ts
+++ b/src/commands/__tests__/prepare.test.ts
@@ -5,6 +5,7 @@ import { runPreReleaseCommand } from '../prepare';
 jest.mock('../../utils/system');
 
 describe('runPreReleaseCommand', () => {
+  const oldVersion = '2.3.3';
   const newVersion = '2.3.4';
   const mockedSpawnProcess = spawnProcess as jest.Mock;
 
@@ -15,16 +16,16 @@ describe('runPreReleaseCommand', () => {
   test('runs with default command', async () => {
     expect.assertions(1);
 
-    await runPreReleaseCommand(newVersion);
+    await runPreReleaseCommand(oldVersion, newVersion);
 
     expect(mockedSpawnProcess).toBeCalledWith(
       '/bin/bash',
-      [pathJoin('scripts', 'bump-version.sh'), '', newVersion],
+      [pathJoin('scripts', 'bump-version.sh'), oldVersion, newVersion],
       {
         env: {
           ...process.env,
           CRAFT_NEW_VERSION: newVersion,
-          CRAFT_OLD_VERSION: '',
+          CRAFT_OLD_VERSION: oldVersion,
         },
       }
     );
@@ -34,18 +35,19 @@ describe('runPreReleaseCommand', () => {
     expect.assertions(1);
 
     await runPreReleaseCommand(
+      oldVersion,
       newVersion,
       'python ./increase_version.py "argument 1"'
     );
 
     expect(mockedSpawnProcess).toBeCalledWith(
       'python',
-      ['./increase_version.py', 'argument 1', '', newVersion],
+      ['./increase_version.py', 'argument 1', oldVersion, newVersion],
       {
         env: {
           ...process.env,
           CRAFT_NEW_VERSION: newVersion,
-          CRAFT_OLD_VERSION: '',
+          CRAFT_OLD_VERSION: oldVersion,
         },
       }
     );

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -17,6 +17,11 @@ export async function getDefaultBranch(
   );
 }
 
+export async function getLatestTag(git: SimpleGit): Promise<string> {
+  // This part is courtesy of https://stackoverflow.com/a/7261049/90297
+  return (await git.raw('describe', '--tags', '--abbrev=0')).trim();
+}
+
 export function stripRemoteName(
   branch: string | undefined,
   remoteName: string


### PR DESCRIPTION
With this patch, we do a crude determination of the previous release,
assuming the first tag before current tip  the previous release.
This is rather naive as we allow custom formatting of git tags but it is
a good start nevertheless.
