### PR TITLE
ref: Remove spinners from github target artifacts upload

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -20,7 +20,6 @@ import { isPreviewRelease, versionToTag } from '../utils/version';
 import { BaseTarget } from './base';
 import { BaseArtifactProvider } from '../artifact_providers/base';
 import { logger } from '../logger';
-import ora from 'ora';
 
 /**
  * Default content type for GitHub release assets.
@@ -269,9 +268,9 @@ export class GitHubTarget extends BaseTarget {
       return;
     }
 
-    const uploadSpinner = ora(
-      `Uploading asset "${name}" to ${this.githubConfig.owner}/${this.githubConfig.repo}:${release.tag_name}`
-    ).start();
+    process.stderr.write(
+      `Uploading asset "${name}" to ${this.githubConfig.owner}/${this.githubConfig.repo}:${release.tag_name}\n`
+    );
 
     try {
       const file = createReadStream(path);
@@ -282,16 +281,15 @@ export class GitHubTarget extends BaseTarget {
         // want as we upload binary data.
         data: file as any,
       });
-      uploadSpinner.text = `Verifying asset "${name}...`;
       if (size != stats.size) {
         throw new Error(
           `Uploaded asset size (${size} bytes) does not match local asset size (${stats.size} bytes) for "${name}".`
         );
       }
-      uploadSpinner.succeed(`Uploaded asset "${name}".`);
+      process.stderr.write(`✔ Uploaded asset "${name}".\n`);
       return url;
     } catch (e) {
-      uploadSpinner.fail(`Cannot upload asset "${name}".`);
+      process.stderr.write(`✖ Cannot upload asset "${name}".\n`);
       throw e;
     }
   }


### PR DESCRIPTION
Due to `ora` not being able to handle multiple spinners, there's a suspicion that it interrupts our main `Promise.all` handler in some way, or with the retry process. This makes some releases somehow stuck. Funny enough, in 99% of cases they work on the first try during retry.

Before swapping `ora` for something else, I believe it's way easier to verify that this is the culprit by simply removing it entirely and leaving just the text itself. In the CI, where we look at those logs, there are no spinners anyway, and everything is logged one by one.

I removed `Verifying asset` text, as it looks redundant to me, due to a very clear error message in case something goes wrong. With the happy path, it provides no value.

Also used `process.stderr.write` instead of `console.error` (which is an alias for `process.stderr.write` with a new-line added) to make it more obvious that it's not a left out by an accident `console` call. It also mimics `ora` behavior 1:1.

A possible fix for https://github.com/getsentry/craft/issues/384

cc @BYK 