### PR TITLE
fix: Remove GitHub asset checksum

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -1,8 +1,7 @@
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { RequestError } from '@octokit/request-error';
-import { readFileSync, promises, statSync } from 'fs';
+import { createReadStream, promises, statSync } from 'fs';
 import { basename } from 'path';
-import { BinaryLike, createHash } from 'crypto';
 
 import { getConfiguration } from '../config';
 import {
@@ -361,8 +360,9 @@ export class GithubTarget extends BaseTarget {
     const uploadSpinner = ora(
       `Uploading asset "${name}" to ${this.githubConfig.owner}/${this.githubConfig.repo}:${release.tag_name}`
     ).start();
+
     try {
-      const file = readFileSync(path);
+      const file = createReadStream(path);
       const { url, size } = await this.handleGitHubUpload({
         ...params,
         // XXX: Octokit types this out as string, but in fact it also
@@ -370,86 +370,18 @@ export class GithubTarget extends BaseTarget {
         // want as we upload binary data.
         data: file as any,
       });
-
       uploadSpinner.text = `Verifying asset "${name}...`;
       if (size != stats.size) {
         throw new Error(
           `Uploaded asset size does not match local asset size for "${name} (${stats.size} != ${size}).`
         );
       }
-
-      const remoteChecksum = await this.checksumFromUrl(url);
-      const localChecksum = this.checksumFromData(file);
-      if (localChecksum !== remoteChecksum) {
-        throw new Error(
-          `Uploaded asset checksum does not match local asset checksum for "${name} (${localChecksum} != ${remoteChecksum})`
-        );
-      }
       uploadSpinner.succeed(`Uploaded asset "${name}".`);
       return url;
     } catch (e) {
       uploadSpinner.fail(`Cannot upload asset "${name}".`);
-
       throw e;
     }
-  }
-
-  private async checksumFromUrl(url: string): Promise<string> {
-    // XXX: This is a bit hacky as we rely on various things:
-    // 1. GitHub issuing a redirect to AWS S3.
-    // 2. S3 using the MD5 hash of the file for its ETag cache header.
-    // 3. The file being small enough to fit in memory.
-    //
-    // Note that if assets are large (5GB) assumption 2 is not correct. See
-    // https://github.com/getsentry/craft/issues/322#issuecomment-964303174
-    let response;
-    try {
-      response = await this.github.request(`HEAD ${url}`, {
-        headers: {
-          // WARNING: You **MUST** pass this accept header otherwise you'll
-          //          get a useless JSON API response back, instead of getting
-          //          redirected to the raw file itself.
-          //          And don't even think about using `browser_download_url`
-          //          field as it is close to impossible to authenticate for
-          //          that URL with a token and you'll lose hours getting 404s
-          //          for private repos. Consider yourself warned. --xoxo BYK
-          Accept: DEFAULT_CONTENT_TYPE,
-        },
-      });
-    } catch (e) {
-      throw new Error(
-        `Cannot get asset on GitHub. Status: ${(e as any).status}\n` + e
-      );
-    }
-
-    const etag = response.headers['etag'];
-    if (etag && etag.length > 0) {
-      // ETag header comes in quotes for some reason so strip those
-      return etag.slice(1, -1);
-    }
-
-    return await this.md5FromUrl(url);
-  }
-
-  private async md5FromUrl(url: string): Promise<string> {
-    this.logger.debug('Downloading asset from GitHub to check MD5 hash: ', url);
-    let response;
-    try {
-      response = await this.github.request(`GET ${url}`, {
-        headers: {
-          Accept: DEFAULT_CONTENT_TYPE,
-        },
-      });
-    } catch (e) {
-      throw new Error(
-        `Cannot download asset from GitHub. Status: ${(e as any).status}\n` + e
-      );
-    }
-    return this.checksumFromData(Buffer.from(response.data));
-  }
-
-  private checksumFromData(data: BinaryLike): string {
-    return createHash('md5').update(data).digest('hex');
   }
 
   private async handleGitHubUpload(


### PR DESCRIPTION
Upon close inspection of the code changes introduced in 57e96687cfd80522dc5c9fb8deeac3d5583b5733, it turns out that the portion of code that compares the checksum of the local file against the uploaded file was innefective to protect against the bug introduced in c978bf605d7b4a3a6c297659e4a55f91b7a869f4.

The checksum comparison compared bytes after reading an asset file from disk, and essentially protected us from mishandling on GitHub's side, but not from reading and uploading incorrect data, specifically:

	readFileSync(path, { encoding: 'binary' })

The bug was fixed in 4697dbdbecfdc6444e62b9c50bdd617829d20d18, but notice how from then on we started using `readFileSync` instead of `createReadStream` (a potential problem for large assets as we don't really need to hold all bytes in memory at once).

This change reintroduces the use of `createReadStream`, and reverts the several iterations of trying to do checksums (57e96687cfd80522dc5c9fb8deeac3d5583b5733, ea24f4d3d7f24b6435f7bacc5e11726135f308ae, and d14a988683690a28af269c331a8e4670b8d557df).

We choose to remove the checksum-related code because it is fragile, depends on undocumented APIs and has shown to be problematic in recently attempts to make releases with Craft, leading up to new incidents. And, as stated earlier, because it doesn't really protect us from the original problem it was trying to address.

Note that we keep the size check introduced in the same commit 57e96687cfd80522dc5c9fb8deeac3d5583b5733 and that we've proved that it, by itself, is capable of detecting the original bug, as described below.

First we reintroduce the bug:

	$ git diff
	diff --git a/src/targets/github.ts b/src/targets/github.ts
	index 8fb44cd..62aa2e1 100644
	--- a/src/targets/github.ts
	+++ b/src/targets/github.ts
	@@ -1,6 +1,6 @@
	 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
	 import { RequestError } from '@octokit/request-error';
	-import { createReadStream, promises, statSync } from 'fs';
	+import { readFileSync, promises, statSync } from 'fs';
	 import { basename } from 'path';

	 import { getConfiguration } from '../config';
	@@ -362,7 +362,7 @@ export class GithubTarget extends BaseTarget {
	     ).start();

	     try {
	-      const file = createReadStream(path);
	+      const file = readFileSync(path, { encoding: 'binary' });
	       const { url, size } = await this.handleGitHubUpload({
	         ...params,
	         // XXX: Octokit types this out as string, but in fact it also

Then we make a release and see that the asset size check fails:

	$ cd craft
	$ yarn build
	$ cd release-tester
	$ node --enable-source-maps ../craft/dist/craft publish 0.26.0 --target github --no-merge --no-input
	...
	Error: Uploaded asset size (440 bytes) does not match local asset size (413 bytes) for "gh-pages.zip".

Removing the above patch, rebuilding and running the release process again leads to a successful release (and one that doesn't depend on checksum checking).

We could re-introduce checksumming in the future, but then probably a better approach would involve either using some (new) GitHub API that can provide a checksum (non-existent today) or to fully download assets.

Additionally, it would be useful to perform asset-specific/project-specific sanity checks, for example, for binary executables we could download the asset and run `./binary --help` to ensure it succeeds or `./binary --version` to ensure it produces the expected output.

---

Related:
- #290
- #302 
- #308 
- #323 
- #328