### PR TITLE
upgrade(octokit): Upgrade octokit to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "devDependencies": {
     "@aws-sdk/client-lambda": "^3.2.0",
     "@google-cloud/storage": "^5.7.0",
-    "@octokit/plugin-retry": "^3.0.7",
-    "@octokit/rest": "16.35.2",
+    "@octokit/plugin-retry": "^3.0.9",
+    "@octokit/rest": "^18.10.0",
     "@sentry/node": "4.6.3",
     "@sentry/typescript": "^5.17.0",
     "@types/async": "^3.0.1",

--- a/src/artifact_providers/__tests__/github.test.ts
+++ b/src/artifact_providers/__tests__/github.test.ts
@@ -10,12 +10,12 @@ class TestGithubArtifactProvider extends GithubArtifactProvider {
 
 describe('GitHub Artifact Provider', () => {
   let githubArtifactProvider: TestGithubArtifactProvider;
-  let mockClient: { request: jest.Mock };
+  let mockClient: { actions: { listArtifactsForRepo: jest.Mock } };
 
   beforeEach(() => {
     jest.resetAllMocks();
     mockClient = {
-      request: jest.fn(),
+      actions: { listArtifactsForRepo: jest.fn() },
     };
     (getGithubClient as jest.MockedFunction<
       typeof getGithubClient
@@ -31,7 +31,7 @@ describe('GitHub Artifact Provider', () => {
 
   describe('listArtifactsForRevision', () => {
     test('it should get the artifact with the revision name', async () => {
-      mockClient.request.mockResolvedValueOnce({
+      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
         status: 200,
         data: {
           total_count: 2,
@@ -88,7 +88,7 @@ describe('GitHub Artifact Provider', () => {
     });
 
     test('it should get the latest artifact with the same name ', async () => {
-      mockClient.request.mockResolvedValueOnce({
+      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
         status: 200,
         data: {
           total_count: 2,
@@ -145,7 +145,7 @@ describe('GitHub Artifact Provider', () => {
     });
 
     test('it should throw when no artifacts are found after 3 retries', async () => {
-      mockClient.request.mockResolvedValue({
+      mockClient.actions.listArtifactsForRepo.mockResolvedValue({
         status: 200,
         data: {
           total_count: 0,
@@ -160,11 +160,11 @@ describe('GitHub Artifact Provider', () => {
         `"Failed to discover any artifacts (tries: 3)"`
       );
 
-      expect(mockClient.request).toBeCalledTimes(3);
+      expect(mockClient.actions.listArtifactsForRepo).toBeCalledTimes(3);
     });
 
     test('it should throw when no artifacts with the name can be found', async () => {
-      mockClient.request.mockResolvedValue({
+      mockClient.actions.listArtifactsForRepo.mockResolvedValue({
         status: 200,
         data: {
           total_count: 2,

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -194,18 +194,14 @@ export class GithubArtifactProvider extends BaseArtifactProvider {
   ): Promise<string> {
     const { repoName, repoOwner } = this.config;
 
-    const archiveResponse = await this.github.actions.getArtifact({
+    const archiveResponse = await this.github.actions.downloadArtifact({
       owner: repoOwner,
       repo: repoName,
       artifact_id: foundArtifact.id,
+      archive_format: 'zip',
     });
 
-    if (archiveResponse.status !== 200) {
-      throw new Error(
-        `Failed to fetch archive ${JSON.stringify(archiveResponse)}`
-      );
-    }
-    return archiveResponse.data.archive_download_url;
+    return archiveResponse.url;
   }
 
   /**

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -43,7 +43,7 @@ interface ArchiveResponse extends Github.AnyResponse {
  */
 export class GithubArtifactProvider extends BaseArtifactProvider {
   /** Github client */
-  public readonly github: Github;
+  public readonly github: Octokit;
 
   public constructor(config: ArtifactProviderConfig) {
     super(config);

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import * as Github from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
   getAuthUsername,
@@ -47,7 +47,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
   /** Target options */
   public readonly awsLambdaConfig: AwsLambdaTargetConfig;
   /** GitHub client. */
-  public readonly github: Github;
+  public readonly github: Octokit;
   /** The directory where the runtime-specific directories are. */
   private readonly AWS_REGISTRY_DIR = 'aws-lambda-layers';
   /** File containing data fields every new version file overrides  */
@@ -262,8 +262,8 @@ export class AwsLambdaLayerTarget extends BaseTarget {
           this.logger.debug('Finished publishing to all regions.');
         } catch (error) {
           this.logger.error(
-            `Did not publish layers for ${runtime.name}. ` +
-              `Something went wrong with AWS: ${error.message}`
+            `Did not publish layers for ${runtime.name}.`,
+            error
           );
           return;
         }

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -131,7 +131,7 @@ export class BrewTarget extends BaseTarget {
         return undefined;
       }
       return response.data.sha;
-    } catch (e) {
+    } catch (e: any) {
       if (e.status === 404) {
         return undefined;
       }

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -1,5 +1,5 @@
 import { mapLimit } from 'async';
-import * as Github from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError } from '../utils/errors';
@@ -47,7 +47,7 @@ export class BrewTarget extends BaseTarget {
   /** Target options */
   public readonly brewConfig: BrewTargetOptions;
   /** Github client */
-  public readonly github: Github;
+  public readonly github: Octokit;
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
@@ -123,7 +123,7 @@ export class BrewTarget extends BaseTarget {
     try {
       const tap = this.brewConfig.tapRepo;
       this.logger.debug(`Loading SHA for ${tap.owner}/${tap.repo}:${path}`);
-      const response = await this.github.repos.getContents({
+      const response = await this.github.repos.getContent({
         ...tap,
         path,
       });
@@ -205,7 +205,7 @@ export class BrewTarget extends BaseTarget {
     );
 
     if (!isDryRun()) {
-      await this.github.repos.createOrUpdateFile(params);
+      await this.github.repos.createOrUpdateFileContents(params);
     } else {
       this.logger.info(`[dry-run] Skipping file action: ${action}`);
     }

--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -1,4 +1,4 @@
-import * as Github from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import * as fs from 'fs';
 import { basename, join } from 'path';
 import { promisify } from 'util';
@@ -34,7 +34,7 @@ export class CocoapodsTarget extends BaseTarget {
   /** Target options */
   public readonly cocoapodsConfig: CocoapodsTargetOptions;
   /** Github client */
-  public readonly github: Github;
+  public readonly github: Octokit;
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import * as Github from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
@@ -44,7 +44,7 @@ export class GhPagesTarget extends BaseTarget {
   /** Target options */
   public readonly ghPagesConfig: GhPagesConfig;
   /** Github client */
-  public readonly github: Github;
+  public readonly github: Octokit;
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -57,12 +57,7 @@ interface GithubRelease {
  */
 type GithubCreateTagType = 'commit' | 'tree' | 'blob';
 
-type ArrayElement<
-  ArrayType extends readonly unknown[]
-> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
-type ReposListAssetsForReleaseResponseItem = ArrayElement<
-  RestEndpointMethodTypes['repos']['listReleaseAssets']['response']['data']
->;
+type ReposListAssetsForReleaseResponseItem = RestEndpointMethodTypes['repos']['listReleaseAssets']['response']['data'][0];
 
 /**
  * Target responsible for publishing releases on Github

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -1,5 +1,5 @@
 import { mapLimit } from 'async';
-import * as Github from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import simpleGit, { SimpleGit } from 'simple-git';
 
 import { GithubGlobalConfig, TargetConfig } from '../schemas/project_config';
@@ -78,7 +78,7 @@ export class RegistryTarget extends BaseTarget {
   /** Target options */
   public readonly registryConfig: RegistryConfig[];
   /** Github client */
-  public readonly github: Github;
+  public readonly github: Octokit;
   /** Github repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -1,4 +1,4 @@
-import * as Github from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
   getAuthUsername,
@@ -27,7 +27,7 @@ export class UpmTarget extends BaseTarget {
   /** Target name */
   public readonly name: string = 'upm';
   /** Github client */
-  public readonly github: Github;
+  public readonly github: Octokit;
   /** Internal GitHub Target */
   private readonly githubTarget: GithubTarget;
 

--- a/src/utils/__tests__/githubApi.test.ts
+++ b/src/utils/__tests__/githubApi.test.ts
@@ -73,7 +73,7 @@ describe('getFile', () => {
 
     try {
       await getFile(github, owner, repo, '/path/to/missing', 'v1.0.0');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toMatch(errorText);
       expect(e.status).toBe(500);
       expect(e.code).toBe(undefined);

--- a/src/utils/__tests__/githubApi.test.ts
+++ b/src/utils/__tests__/githubApi.test.ts
@@ -1,27 +1,27 @@
-import Github from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 
 import { getFile } from '../githubApi';
 
 const mockRepos = {
-  getContents: jest.fn(),
+  getContent: jest.fn(),
 };
 
-jest.mock('@octokit/rest', () =>
-  jest.fn().mockImplementation(() => ({ repos: mockRepos }))
-);
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn().mockImplementation(() => ({ repos: mockRepos })),
+}));
 
 describe('getFile', () => {
-  const github = new Github();
+  const github = new Octokit();
   const owner = 'owner';
   const repo = 'repo';
 
-  const getContents = (github.repos.getContents as unknown) as jest.Mock;
+  const getContent = (github.repos.getContent as unknown) as jest.Mock;
 
   test('loads and decodes the file', async () => {
     expect.assertions(2);
     const testContent = 'test content.';
 
-    getContents.mockReturnValue({
+    getContent.mockReturnValue({
       data: { content: Buffer.from(testContent).toString('base64') },
     });
 
@@ -32,7 +32,7 @@ describe('getFile', () => {
       '/path/to/file',
       'v1.0.0'
     );
-    expect(getContents).toHaveBeenCalledWith({
+    expect(getContent).toHaveBeenCalledWith({
       owner: 'owner',
       path: '/path/to/file',
       ref: 'v1.0.0',
@@ -45,7 +45,7 @@ describe('getFile', () => {
   test('returns null for missing files', async () => {
     expect.assertions(1);
 
-    getContents.mockImplementation(() => {
+    getContent.mockImplementation(() => {
       const e = new Error('file not found') as any;
       e.status = 404;
       throw e;
@@ -65,7 +65,7 @@ describe('getFile', () => {
     expect.assertions(3);
 
     const errorText = 'internal server error';
-    getContents.mockImplementation(() => {
+    getContent.mockImplementation(() => {
       const e = new Error(errorText) as any;
       e.status = 500;
       throw e;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,6 +1011,26 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
+"@octokit/auth-token@^2.4.4":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
+  integrity sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
+  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.0"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/endpoint@^6.0.1":
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.10.tgz#741ce1fa2f4fb77ce8ebe0c6eaf5ce63f565f8e8"
@@ -1020,83 +1040,85 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-2.2.0.tgz#123e0438a0bc718ccdac3b5a2e69b3dd00daa85b"
-  integrity sha512-274lNUDonw10kT8wHg8fCcUc1ZjZHbWv0/TbAwb0ojhBQqZYc1cQ/4yqTVTtPMDeZ//g7xVEYe/s3vURkRghPg==
+"@octokit/graphql@^4.5.8":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
+  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
 
-"@octokit/plugin-retry@^3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.7.tgz#174516f2b80b7140aee71ebc2b506db2c5c1d3d6"
-  integrity sha512-n08BPfVeKj5wnyH7IaOWnuKbx+e9rSJkhDHMJWXLPv61625uWjsN8G7sAW3zWm9n9vnS4friE7LL/XLcyGeG8Q==
+"@octokit/openapi-types@^10.2.2":
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-10.2.2.tgz#6c1c839d7d169feabaf1d2a69c79439c75d979cd"
+  integrity sha512-EVcXQ+ZrC04cg17AMg1ofocWMxHDn17cB66ZHgYc0eUwjFtxS0oBzkyw2VqIrHBwVgtfoYrq1WMQfQmMjUwthw==
+
+"@octokit/plugin-paginate-rest@^2.16.0":
+  version "2.16.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.3.tgz#6dbf74a12a53e04da6ca731d4c93f20c0b5c6fe9"
+  integrity sha512-kdc65UEsqze/9fCISq6BxLzeB9qf0vKvKojIfzgwf4tEF+Wy6c9dXnPFE6vgpoDFB1Z5Jek5WFVU6vL1w22+Iw==
+  dependencies:
+    "@octokit/types" "^6.28.1"
+
+"@octokit/plugin-request-log@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
+"@octokit/plugin-rest-endpoint-methods@^5.9.0":
+  version "5.10.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.4.tgz#97e85eb7375e30b9bf193894670f9da205e79408"
+  integrity sha512-Dh+EAMCYR9RUHwQChH94Skl0lM8Fh99auT8ggck/xTzjJrwVzvsd0YH68oRPqp/HxICzmUjLfaQ9sy1o1sfIiA==
+  dependencies:
+    "@octokit/types" "^6.28.1"
+    deprecation "^2.3.1"
+
+"@octokit/plugin-retry@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz#ae625cca1e42b0253049102acd71c1d5134788fe"
+  integrity sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==
   dependencies:
     "@octokit/types" "^6.0.3"
     bottleneck "^2.15.3"
 
-"@octokit/request-error@^1.0.2":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.2.1.tgz#ede0714c773f32347576c25649dc013ae6b31801"
-  integrity sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==
+"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
   dependencies:
-    "@octokit/types" "^2.0.0"
-    deprecation "^2.0.0"
-    once "^1.4.0"
-
-"@octokit/request-error@^2.0.0":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.4.tgz#07dd5c0521d2ee975201274c472a127917741262"
-  integrity sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==
-  dependencies:
-    "@octokit/types" "^6.0.0"
-    deprecation "^2.0.0"
-    once "^1.4.0"
-
-"@octokit/request@^5.2.0":
-  version "5.4.12"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.12.tgz#b04826fa934670c56b135a81447be2c1723a2ffc"
-  integrity sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==
-  dependencies:
-    "@octokit/endpoint" "^6.0.1"
-    "@octokit/request-error" "^2.0.0"
     "@octokit/types" "^6.0.3"
     deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.1.tgz#f97aff075c37ab1d427c49082fefeef0dba2d8ce"
+  integrity sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.1"
-    once "^1.4.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@16.35.2":
-  version "16.35.2"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.35.2.tgz#0098c9e2a895d4afb0fa6578479283553543143c"
-  integrity sha512-iijaNZpn9hBpUdh8YdXqNiWazmq4R1vCUsmxpBB0kCQ0asHZpCx+HNs22eiHuwYKRhO31ZSAGBJLi0c+3XHaKQ==
+"@octokit/rest@^18.10.0":
+  version "18.10.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.10.0.tgz#8a0add9611253e0e31d3ed5b4bc941a3795a7648"
+  integrity sha512-esHR5OKy38bccL/sajHqZudZCvmv4yjovMJzyXlphaUo7xykmtOdILGJ3aAm0mFHmMLmPFmDMJXf39cAjNJsrw==
   dependencies:
-    "@octokit/request" "^5.2.0"
-    "@octokit/request-error" "^1.0.2"
-    atob-lite "^2.0.0"
-    before-after-hook "^2.0.0"
-    btoa-lite "^1.0.0"
-    deprecation "^2.0.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
-    once "^1.4.0"
-    universal-user-agent "^4.0.0"
+    "@octokit/core" "^3.5.1"
+    "@octokit/plugin-paginate-rest" "^2.16.0"
+    "@octokit/plugin-request-log" "^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods" "^5.9.0"
 
-"@octokit/types@^2.0.0":
-  version "2.16.2"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.16.2.tgz#4c5f8da3c6fecf3da1811aef678fda03edac35d2"
-  integrity sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==
+"@octokit/types@^6.0.0", "@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.28.1":
+  version "6.28.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.28.1.tgz#ab990d1fe952226055e81c7650480e6bacfb877c"
+  integrity sha512-XlxDoQLFO5JnFZgKVQTYTvXRsQFfr/GwDUU108NJ9R5yFPkA2qXhTJjYuul3vE4eLXP40FA2nysOu2zd6boE+w==
   dependencies:
-    "@types/node" ">= 8"
-
-"@octokit/types@^6.0.0", "@octokit/types@^6.0.3":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.2.1.tgz#7f881fe44475ab1825776a4a59ca1ae082ed1043"
-  integrity sha512-jHs9OECOiZxuEzxMZcXmqrEO8GYraHF+UzNVH2ACYh8e/Y7YoT+hUf9ldvVd6zIvWv4p3NdxbQ0xx3ku5BnSiA==
-  dependencies:
-    "@octokit/openapi-types" "^2.2.0"
-    "@types/node" ">= 8"
+    "@octokit/openapi-types" "^10.2.2"
 
 "@sentry/core@4.6.3":
   version "4.6.3"
@@ -1357,7 +1379,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^12.11.1":
+"@types/node@*", "@types/node@^12.11.1":
   version "12.19.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.13.tgz#888e2b34159fb91496589484ec169618212b51b7"
   integrity sha512-qdixo2f0U7z6m0UJUugTJqVF94GNDkdgQhfBtMs8t5898JE7G/D2kJYw4rc1nzjIPLVAsDkY2MdABnLAP5lM1w==
@@ -1729,11 +1751,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-atob-lite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
-  integrity sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=
-
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1840,10 +1857,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-before-after-hook@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
-  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
+before-after-hook@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
+  integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
 big-integer@^1.6.17:
   version "1.6.48"
@@ -1936,11 +1953,6 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
-
-btoa-lite@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
-  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -2385,7 +2397,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-deprecation@^2.0.0:
+deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
@@ -4183,20 +4195,10 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -4207,11 +4209,6 @@ lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
-
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@4.x, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.21"
@@ -4249,11 +4246,6 @@ lsmod@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
   integrity sha1-mgD3bco26yP6BTUK/htYXUKZ5ks=
-
-macos-release@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"
-  integrity sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -4595,11 +4587,6 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-octokit-pagination-methods@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
-  integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -4659,14 +4646,6 @@ ora@5.4.0:
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
-
-os-name@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
-  integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
-  dependencies:
-    macos-release "^2.2.0"
-    windows-release "^3.1.0"
 
 p-each-series@^2.1.0:
   version "2.2.0"
@@ -5129,15 +5108,15 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -5885,13 +5864,6 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
-universal-user-agent@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.1.tgz#fd8d6cb773a679a709e967ef8288a31fcc03e557"
-  integrity sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==
-  dependencies:
-    os-name "^3.1.0"
-
 universal-user-agent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
@@ -6069,13 +6041,6 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-windows-release@^3.1.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.3.3.tgz#1c10027c7225743eec6b89df160d64c2e0293999"
-  integrity sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==
-  dependencies:
-    execa "^1.0.0"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
This is needed so we can use the GraphQL endpoints.

List of breaking changes: https://github.com/octokit/rest.js/releases/tag/v18.0.0

All tests pass and also manually verified locally by preparing and releasing https://github.com/getsentry/release-tester/releases/0.18.0
