### PR TITLE
Limit the number of leftovers listed

### DIFF
--- a/src/utils/__tests__/changelog.test.ts
+++ b/src/utils/__tests__/changelog.test.ts
@@ -411,10 +411,18 @@ describe('generateChangesetFromGit', () => {
           body: '',
           pr: { remote: { number: '456', author: { login: 'bob' } } },
         },
+        {
+          hash: 'cdef1234567890ad',
+          title: 'Refactored the crankshaft again',
+          body: '',
+          pr: { remote: { number: '458', author: { login: 'bob' } } },
+        },
       ],
       {},
       [
         '### Various fixes & improvements',
+        '',
+        '(Only listing 3 out of 4.)',
         '',
         '- Upgraded the kernel (abcdef12)',
         '- Upgraded the manifold (#123) by @alice',
@@ -706,7 +714,7 @@ describe('generateChangesetFromGit', () => {
       output: string
     ) => {
       setup(commits, milestones);
-      const changes = await generateChangesetFromGit(dummyGit, '1.0.0');
+      const changes = await generateChangesetFromGit(dummyGit, '1.0.0', 3);
       expect(changes).toBe(output);
     }
   );

--- a/src/utils/__tests__/changelog.test.ts
+++ b/src/utils/__tests__/changelog.test.ts
@@ -422,11 +422,11 @@ describe('generateChangesetFromGit', () => {
       [
         '### Various fixes & improvements',
         '',
-        '_Listing 3 out of 4_',
-        '',
         '- Upgraded the kernel (abcdef12)',
         '- Upgraded the manifold (#123) by @alice',
         '- Refactored the crankshaft (#456) by @bob',
+        '',
+        '_Plus 1 more_',
       ].join('\n'),
     ],
     [

--- a/src/utils/__tests__/changelog.test.ts
+++ b/src/utils/__tests__/changelog.test.ts
@@ -422,7 +422,7 @@ describe('generateChangesetFromGit', () => {
       [
         '### Various fixes & improvements',
         '',
-        '(Only listing 3 out of 4.)',
+        '_Listing 3 out of 4_',
         '',
         '- Upgraded the kernel (abcdef12)',
         '- Upgraded the manifold (#123) by @alice',

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -16,7 +16,7 @@ const DEFAULT_CHANGESET_BODY = '- No documented changes.';
 const VERSION_HEADER_LEVEL = 2;
 const SUBSECTION_HEADER_LEVEL = VERSION_HEADER_LEVEL + 1;
 const MAX_COMMITS_PER_QUERY = 50;
-const MAX_LEFTOVERS = 64;
+const MAX_LEFTOVERS = 24;
 
 // Ensure subsections are nested under version headers otherwise we won't be
 // able to find them and put on GitHub releases.
@@ -343,12 +343,12 @@ export async function generateChangesetFromGit(
     changelogSections.push(
       markdownHeader(SUBSECTION_HEADER_LEVEL, 'Various fixes & improvements')
     );
-    if (nLeftovers > maxLeftovers) {
-      changelogSections.push(`_Listing ${maxLeftovers} out of ${nLeftovers}_`);
-    }
     changelogSections.push(
       leftovers.slice(0, maxLeftovers).map(formatCommit).join('\n')
     );
+    if (nLeftovers > maxLeftovers) {
+      changelogSections.push(`_Plus ${nLeftovers - maxLeftovers} more_`);
+    }
   }
 
   return changelogSections.join('\n\n');

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -344,9 +344,7 @@ export async function generateChangesetFromGit(
       markdownHeader(SUBSECTION_HEADER_LEVEL, 'Various fixes & improvements')
     );
     if (nLeftovers > maxLeftovers) {
-      changelogSections.push(
-        `(Only listing ${maxLeftovers} out of ${nLeftovers}.)`
-      );
+      changelogSections.push(`_Listing ${maxLeftovers} out of ${nLeftovers}_`);
     }
     changelogSections.push(
       leftovers.slice(0, maxLeftovers).map(formatCommit).join('\n')

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -16,7 +16,7 @@ const DEFAULT_CHANGESET_BODY = '- No documented changes.';
 const VERSION_HEADER_LEVEL = 2;
 const SUBSECTION_HEADER_LEVEL = VERSION_HEADER_LEVEL + 1;
 const MAX_COMMITS_PER_QUERY = 50;
-const MAX_LEFTOVERS = 128;
+const MAX_LEFTOVERS = 64;
 
 // Ensure subsections are nested under version headers otherwise we won't be
 // able to find them and put on GitHub releases.


### PR DESCRIPTION
Nobody's going to read through a list of 1,000s of commits, may as well use git log at that point.

What's more, over-long changesets can lead to [GitHub API failures](https://github.com/getsentry/self-hosted/issues/1193#issuecomment-995011767).