### PR TITLE
ref: Upload GitHub artifacts in series

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -379,11 +379,12 @@ export class GitHubTarget extends BaseTarget {
       revision,
       changelog
     );
-    await Promise.all(
-      localArtifacts.map(({ path, mimeType }) =>
-        this.uploadAsset(draftRelease, path, mimeType)
-      )
-    );
+
+    // We don't want to do this in parallel but in serial, because the GitHub
+    // artifacts endpoint has a tendency to randomly timeout on multiple requests.
+    for (const { path, mimeType } of localArtifacts) {
+      await this.uploadAsset(draftRelease, path, mimeType);
+    }
 
     await this.publishRelease(draftRelease);
   }


### PR DESCRIPTION
GH Support suggested that our issues might be caused by too many requests in quick succession.
This change would verify this claim, but I'm still discussing this possibility with them.