### PR TITLE
feat(changelog): Skip items with `#skip-changelog` in them

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -6,7 +6,8 @@ import { logger } from '../logger';
 
 export interface GitChange {
   hash: string;
-  message: string;
+  title: string;
+  body: string;
   pr: string | null;
 }
 
@@ -54,7 +55,8 @@ export async function getChangesSince(
   });
   return commits.map(commit => ({
     hash: commit.hash,
-    message: commit.message,
+    title: commit.message,
+    body: commit.body,
     pr: commit.message.match(PRExtractor)?.[0] || null,
   }));
 }


### PR DESCRIPTION
We sometimes want to omit certain changes (such as internal changes in Relay and this patch brings the option to skip them from the changelog altogether.
