### PR TITLE
fix: github release uploads

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -333,7 +333,10 @@ export class GithubTarget extends BaseTarget {
     const name = basename(path);
     const params = {
       ...this.githubConfig,
-      data: readFileSync(path, { encoding: 'binary' }),
+      // so note here.  Octokit types this out as string, but in fact it also
+      // accepts a `Buffer` here.  In fact passing a string is not what we want
+      // as we upload binary data.
+      data: readFileSync(path) as any,
       headers: {
         'Content-Length': stats.size,
         'Content-Type': contentTypeProcessed,


### PR DESCRIPTION
The upload requires binary data not strings.  Unfortunately the typing
information in the generated octokit typings is wrong about this.

Passing a string here creates invalid binary uploads and has caused an
incident at Sentry that caused invalid uploads.

Octokit issue: https://github.com/octokit/octokit.js/issues/2086

Fixes https://github.com/getsentry/sentry-cli/issues/1037