### PR TITLE
breaking: Rename latest tag to nightly

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: '0.25.3'
+minVersion: '0.30.0'
 changelogPolicy: auto
 preReleaseCommand: >-
   node -p "
@@ -32,8 +32,14 @@ targets:
         checksums:
           - algorithm: sha256
             format: hex
-  - name: docker
+  - id: release
+    name: docker
     source: us.gcr.io/sentryio/craft
     target: getsentry/craft
+  - id: latest
+    name: docker
+    source: us.gcr.io/sentryio/craft
+    target: getsentry/craft
+    targetFormat: '{{{target}}}:latest'
   - name: github
   - name: gh-pages

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,8 +39,8 @@ steps:
         docker push getsentry/craft:$SHORT_SHA
         docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:$COMMIT_SHA
         docker push getsentry/craft:$COMMIT_SHA
-        docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:latest
-        docker push getsentry/craft:latest
+        docker tag us.gcr.io/$PROJECT_ID/craft:$COMMIT_SHA getsentry/craft:nightly
+        docker push getsentry/craft:nightly
 timeout: 960s
 options:
   machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
Make the `:latest` tag on Docker Hub to mean latest release and introduce the `:nightly` tag for the per-master builds. This is in alignment with other Sentry projects. Should address getsentry/publish#666.
