### PR TITLE
fix(crates): Skip path-only dev-dependencies in dep cycle checking

### DIFF
--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -185,7 +185,12 @@ export class CratesTarget extends BaseTarget {
     const isWorkspaceDependency = (dep: CrateDependency) => {
       // Optionally exclude dev dependencies from dependency resolution. When
       // this flag is provided, these usually lead to circular dependencies.
-      if (this.cratesConfig.noDevDeps && dep.kind === 'dev') {
+      // Path-only dependencies are designated by `req = *`, and are not being
+      // validated by cargo on publish.
+      if (
+        dep.kind === 'dev' &&
+        (dep.req === '*' || this.cratesConfig.noDevDeps)
+      ) {
         return false;
       }
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry-rust/issues/374#issuecomment-952669578

The initial problem is that cargo validates (dev)-dependencies before publishing, and rejects that if the required version does not exist on crates.io yet. path-only dev-dependencies skip this check, and are thus not holding up publishing.

The previous method of using `cargo-hack` and the `noDevDeps` flag should be discouraged as it uses the `--allow-dirty` flag and thus prevents cargo from putting in more metadata that could be used for crate integrity validation (aka, the code in the crate matches a git commit; which it currently does not due to usage of `cargo-hack`)

Read https://codeandbitters.com/published-crate-analysis/ for more insight into why `cargo-hack` should be avoided.