### PR TITLE
ref: Fix TypeScript type warning regarding catch

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -319,10 +319,10 @@ async function checkRevisionStatus(
     logger.debug('Repository info received');
     logger.trace(repositoryInfo);
   } catch (e) {
-    reportError(
-      `Cannot get repository information from ${statusProvider.config.name}. Check your configuration and credentials.\n` +
-        `Error: ${e.message}`
+    logger.error(
+      `Cannot get repository information from ${statusProvider.config.name}. Check your configuration and credentials.`
     );
+    reportError(e);
   }
 
   await statusProvider.waitForTheBuildToSucceed(revision);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -27,7 +27,7 @@ export class ConfigurationError extends Error {
  * @param errorLogger Optional logger to use
  */
 export function reportError(
-  error: Error | string,
+  error: unknown,
   errorLogger: {
     error: (...message: string[]) => void;
     [key: string]: any;
@@ -35,7 +35,7 @@ export function reportError(
 ): void {
   if (!isDryRun()) {
     // wrap the error in an Error object if it isn't already one
-    const errorObj = error instanceof Error ? error : new Error(error);
+    const errorObj = error instanceof Error ? error : new Error(String(error));
     throw errorObj;
   } else {
     // conversely, convert the error to a string if it isn't already one


### PR DESCRIPTION
TypeScript now defaults to `unknown` for caught error types instead of `any` causing us to get warnings when trying to access some standard `Error` properties. This PR changes the code accordingly so it is both safer, cleaner, and does not have this warning anymore.