### PR TITLE
Publish to GitHub more atomically using draft repos

### DIFF
--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -492,7 +492,7 @@ export async function prepareMain(argv: PrepareOptions): Promise<any> {
   // a custom revision and it is harder to tell git to give us the tag right
   // before a specific revision.
   // TL;DR - WARNING:
-  // The order matters here, do not move this command above craeteReleaseBranch!
+  // The order matters here, do not move this command above createReleaseBranch!
   const oldVersion = await getLatestTag(git);
 
   // Check & update the changelog

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -262,7 +262,7 @@ export class GithubTarget extends BaseTarget {
   /**
    * Deletes the provided asset from its respective release
    *
-   * Can be also used to delete orphaned (unfinished) releases
+   * Can also be used to delete orphaned (unfinished) releases
    *
    * @param asset Asset to delete
    */
@@ -271,7 +271,7 @@ export class GithubTarget extends BaseTarget {
   ): Promise<boolean> {
     this.logger.debug(`Deleting asset: "${asset.name}"...`);
     if (isDryRun()) {
-      this.logger.info(`[dry-run] Not uploading deleting "${asset.name}"`);
+      this.logger.info(`[dry-run] Not deleting "${asset.name}"`);
       return false;
     }
 

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -52,11 +52,6 @@ interface GithubRelease {
   upload_url: string;
 }
 
-/**
- * Tag type as expected by the GitHub API.
- */
-type GithubCreateTagType = 'commit' | 'tree' | 'blob';
-
 type ReposListAssetsForReleaseResponseItem = RestEndpointMethodTypes['repos']['listReleaseAssets']['response']['data'][0];
 
 interface OctokitError {

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -137,19 +137,19 @@ export class GithubTarget extends BaseTarget {
         tag_name: tag,
         upload_url: '',
       };
-    } else {
-      const created = await this.github.repos.createRelease({
-        draft: true,
-        name: tag,
-        owner: this.githubConfig.owner,
-        prerelease: isPreview,
-        repo: this.githubConfig.repo,
-        tag_name: tag,
-        target_commitish: revision,
-        ...changes,
-      });
-      return created.data;
     }
+
+    const created = await this.github.repos.createRelease({
+      draft: true,
+      name: tag,
+      owner: this.githubConfig.owner,
+      prerelease: isPreview,
+      repo: this.githubConfig.repo,
+      tag_name: tag,
+      target_commitish: revision,
+      ...changes,
+    });
+    return created.data;
   }
 
   public async getChangelog(version: string): Promise<Changeset> {
@@ -342,14 +342,15 @@ export class GithubTarget extends BaseTarget {
   public async publishReleaseDraft(release_id: number) {
     if (isDryRun()) {
       this.logger.info(`[dry-run] Not publishing the release draft`);
-    } else {
-      await this.github.repos.updateRelease({
-        owner: this.githubConfig.owner,
-        repo: this.githubConfig.repo,
-        release_id,
-        draft: false,
-      });
+      return;
     }
+
+    await this.github.repos.updateRelease({
+      owner: this.githubConfig.owner,
+      repo: this.githubConfig.repo,
+      release_id,
+      draft: false,
+    });
   }
 
   /**

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -204,7 +204,7 @@ export class GithubTarget extends BaseTarget {
    *
    * @param release Release to fetch assets from
    */
-  public async getAssetsForReleaseDraft(
+  public async getAssetsForRelease(
     release_id: number
   ): Promise<ReposListAssetsForReleaseResponseItem[]> {
     const assetsResponse = await this.github.repos.listReleaseAssets({
@@ -226,7 +226,7 @@ export class GithubTarget extends BaseTarget {
     release_id: number,
     assetName: string
   ): Promise<boolean> {
-    const assets = await this.getAssetsForReleaseDraft(release_id);
+    const assets = await this.getAssetsForRelease(release_id);
     const assetToDelete = assets.find(({ name }) => name === assetName);
     if (!assetToDelete) {
       throw new Error(
@@ -369,7 +369,7 @@ export class GithubTarget extends BaseTarget {
 
     const draft = await this.createReleaseDraft(version, revision, changelog);
 
-    const assets = await this.getAssetsForReleaseDraft(draft.id);
+    const assets = await this.getAssetsForRelease(draft.id);
     if (assets.length > 0) {
       throw new Error('Existing assets found for the release draft! Why?');
     }

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -139,16 +139,18 @@ export class GithubTarget extends BaseTarget {
       };
     }
 
-    return (await this.github.repos.createRelease({
-      draft: true,
-      name: tag,
-      owner: this.githubConfig.owner,
-      prerelease: isPreview,
-      repo: this.githubConfig.repo,
-      tag_name: tag,
-      target_commitish: revision,
-      ...changes,
-    })).data;
+    return (
+      await this.github.repos.createRelease({
+        draft: true,
+        name: tag,
+        owner: this.githubConfig.owner,
+        prerelease: isPreview,
+        repo: this.githubConfig.repo,
+        tag_name: tag,
+        target_commitish: revision,
+        ...changes,
+      })
+    ).data;
   }
 
   public async getChangelog(version: string): Promise<Changeset> {
@@ -374,7 +376,11 @@ export class GithubTarget extends BaseTarget {
       }))
     );
 
-    const draftRelease = await this.createDraftRelease(version, revision, changelog);
+    const draftRelease = await this.createDraftRelease(
+      version,
+      revision,
+      changelog
+    );
     await Promise.all(
       localArtifacts.map(({ path, mimeType }) =>
         this.uploadAsset(draftRelease, path, mimeType)

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -145,12 +145,12 @@ export class UpmTarget extends BaseTarget {
         } else {
           await git.push(['origin', 'main']);
           const changes = await this.githubTarget.getChangelog(version);
-          const draft = await this.githubTarget.createReleaseDraft(
+          const draftRelease = await this.githubTarget.createDraftRelease(
             version,
             targetRevision,
             changes
           );
-          await this.githubTarget.publishReleaseDraft(draft.id);
+          await this.githubTarget.publishRelease(draftRelease);
         }
       },
       true,

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -145,11 +145,12 @@ export class UpmTarget extends BaseTarget {
         } else {
           await git.push(['origin', 'main']);
           const changes = await this.githubTarget.getChangelog(version);
-          await this.githubTarget.getOrCreateRelease(
+          const draft = await this.githubTarget.createReleaseDraft(
             version,
             targetRevision,
             changes
           );
+          await this.githubTarget.publishReleaseDraft(draft.id);
         }
       },
       true,


### PR DESCRIPTION
Closes #336.

Tested with https://github.com/getsentry/testing-craft-chadwhitacre/blob/0.0.9/test.

E.g. https://github.com/getsentry/testing-craft-chadwhitacre/

------------

<img width="1166" alt="Screen Shot 2022-01-14 at 2 28 52 PM" src="https://user-images.githubusercontent.com/134455/149574405-2466a997-b35f-486d-b608-37813aa640db.png">

------------

<img width="1086" alt="Screen Shot 2022-01-14 at 2 29 05 PM" src="https://user-images.githubusercontent.com/134455/149574418-5e785b7e-98eb-460a-acc4-5a0ca78f2861.png">