### PR TITLE
fix(changelog): Accomodate `null` milestone descriptions

### DIFF
--- a/src/utils/__tests__/changelog.test.ts
+++ b/src/utils/__tests__/changelog.test.ts
@@ -297,7 +297,7 @@ describe('generateChangesetFromGit', () => {
 
   interface TestMilestone {
     title: string;
-    description: string;
+    description: string | null;
   }
 
   function setup(
@@ -516,13 +516,20 @@ describe('generateChangesetFromGit', () => {
       ].join('\n'),
     ],
     [
-      'should omit milestone body if it is empty',
+      'should omit milestone body if it is empty or null',
       [
         {
           hash: 'abcdef1234567890',
           title: 'Upgraded the kernel',
           body: '',
           pr: { local: '123', remote: { number: '123', milestone: '1' } },
+        },
+
+        {
+          hash: 'bcdef123456789a',
+          title: 'Upgraded the manifold (#456)',
+          body: '',
+          pr: { local: '456', remote: { number: '456', milestone: '2' } },
         },
       ],
       {
@@ -531,8 +538,21 @@ describe('generateChangesetFromGit', () => {
           description: '',
           state: 'CLOSED',
         },
+        '2': {
+          title: 'Better Engine',
+          description: null,
+          state: 'CLOSED',
+        },
       },
-      '### Better drivetrain\n\nPRs: #123',
+      [
+        '### Better drivetrain',
+        '',
+        'PRs: #123',
+        '',
+        '### Better Engine',
+        '',
+        'PRs: #456',
+      ].join('\n'),
     ],
     [
       `should skip commits & prs with the magic ${SKIP_CHANGELOG_MAGIC_WORD}`,

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -300,7 +300,7 @@ export async function generateChangesetFromGit(
         `${milestone.title}${milestone.state === 'OPEN' ? ' (ongoing)' : ''}`
       )
     );
-    if (milestone.description && milestone.description !== '') {
+    if (milestone.description) {
       changelogSections.push(escapeMarkdownPound(milestone.description));
     }
     changelogSections.push(

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -212,7 +212,7 @@ interface Commit {
 
 interface Milestone {
   title: string;
-  description: string;
+  description: string | null;
   state: 'OPEN' | 'CLOSED';
 }
 type MilestoneWithPRs = Milestone & {
@@ -300,7 +300,7 @@ export async function generateChangesetFromGit(
         `${milestone.title}${milestone.state === 'OPEN' ? ' (ongoing)' : ''}`
       )
     );
-    if (milestone.description !== '') {
+    if (milestone.description && milestone.description !== '') {
       changelogSections.push(escapeMarkdownPound(milestone.description));
     }
     changelogSections.push(
@@ -353,23 +353,28 @@ async function getPRAndMilestoneFromCommit(
     .join('\n');
 
   const { repo, owner } = await getGlobalGithubConfig();
-  const commitInfo = ((await getGitHubClient().graphql(`{
-    repository(name: "${repo}", owner: "${owner}") {
-      ${commitsQuery}
-    }
-  }
-
-  fragment PRFragment on Commit {
-    associatedPullRequests(first: 1) {
-      nodes {
-        number
-        body
-        milestone {
-          number
-        }
+  const graphqlQuery = `{
+      repository(name: "${repo}", owner: "${owner}") {
+        ${commitsQuery}
       }
     }
-  }`)) as CommitInfoResult).repository;
+
+    fragment PRFragment on Commit {
+      associatedPullRequests(first: 1) {
+        nodes {
+          number
+          body
+          milestone {
+            number
+          }
+        }
+      }
+    }`;
+  logger.trace('Running graphql query:', graphqlQuery);
+  const commitInfo = ((await getGitHubClient().graphql(
+    graphqlQuery
+  )) as CommitInfoResult).repository;
+  logger.trace('Query result:', commitInfo);
 
   return Object.fromEntries(
     Object.entries(commitInfo).map(([hash, commit]) => {
@@ -416,18 +421,23 @@ async function getMilestoneInfo(
     .join('\n');
 
   const { repo, owner } = await getGlobalGithubConfig();
-  const milestoneInfo = ((await getGitHubClient().graphql(`{
-    repository(name: "${repo}", owner: "${owner}") {
-      ${milestoneQuery}
+  const graphqlQuery = `{
+      repository(name: "${repo}", owner: "${owner}") {
+        ${milestoneQuery}
+      }
     }
-  }
 
-  fragment MilestoneFragment on Milestone {
-    title
-    description
-    state
-  }
-`)) as MilestonesDetailsResult).repository;
+    fragment MilestoneFragment on Milestone {
+      title
+      description
+      state
+    }
+  `;
+  logger.trace('Running graphql query:', graphqlQuery);
+  const milestoneInfo = ((await getGitHubClient().graphql(
+    graphqlQuery
+  )) as MilestonesDetailsResult).repository;
+  logger.trace('Query result:', milestoneInfo);
 
   return Object.fromEntries(
     Object.entries(milestoneInfo).map(([number, milestone]) => [


### PR DESCRIPTION
While testing this on Sentry, we came by some milestones where their `description` field was `null`. This does not happen with new milestones but we still need to cover for that case to avoid crashes.
