### PR TITLE
deps: Roll back to symbol-collector 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get -qq update \
   && cargo install cargo-hack \
   && gem install cocoapods \
   # Install https://github.com/getsentry/symbol-collector
-  && symbol_collector_url=$(curl -s https://api.github.com/repos/getsentry/symbol-collector/releases/tags/1.5.1 | \
+  && symbol_collector_url=$(curl -s https://api.github.com/repos/getsentry/symbol-collector/releases/tags/1.4.2 | \
   jq -r '.assets[].browser_download_url | select(endswith("symbolcollector-console-linux-x64.zip"))') \
   && curl -sL $symbol_collector_url -o "/tmp/sym-collector.zip" \
   && unzip /tmp/sym-collector.zip -d /usr/local/bin/ \


### PR DESCRIPTION
Current version is failing for some releasese, eg. https://github.com/getsentry/publish/runs/5333817295?check_suite_focus=true
ref: https://github.com/getsentry/symbol-collector/issues/124