### PR TITLE
feat(target-gh): Check asset MD5 hash by downloading the asset

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -378,11 +378,11 @@ export class GithubTarget extends BaseTarget {
         );
       }
 
-      const remoteChecksum = await this.getRemoteChecksum(url);
-      const localChecksum = this.md5FromData(file);
+      const remoteChecksum = await this.checksumFromUrl(url);
+      const localChecksum = this.checksumFromData(file);
       if (localChecksum !== remoteChecksum) {
         throw new Error(
-          `Uploaded asset MD5 checksum does not match local asset checksum for "${name} (${localChecksum} != ${remoteChecksum})`
+          `Uploaded asset checksum does not match local asset checksum for "${name} (${localChecksum} != ${remoteChecksum})`
         );
       }
       uploadSpinner.succeed(`Uploaded asset "${name}".`);
@@ -394,7 +394,7 @@ export class GithubTarget extends BaseTarget {
     }
   }
 
-  private async getRemoteChecksum(url: string): Promise<string> {
+  private async checksumFromUrl(url: string): Promise<string> {
     // XXX: This is a bit hacky as we rely on two things:
     // 1. GitHub issuing a redirect to S3, where they store the artifacts,
     //    or at least pass those request headers unmodified to us
@@ -443,10 +443,10 @@ export class GithubTarget extends BaseTarget {
         `Cannot download asset from GitHub. Status: ${(e as any).status}\n` + e
       );
     }
-    return this.md5FromData(Buffer.from(response.data));
+    return this.checksumFromData(Buffer.from(response.data));
   }
 
-  private md5FromData(data: BinaryLike): string {
+  private checksumFromData(data: BinaryLike): string {
     return createHash('md5').update(data).digest('hex');
   }
 

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -395,11 +395,13 @@ export class GithubTarget extends BaseTarget {
   }
 
   private async checksumFromUrl(url: string): Promise<string> {
-    // XXX: This is a bit hacky as we rely on two things:
-    // 1. GitHub issuing a redirect to S3, where they store the artifacts,
-    //    or at least pass those request headers unmodified to us
-    // 2. AWS S3 using the MD5 hash of the file for its ETag cache header
-    //    when we issue a HEAD request.
+    // XXX: This is a bit hacky as we rely on various things:
+    // 1. GitHub issuing a redirect to AWS S3.
+    // 2. S3 using the MD5 hash of the file for its ETag cache header.
+    // 3. The file being small enough to fit in memory.
+    //
+    // Note that if assets are large (5GB) assumption 2 is not correct. See
+    // https://github.com/getsentry/craft/issues/322#issuecomment-964303174
     let response;
     try {
       response = await this.github.request(`HEAD ${url}`, {

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -385,6 +385,7 @@ export class GithubTarget extends BaseTarget {
           `Uploaded asset MD5 checksum does not match local asset checksum for "${name} (${localChecksum} != ${remoteChecksum})`
         );
       }
+      uploadSpinner.succeed(`Uploaded asset "${name}".`);
       return url;
     } catch (e) {
       uploadSpinner.fail(`Cannot upload asset "${name}".`);


### PR DESCRIPTION
The GitHub API doesn't provide any endpoints to get the hash of an asset.
GitHub's response contains an ETag header with the MD5 hash of the asset.  In
certain cases, the ETag header is not present. This means we don't have the
hash of the asset, and thus, we cannot verify the asset correctness. To verify
it, we download the file and calculate the hash locally.

Files are downloaded into memory, and their size is not checked. This has a
risk of downloading too big files, which is something we accept at the moment.

The GitHub SDK throws exceptions when server responses are HTTP errors. These
interactions are wrapped and more detailed errors are thrown.

Originally, the hash check was introduced in https://github.com/getsentry/craft/pull/308.
This is a follow-up to the initial fix: https://github.com/getsentry/craft/pull/323.
Releases were failing before this fix, see https://github.com/getsentry/publish/issues/635.

Closes https://github.com/getsentry/craft/issues/322.