### PR TITLE
docs: Fix typos and cleanup some documentation

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -24,27 +24,27 @@ import { logger } from '../logger';
 import ora from 'ora';
 
 /**
- * Default content type for GitHub release assets
+ * Default content type for GitHub release assets.
  */
 export const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 
 /**
- * Configuration options for the Github target
+ * Configuration options for the GitHub target.
  */
 export interface GithubTargetConfig extends GithubGlobalConfig {
-  /** Path to changelon inside the repository */
+  /** Path to changelog inside the repository */
   changelog: string;
   /** Prefix that will be used to generate tag name */
   tagPrefix: string;
-  /** Mark releases as pre-release, if the version looks like a non-public release */
+  /** Mark release as pre-release, if the version looks like a non-public release */
   previewReleases: boolean;
   /** Use annotated (not lightweight) tag */
   annotatedTag: boolean;
 }
 
 /**
- * An interface that represents a minimal Github release as returned by
- * Github API.
+ * An interface that represents a minimal GitHub release as returned by the
+ * GitHub API.
  */
 interface GithubRelease {
   /** Release id */
@@ -56,7 +56,7 @@ interface GithubRelease {
 }
 
 /**
- * Tag type as used in GitdataCreateTagParams from Github API
+ * Tag type as expected by the GitHub API.
  */
 type GithubCreateTagType = 'commit' | 'tree' | 'blob';
 
@@ -81,16 +81,16 @@ interface OctokitErrorResponse {
 }
 
 /**
- * Target responsible for publishing releases on Github
+ * Target responsible for publishing releases on GitHub.
  */
 export class GithubTarget extends BaseTarget {
   /** Target name */
   public readonly name = 'github';
   /** Target options */
   public readonly githubConfig: GithubTargetConfig;
-  /** Github client */
+  /** GitHub client */
   public readonly github: Octokit;
-  /** Github repo configuration */
+  /** GitHub repo configuration */
   public readonly githubRepo: GithubGlobalConfig;
 
   public constructor(
@@ -119,10 +119,10 @@ export class GithubTarget extends BaseTarget {
   }
 
   /**
-   * Creates an annotated tag for the given revision
+   * Creates an annotated tag for the given revision.
    *
    * Unlike a lightweight tag (basically just a pointer to a commit), to
-   * create an annotateg tag we must create a tag object first, and then
+   * create an annotated tag we must create a tag object first, and then
    * create a reference to it manually.
    *
    * @param version The version to release
@@ -167,7 +167,7 @@ export class GithubTarget extends BaseTarget {
   }
 
   /**
-   * Gets an existing or creates a new release for the given version
+   * Gets an existing or creates a new release for the given version.
    *
    * The release name and description body is brought in from `changes`
    * respective tag, if present. Otherwise, the release name defaults to the
@@ -289,7 +289,7 @@ export class GithubTarget extends BaseTarget {
   /**
    * Fetches a list of all assets for the given release
    *
-   * The result includes unfinshed asset uploads.
+   * The result includes unfinished asset uploads.
    *
    * @param release Release to fetch assets from
    */
@@ -389,7 +389,7 @@ export class GithubTarget extends BaseTarget {
           //          get a useless JSON API response back, instead of getting
           //          redirected to the raw file itself.
           //          And don't even think about using `browser_download_url`
-          //          field as it is close to impossible to authendicate for
+          //          field as it is close to impossible to authenticate for
           //          that URL with a token and you'll lose hours getting 404s
           //          for private repos. Consider yourself warned. --xoxo BYK
           Accept: DEFAULT_CONTENT_TYPE,

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,7 +1,7 @@
 import { getGitTagPrefix } from '../config';
 
 /**
- * Regular expression for matching semver versions
+ * Regular expression for matching semver versions.
  *
  * Modified to match version components
  * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
@@ -11,7 +11,7 @@ const semverRegex = () =>
   /\bv?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-?([\da-z-]+(?:\.[\da-z-]+)*))?(?:\+([\da-z-]+(?:\.[\da-z-]+)*))?\b/gi;
 
 /**
- * Extracts a version number from the given text
+ * Extracts a version number from the given text.
  *
  * In case the version contains a leading "v", it is stripped from the result.
  * All semantic versions are supported. See {@link http://semver.org/} for
@@ -29,7 +29,7 @@ export function getVersion(text: string): string | null {
 }
 
 /**
- * Checks if the provided text is a valid version string
+ * Checks if the provided text is a valid version string.
  *
  * @param text String to check
  * @returns true if the string is a valid semantic version, false otherwise
@@ -39,7 +39,7 @@ export function isValidVersion(text: string): boolean {
 }
 
 /**
- * SemVer Parsed semantic version
+ * SemVer is a parsed semantic version.
  */
 export interface SemVer {
   /** The major version number */
@@ -55,7 +55,7 @@ export interface SemVer {
 }
 
 /**
- * Parses a version number from the given text
+ * Parses a version number from the given text.
  *
  * @param text Some text containing a version
  * @returns The parsed version or null
@@ -105,7 +105,7 @@ export function versionGreaterOrEqualThan(v1: SemVer, v2: SemVer): boolean {
 }
 
 /**
- * A regular expression to detect that the version is a pre-release
+ * A regular expression to detect that a version is a pre-release version.
  */
 export const PREVIEW_RELEASE_REGEX = /(?:[^a-z])(preview|pre|rc|dev|alpha|beta|unstable|a|b)(?:[^a-z]|$)/i;
 
@@ -120,7 +120,7 @@ export function isPreviewRelease(text: string): boolean {
 }
 
 /**
- * Returns the git version based on the provided version
+ * Returns the Git version based on the provided version.
  *
  * If no tag prefix is provided, it is taken from the configuration.
  *
@@ -134,7 +134,7 @@ export function versionToTag(version: string, tagPrefix?: string): string {
 }
 
 /**
- * Reads "package.json" from project root and returns its contents
+ * Reads "package.json" from project root and returns its contents.
  */
 export function getPackage(): any {
   const pkg = require('../../package.json') || {};
@@ -146,7 +146,7 @@ export function getPackage(): any {
 }
 
 /**
- * Reads the package's version from "package.json"
+ * Reads the package's version from "package.json".
  */
 export function getPackageVersion(): string {
   const { version } = getPackage();


### PR DESCRIPTION
Was reading some code, and in passing cleaned some docs.

Notes:
- Terminate sentences with punctuation
- Github -> GitHub (but didn't change functions/methods/types in this passing, only references to the company name)