### PR TITLE
fix: Use unzipper.Open to use CentralDirectory instead of local headers

### DIFF
--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -344,15 +344,10 @@ export async function extractZipArchive(
   filePath: string,
   dir: string
 ): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    try {
-      fs.createReadStream(filePath)
-        .pipe(unzipper.Extract({ path: dir, concurrency: 2 }))
-        .on('error', reject)
-        .on('close', resolve);
-    } catch (e) {
-      reject(e);
-    }
+  const archive = await unzipper.Open.file(filePath);
+  await archive.extract({
+    path: dir,
+    concurrency: 2,
   });
 }
 


### PR DESCRIPTION
For some reason, one of our GitHub artifacts archives was failing to unzip correctly. I believe its caused by the archive itself containing nothing else than another two zip archives.

```
Error: unexpected end of file
    at Zlib.zlibOnError [as onerror] (node:zlib:189:17) {
  errno: -5,
  code: 'Z_BUF_ERROR'
}
```

By using `unzipper.Open` we are reading the end of the file first and getting central directory listing instead of local file headers. This is more reliable and works fine with the broken artifact - https://github.com/getsentry/sentry-cocoa/actions/runs/2015128317

https://github.com/ZJONSSON/node-unzipper#open
https://github.com/ZJONSSON/node-unzipper/issues/202#issuecomment-647546830
https://github.com/ZJONSSON/node-unzipper/issues/149#issuecomment-527226929

ref: https://github.com/getsentry/publish/runs/5624900873?check_suite_focus=true