### PR TITLE
upgrade(ansi-regex): Upgrade ansi-regex to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "**/kind-of": ">=6.0.3",
     "**/node-fetch": ">=2.6.1",
     "**/yargs-parser": ">=18.1.2",
-    "**/parse-url": ">=5.0.3"
+    "**/parse-url": ">=5.0.3",
+    "**/ansi-regex": ">=5.0.1 < 6.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-lambda": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,20 +1617,10 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-regex@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+"ansi-regex@>=5.0.1 < 6.0.0", ansi-regex@^2.1.1, ansi-regex@^4.1.0, ansi-regex@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This is to address [CVE-2021-3807](https://github.com/advisories/GHSA-93q8-gq69-wqmw)

The only breaking changes from version `2.1.1` to `5.0.1` were supported Node versions so I forced all of them to `5.0.1`. Avoided `6.0.1` as it converted the package into ESM which I'm not sure if we are ready for yet.
