### PR TITLE
fix(registry): Add missing await to manifest update

### DIFF
--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -401,14 +401,16 @@ export class RegistryTarget extends BaseTarget {
       version
     );
 
-    updateManifestSymlinks(
-      await this.getUpdatedManifest(
-        registryConfig,
-        packageManifest,
-        canonicalName,
-        version,
-        revision
-      ),
+    const newManifest = await this.getUpdatedManifest(
+      registryConfig,
+      packageManifest,
+      canonicalName,
+      version,
+      revision
+    );
+
+    await updateManifestSymlinks(
+      newManifest,
       version,
       versionFilePath,
       packageManifest.version || undefined


### PR DESCRIPTION
This fixes a rare but regular race condition where our `git add . && git commit` action does not wait for the update on the manifest file, causing the target to fail with a 'dirty repo' warning on `pull --rebase` such as in getsentr/publish#661.