### PR TITLE
fix(crates): Resume workspace publish

### DIFF
--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -278,7 +278,7 @@ export class CratesTarget extends BaseTarget {
     await withRetry(
       async () => {
         try {
-          spawnProcess(CARGO_BIN, args, { env })
+          await spawnProcess(CARGO_BIN, args, { env });
         } catch (err) {
           if (err instanceof Error && err.message.includes(REPUBLISH_ERROR)) {
             this.logger.info(`Skipping ${crate.name}, version ${crate.version} already published`);


### PR DESCRIPTION
The crates target is not able to resume a workspace publish because already published crates cannot be republished. This means a partially successful publish cannot be retried.

To work around this, the `crates` target can skip publishing a crate if it already exists in this version. The downside of this is that we would silence errors when publishing the wrong version.

See https://github.com/getsentry/publish/issues/1070#issuecomment-1122077509