### PR TITLE
ci: Change machineType for Google Cloud Build to E2_HIGHCPU_8

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -42,6 +42,8 @@ steps:
         docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:latest
         docker push getsentry/craft:latest
 timeout: 960s
+options:
+  machineType: 'E2_HIGHCPU_8'
 secrets:
   - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
     secretEnv:


### PR DESCRIPTION
This gives our machine more memory, which prevents `"gcr.io/kaniko-project/executor:v1.5.1" failed: step exited with non-zero status: 137` errors after adding too many new targets.