### PR TITLE
Add additional context to error when version has a 'v' prefix

### DIFF
--- a/src/commands/__tests__/prepare.test.ts
+++ b/src/commands/__tests__/prepare.test.ts
@@ -1,6 +1,6 @@
 import { join as pathJoin } from 'path';
 import { spawnProcess } from '../../utils/system';
-import { runPreReleaseCommand } from '../prepare';
+import { runPreReleaseCommand, checkVersionOrPart } from '../prepare';
 
 jest.mock('../../utils/system');
 
@@ -51,5 +51,37 @@ describe('runPreReleaseCommand', () => {
         },
       }
     );
+  });
+
+  test('return true for valid version', () => {
+    const validVersions = [
+      '2.3.3',
+      '0.0.1',
+    ];
+    for (const v of validVersions) {
+      expect(
+        checkVersionOrPart({
+          newVersion: v,
+        }, null)
+      ).toBe(true);
+    }
+  });
+
+  test('throw an error for invalid version', () => {
+    const invalidVersions = [
+      { v: 'invalid-2.3.3', e: 'Invalid version or version part specified: "invalid-2.3.3"' },
+      { v: 'v2.3.3', e: 'Invalid version or version part specified: "v2.3.3". Removing the "v" prefix will likely fix the issue' },
+      { v: 'major', e: 'Version part is not supported yet' },
+      { v: 'minor', e: 'Version part is not supported yet' },
+      { v: 'patch', e: 'Version part is not supported yet' },
+    ];
+    for (const t of invalidVersions) {
+      const fn = () => {
+        checkVersionOrPart({
+          newVersion: t.v,
+        }, null);
+      };
+      expect(fn).toThrow(t.e);
+    }
   });
 });

--- a/src/commands/__tests__/prepare.test.ts
+++ b/src/commands/__tests__/prepare.test.ts
@@ -52,7 +52,9 @@ describe('runPreReleaseCommand', () => {
       }
     );
   });
+});
 
+describe('checkVersionOrPart', () => {
   test('return true for valid version', () => {
     const validVersions = [
       '2.3.3',

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -120,7 +120,7 @@ export function checkVersionOrPart(argv: Arguments<any>, _opt: any): boolean {
     return true;
   } else {
     let errMsg = `Invalid version or version part specified: "${version}"`;
-    if (version.indexOf('v') === 0) {
+    if (version.startsWith('v')) {
       errMsg += '. Removing the "v" prefix will likely fix the issue';
     }
     throw Error(errMsg);
@@ -281,7 +281,7 @@ function checkGitStatus(repoStatus: StatusResult, rev: string) {
   ) {
     reportError(
       'Your repository is in a dirty state. ' +
-      'Please stash or commit the pending changes.',
+        'Please stash or commit the pending changes.',
       logger
     );
   }

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -112,14 +112,18 @@ const SLEEP_BEFORE_PUBLISH_SECONDS = 30;
  * @param argv Parsed yargs arguments
  * @param _opt A list of options and aliases
  */
-function checkVersionOrPart(argv: Arguments<any>, _opt: any): any {
+export function checkVersionOrPart(argv: Arguments<any>, _opt: any): boolean {
   const version = argv.newVersion;
   if (['major', 'minor', 'patch'].indexOf(version) > -1) {
     throw Error('Version part is not supported yet');
   } else if (isValidVersion(version)) {
     return true;
   } else {
-    throw Error(`Invalid version or version part specified: "${version}"`);
+    let errMsg = `Invalid version or version part specified: "${version}"`;
+    if (version.indexOf('v') === 0) {
+      errMsg += '. Removing the "v" prefix will likely fix the issue';
+    }
+    throw Error(errMsg);
   }
 }
 
@@ -277,7 +281,7 @@ function checkGitStatus(repoStatus: StatusResult, rev: string) {
   ) {
     reportError(
       'Your repository is in a dirty state. ' +
-        'Please stash or commit the pending changes.',
+      'Please stash or commit the pending changes.',
       logger
     );
   }


### PR DESCRIPTION
This PR also adds tests to the `checkVersionOrPart` function, this is largely for my own piece of mind that I haven't broken anything, let me know if these should be changed or removed (I acknowledge they aren't the most useful tests in the world).