### PR TITLE
ci(lint): Make lint job work for external contributors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
           git config user.name "getsentry-bot" &&
           git diff --quiet ||
           git commit -anm 'ref: Lint fixes' &&
-          git push origin refs/pull/${{ github.event.pull_request.number }}/head
+          git push origin refs/pull/${{ github.event.pull_request.number }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
           git config user.name "getsentry-bot" &&
           git diff --quiet ||
           git commit -anm 'ref: Lint fixes' &&
-          git push origin refs/remotes/origin/pull/${{ github.event.pull_request.number }}
+          git push origin pull/${{ github.event.pull_request.number }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 10
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: volta-cli/action@v1
       - uses: actions/cache@v3
         id: cache
@@ -28,4 +28,4 @@ jobs:
           git config user.name "getsentry-bot" &&
           git diff --quiet ||
           git commit -anm 'ref: Lint fixes' &&
-          git push
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
       - uses: volta-cli/action@v1
       - uses: actions/cache@v3
         id: cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
           git config user.name "getsentry-bot" &&
           git diff --quiet ||
           git commit -anm 'ref: Lint fixes' &&
-          git push origin refs/pull/${{ github.event.pull_request.number }}
+          git push origin HEAD:refs/pull/${{ github.event.pull_request.number }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: 'Lint'
 on:
-  pull_request:
+  pull_request_target:
     branches: [master]
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
           git config user.name "getsentry-bot" &&
           git diff --quiet ||
           git commit -anm 'ref: Lint fixes' &&
-          git push origin ${{ github.head_ref }}
+          git push origin refs/remotes/origin/pull/${{ github.event.pull_request.number }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
           git config user.name "getsentry-bot" &&
           git diff --quiet ||
           git commit -anm 'ref: Lint fixes' &&
-          git push origin pull/${{ github.event.pull_request.number }}
+          git push origin refs/pull/${{ github.event.pull_request.number }}/head

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,17 +1,16 @@
 name: 'Lint'
 on:
   pull_request:
+    branches: [master]
 
 jobs:
   lint:
     name: Lint fixes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/checkout@v3
       - uses: volta-cli/action@v1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: node_modules


### PR DESCRIPTION
Using `pull_request.head.ref` does not work if the PR is made from a fork as the local repo credentials don't work for pulling from remote repos (obviously :D). This PR fixes that.
