### PR TITLE
fix: Only log error on tempdir rm when ther is an error

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -90,7 +90,9 @@ export async function withTempDir<T>(
         // don't care as this is already a temporary file and will be removed
         // eventually by the OS. And it doesn't make sense to wait until this op
         // finishes then as nothing relies on the removal of this file.
-        logger.trace(`Couldn't remove temp dir ${directory}: `, err);
+        if (err) {
+          logger.trace(`Couldn't remove temp dir ${directory}:`, err);
+        }
       });
     }
   }


### PR DESCRIPTION
Fixes the useless and incorrect
`Couldn't remote temp dir XXX: null` error.
