### PR TITLE
fix(logs): Fix blunder in debug logging for asset deletion

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -474,7 +474,7 @@ export class GithubTarget extends BaseTarget {
           assets.map(asset => this.deleteAsset(asset))
         );
         const failed = results.filter(
-          ({ status }) => status === 'fulfilled'
+          ({ status }) => status === 'rejected'
         ) as PromiseRejectedResult[];
         if (failed.length === 0) {
           this.logger.debug(`Deleted ${assets.length} assets`);


### PR DESCRIPTION
Fix up to #315, prevents the confusing and incorrect log output saying 'Failed to delete some assets: [undefined, undefined]'
