### PR TITLE
fix(changelog): Make auto changelog titles level 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,31 @@
 
 ## 0.25.0
 
-## Automated Changelog Generation
+### Automated Changelog Generation
 
 We now automatically generate changelog entries for the `auto` changelog policy where none provided, instead of saying "No documented changes". The commits/PRs are grouped by their associated GitHub milestones and the milestone title and description are used in the changelog along with a list of related commits/PRs. Any unaccounted changes are grouped under the "Various improvements and fixes" section.
 
 PRs: #291, #290, #289, #287, #285
 
-## Added Maven Target (ongoing)
+### Added Maven Target (ongoing)
 
 Added the long-awaited Maven target, full with Android support.
 
 PRs: #271, #275, #276, #270, #258
 
-## Added symbol-collector Target
+### Added symbol-collector Target
 
 Added target for our very own [symbol-collector](https://github.com/getsentry/symbol-collector/) to collect and upload all native system symbols with Craft.
 
 PRs: #284, #277, #269, #268, #267, #266
 
-## Fixed Cocoapods Support
+### Fixed Cocoapods Support
 
-Turns out our Cocoapods target was a bit outdated and broken. We have fixed it in this release! 🥳 
+Turns out our Cocoapods target was a bit outdated and broken. We have fixed it in this release! 🥳
 
 PRs: #281, #282
 
-## Various fixes & improvements
+### Various fixes & improvements
 
 - build: Drop Node 12 support, target Node 14 (#293)
 - build(deps): Bump tmpl from 1.0.4 to 1.0.5 (#292)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ PRs: #281, #282
 - build(deps): Bump path-parse from 1.0.6 to 1.0.7 (#274)
 - build(deps-dev): Bump tar from 4.4.8 to 4.4.15 (#273)
 - docs: Consistent code samples for shell (e84f693f)
-- docs: Mention release/** branches on README (#263)
+- docs: Mention release/\*\* branches on README (#263)
 
 ## 0.24.4
 

--- a/src/utils/__tests__/changelog.test.ts
+++ b/src/utils/__tests__/changelog.test.ts
@@ -318,7 +318,7 @@ describe('generateChangesetFromGit', () => {
       makeCommitResponse([]);
       const changes = await generateChangesetFromGit(dummyGit, '1.0.0');
       expect(changes).toMatchInlineSnapshot(`
-        "## Various fixes & improvements
+        "### Various fixes & improvements
 
         - Upgraded the kernel (abcdef12)"
       `);
@@ -336,7 +336,7 @@ describe('generateChangesetFromGit', () => {
       makeCommitResponse([{ hash: 'abcdef1234567890' }]);
       const changes = await generateChangesetFromGit(dummyGit, '1.0.0');
       expect(changes).toMatchInlineSnapshot(`
-        "## Various fixes & improvements
+        "### Various fixes & improvements
 
         - Upgraded the kernel (abcdef12)"
       `);
@@ -357,7 +357,7 @@ describe('generateChangesetFromGit', () => {
       ]);
       const changes = await generateChangesetFromGit(dummyGit, '1.0.0');
       expect(changes).toMatchInlineSnapshot(`
-        "## Various fixes & improvements
+        "### Various fixes & improvements
 
         - Upgraded the kernel (#123)"
       `);
@@ -374,7 +374,7 @@ describe('generateChangesetFromGit', () => {
       makeCommitResponse([{ hash: 'abcdef1234567890', pr: '123' }]);
       const changes = await generateChangesetFromGit(dummyGit, '1.0.0');
       expect(changes).toMatchInlineSnapshot(`
-        "## Various fixes & improvements
+        "### Various fixes & improvements
 
         - Upgraded the kernel (#123)"
       `);
@@ -410,7 +410,7 @@ describe('generateChangesetFromGit', () => {
       ]);
       const changes = await generateChangesetFromGit(dummyGit, '1.0.0');
       expect(changes).toMatchInlineSnapshot(`
-        "## Various fixes & improvements
+        "### Various fixes & improvements
 
         - Upgraded the kernel (abcdef12)
         - Upgraded the manifold (#123)
@@ -495,19 +495,19 @@ describe('generateChangesetFromGit', () => {
     });
     const changes = await generateChangesetFromGit(dummyGit, '1.0.0');
     expect(changes).toMatchInlineSnapshot(`
-      "## Better drivetrain
+      "### Better drivetrain
 
       We have upgraded the drivetrain for a smoother and more performant driving experience. Enjoy!
 
       PRs: #123, #456
 
-      ## Better driver experience (ongoing)
+      ### Better driver experience (ongoing)
 
       We are working on making your driving experience more pleasant and safer.
 
       PRs: #789, #900
 
-      ## Various fixes & improvements
+      ### Various fixes & improvements
 
       - Upgraded the kernel (abcdef12)
       - Fix the clacking sound on gear changes (#950)"


### PR DESCRIPTION
In #291 we used level 2 headers for subsections in the auto
generated changelogs. This made them collide with the level 2
version headers, causing our GitHub target to not pick up the
automatically generated changelog. It is also semantically
incorrect.

This patch fixes the issue, introduces constants to determine
these levels, and adds a helper function that utilizes these
constants.
