### PR TITLE
ref: Remove @octokit/plugin-retry and rely on our own logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@aws-sdk/client-lambda": "^3.2.0",
     "@google-cloud/storage": "^5.7.0",
-    "@octokit/plugin-retry": "^3.0.9",
     "@octokit/request-error": "^2.1.0",
     "@octokit/rest": "^18.10.0",
     "@sentry/node": "4.6.3",

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -337,7 +337,7 @@ export class GitHubTarget extends BaseTarget {
    *
    * @param release Release object
    */
-  public async publishRelease(release: GitHubRelease) {
+  public async publishRelease(release: GitHubRelease): Promise<void> {
     if (isDryRun()) {
       this.logger.info(`[dry-run] Not publishing the draft release`);
       return;

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -111,10 +111,7 @@ export function getGitHubClient(token = ''): Octokit {
       };
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { retry } = require('@octokit/plugin-retry');
-    const octokitWithRetries = Octokit.plugin(retry);
-    _GitHubClientCache[githubApiToken] = new octokitWithRetries(attrs);
+    _GitHubClientCache[githubApiToken] = new Octokit(attrs);
   }
 
   return _GitHubClientCache[githubApiToken];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,14 +1095,6 @@
     "@octokit/types" "^6.28.1"
     deprecation "^2.3.1"
 
-"@octokit/plugin-retry@^3.0.9":
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz#ae625cca1e42b0253049102acd71c1d5134788fe"
-  integrity sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==
-  dependencies:
-    "@octokit/types" "^6.0.3"
-    bottleneck "^2.15.3"
-
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
@@ -1929,11 +1921,6 @@ bluebird@~3.4.1:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
   integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
-
-bottleneck@^2.15.3:
-  version "2.19.5"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
-  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 bowser@^2.11.0:
   version "2.11.0"


### PR DESCRIPTION
We do already have our own logic implemented here - https://github.com/getsentry/craft/blob/2d8ba63ab9670d9b20c8c9e1a082ab60175c2594/src/targets/github.ts#L297-L333