### PR TITLE
misc: Update error message to clarify what size refers to what

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -374,7 +374,7 @@ export class GithubTarget extends BaseTarget {
       uploadSpinner.text = `Verifying asset "${name}...`;
       if (size != stats.size) {
         throw new Error(
-          `Uploaded asset size does not match local asset size for "${name} (${stats.size} != ${size}).`
+          `Uploaded asset size (${size} bytes) does not match local asset size (${stats.size} bytes) for "${name}".`
         );
       }
 


### PR DESCRIPTION
When a size check fails, it was hard to tell what was the local size and
what was the uploaded size without looking at the source code.