### PR TITLE
feat(changelog): Limit changes to current project folder

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -52,6 +52,10 @@ export async function getChangesSince(
     // https://git-scm.com/docs/gitrevisions#_dotted_range_notations for more
     symmetric: false,
     '--no-merges': null,
+    // Limit changes to the CWD to better support monorepos
+    // this should still return all commits for individual repos when run from
+    // the repo root.
+    file: '.',
   });
   return commits.map(commit => ({
     hash: commit.hash,


### PR DESCRIPTION
This change will limit the generated changelog entries to the current working directory, supporting monorepos with multiple different Craft configurations in them. It should have no effect on existing multi-repo use cases.
