### PR TITLE
feat: maven kotlin multiplatform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,14 +1016,16 @@ Note: in order to see the output of the commands, set the [logging level](#loggi
 
 **Configuration**
 
-| Option              | Description                                                          |
-| ------------------- | -------------------------------------------------------------------- |
-| `mavenCliPath`      | Path to the Maven CLI. It must be executable by the calling process. |
-| `mavenSettingsPath` | Path to the Maven `settings.xml` file.                               |
-| `mavenRepoId`       | ID of the Maven server in the `settings.xml`.                        |
-| `mavenRepoUrl`      | URL of the Maven repository.                                         |
-| `android`           | Android configuration, see below.                                    |
+| Option                | Description                                                          |
+| --------------------- | -------------------------------------------------------------------- |
+| `mavenCliPath`        | Path to the Maven CLI. It must be executable by the calling process. |
+| `mavenSettingsPath`   | Path to the Maven `settings.xml` file.                               |
+| `mavenRepoId`         | ID of the Maven server in the `settings.xml`.                        |
+| `mavenRepoUrl`        | URL of the Maven repository.                                         |
+| `android`             | Android configuration, see below.                                    |
+| `kotlinMultiplatform` | Kotlin Multiplatform configuration, see below.                       |
 
+The Kotlin Multiplatform configuration is optional and `false` by default.
 If your project isn't related to Android, you don't need this configuration and
 can set the option to `false`. If not, set the following nested elements:
 
@@ -1056,6 +1058,23 @@ targets:
       distDirRegex: /^sentry-android-.*$/
       fileReplaceeRegex: /\d\.\d\.\d(-SNAPSHOT)?/
       fileReplacerStr: release.aar
+```
+
+**Example (with Kotlin Multiplatform config)**
+```yaml
+targets:
+  - name: maven
+    mavenCliPath: scripts/mvnw.cmd
+    mavenSettingsPath: scripts/settings.xml
+    mavenRepoId: ossrh
+    mavenRepoUrl: https://oss.sonatype.org/service/local/staging/deploy/maven2/
+    android:
+      distDirRegex: /^sentry-android-.*$/
+      fileReplaceeRegex: /\d\.\d\.\d(-SNAPSHOT)?/
+      fileReplacerStr: release.aar
+    kotlinMultiplatform:
+      rootDistDirRegex: /sentry-kotlin-multiplatform-[0-9]+.*$/
+      appleDistDirRegex: /sentry-kotlin-multiplatform-(macos|ios|tvos|watchos).*/
 ```
 
 ### Symbol Collector (`symbol-collector`)

--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,7 @@ Note: in order to see the output of the commands, set the [logging level](#loggi
 | `mavenRepoId`         | ID of the Maven server in the `settings.xml`.                        |
 | `mavenRepoUrl`        | URL of the Maven repository.                                         |
 | `android`             | Android configuration, see below.                                    |
-| `kotlinMultiplatform` | Kotlin Multiplatform configuration, see below.                       |
+| `kmp` | Kotlin Multiplatform configuration, see below.                       |
 
 The Kotlin Multiplatform configuration is optional and `false` by default.
 If your project isn't related to Android, you don't need this configuration and
@@ -1101,7 +1101,7 @@ targets:
       distDirRegex: /^sentry-android-.*$/
       fileReplaceeRegex: /\d\.\d\.\d(-SNAPSHOT)?/
       fileReplacerStr: release.aar
-    kotlinMultiplatform:
+    kmp:
       rootDistDirRegex: /sentry-kotlin-multiplatform-[0-9]+.*$/
       appleDistDirRegex: /sentry-kotlin-multiplatform-(macos|ios|tvos|watchos).*/
 ```

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -71,6 +71,10 @@ function getFullTargetConfig(): any {
       fileReplaceeRegex: '/replacee/',
       fileReplacerStr: 'replacer',
     },
+    kotlinMultiplatform: {
+      rootDistDirRegex: '/distDir/',
+      appleDistDirRegex: '/apple-distDir/'
+    },
   };
 }
 
@@ -84,6 +88,7 @@ function getRequiredTargetConfig(): any {
     mavenRepoId: DEFAULT_OPTION_VALUE,
     mavenRepoUrl: DEFAULT_OPTION_VALUE,
     android: false,
+    kotlinMultiplatform: false
   };
 }
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -71,7 +71,7 @@ function getFullTargetConfig(): any {
       fileReplaceeRegex: '/replacee/',
       fileReplacerStr: 'replacer',
     },
-    kotlinMultiplatform: {
+    kmp: {
       rootDistDirRegex: '/distDir/',
       appleDistDirRegex: '/apple-distDir/',
     },
@@ -88,7 +88,7 @@ function getRequiredTargetConfig(): any {
     mavenRepoId: DEFAULT_OPTION_VALUE,
     mavenRepoUrl: DEFAULT_OPTION_VALUE,
     android: false,
-    kotlinMultiplatform: false,
+    kmp: false,
   };
 }
 
@@ -147,7 +147,7 @@ describe('Maven target configuration', () => {
 
   test('no kotlinMultiplatform config', () => {
     const config = getRequiredTargetConfig();
-    delete config.kotlinMultiplatform;
+    delete config.kmp;
     expect(() => createMavenTarget(config)).not.toThrowError();
   });
 
@@ -161,7 +161,7 @@ describe('Maven target configuration', () => {
 
   test('incorrect one-line kotlinMultiplatform config', () => {
     const config = getRequiredTargetConfig();
-    config.kotlinMultiplatform = 'yes';
+    config.kmp = 'yes';
     expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
       `"Required root configuration for Kotlin Multiplatform is incorrect. See the documentation for more details."`
     );
@@ -176,9 +176,7 @@ describe('Maven target configuration', () => {
   test('correct one-line kotlinMultiplatform config', () => {
     const config = getRequiredTargetConfig();
     const mvnTarget = createMavenTarget(config);
-    expect(mvnTarget.mavenConfig.kotlinMultiplatform).toStrictEqual(
-      config.kotlinMultiplatform
-    );
+    expect(mvnTarget.mavenConfig.kmp).toStrictEqual(config.kmp);
   });
 
   test('incorrect object android config, missing prop', () => {
@@ -191,8 +189,8 @@ describe('Maven target configuration', () => {
 
   test('incorrect object kotlinMultiplatform config, replaced root distDir', () => {
     const config = getFullTargetConfig();
-    delete config.kotlinMultiplatform.rootDistDirRegex;
-    config.kotlinMultiplatform.anotherParam = 'unused';
+    delete config.kmp.rootDistDirRegex;
+    config.kmp.anotherParam = 'unused';
     expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
       `"Required root configuration for Kotlin Multiplatform is incorrect. See the documentation for more details."`
     );
@@ -200,8 +198,8 @@ describe('Maven target configuration', () => {
 
   test('incorrect object kotlinMultiplatform config, replaced apple distDir', () => {
     const config = getFullTargetConfig();
-    delete config.kotlinMultiplatform.appleDistDirRegex;
-    config.kotlinMultiplatform.anotherParam = 'unused';
+    delete config.kmp.appleDistDirRegex;
+    config.kmp.anotherParam = 'unused';
     expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
       `"Required apple configuration for Kotlin Multiplatform is incorrect. See the documentation for more details."`
     );
@@ -227,11 +225,10 @@ describe('Maven target configuration', () => {
 
   test('correct object kotlinMultiplatform config, with additional props', () => {
     const config = getFullTargetConfig();
-    config.kotlinMultiplatform.additionalProp = 'not relevant';
+    config.kmp.additionalProp = 'not relevant';
     const mvnTarget = createMavenTarget(config);
-    const kotlinMultiplatformConfig: any =
-      mvnTarget.mavenConfig.kotlinMultiplatform;
-    expect(config.kotlinMultiplatform).toMatchObject(kotlinMultiplatformConfig);
+    const kotlinMultiplatformConfig: any = mvnTarget.mavenConfig.kmp;
+    expect(config.kmp).toMatchObject(kotlinMultiplatformConfig);
     expect(kotlinMultiplatformConfig.additionalProp).not.toBeDefined();
   });
 
@@ -259,12 +256,8 @@ describe('Maven target configuration', () => {
     expect(typeof mvnTarget.config.android.distDirRegex).toBe('string');
     expect(typeof mvnTarget.config.android.fileReplaceeRegex).toBe('string');
     expect(typeof mvnTarget.config.android.fileReplacerStr).toBe('string');
-    expect(typeof mvnTarget.config.kotlinMultiplatform.rootDistDirRegex).toBe(
-      'string'
-    );
-    expect(typeof mvnTarget.config.kotlinMultiplatform.appleDistDirRegex).toBe(
-      'string'
-    );
+    expect(typeof mvnTarget.config.kmp.rootDistDirRegex).toBe('string');
+    expect(typeof mvnTarget.config.kmp.appleDistDirRegex).toBe('string');
   });
 
   test('import GPG private key if one is present in the environment', () => {

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -227,9 +227,9 @@ describe('Maven target configuration', () => {
     const config = getFullTargetConfig();
     config.kotlinMultiplatform.additionalProp = 'not relevant';
     const mvnTarget = createMavenTarget(config);
-    const androidConfig: any = mvnTarget.mavenConfig.android;
-    expect(config.android).toMatchObject(androidConfig);
-    expect(androidConfig.additionalProp).not.toBeDefined();
+    const kotlinMultiplatformConfig: any = mvnTarget.mavenConfig.kotlinMultiplatform;
+    expect(config.android).toMatchObject(kotlinMultiplatformConfig);
+    expect(kotlinMultiplatformConfig.additionalProp).not.toBeDefined();
   });
 
   test('minimum required options', () => {

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -145,11 +145,25 @@ describe('Maven target configuration', () => {
     );
   });
 
+  test('no kotlinMultiplatform config', () => {
+    const config = getRequiredTargetConfig();
+    delete config.kotlinMultiplatform;
+    expect(() => createMavenTarget(config)).not.toThrowError();
+  });
+
   test('incorrect one-line android config', () => {
     const config = getRequiredTargetConfig();
     config.android = 'yes';
     expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
       `"Required Android configuration is incorrect. See the documentation for more details."`
+    );
+  });
+
+  test('incorrect one-line kotlinMultiplatform config', () => {
+    const config = getRequiredTargetConfig();
+    config.kotlinMultiplatform = 'yes';
+    expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
+      `"Required root configuration for Kotlin Multiplatform is incorrect. See the documentation for more details."`
     );
   });
 
@@ -159,11 +173,35 @@ describe('Maven target configuration', () => {
     expect(mvnTarget.mavenConfig.android).toStrictEqual(config.android);
   });
 
+  test('correct one-line kotlinMultiplatform config', () => {
+    const config = getRequiredTargetConfig();
+    const mvnTarget = createMavenTarget(config);
+    expect(mvnTarget.mavenConfig.kotlinMultiplatform).toStrictEqual(config.kotlinMultiplatform);
+  });
+
   test('incorrect object android config, missing prop', () => {
     const config = getFullTargetConfig();
     delete config.android.distDirRegex;
     expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
       `"Required Android configuration is incorrect. See the documentation for more details."`
+    );
+  });
+
+  test('incorrect object kotlinMultiplatform config, replaced root distDir', () => {
+    const config = getFullTargetConfig();
+    delete config.kotlinMultiplatform.rootDistDirRegex;
+    config.kotlinMultiplatform.anotherParam = 'unused';
+    expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
+      `"Required root configuration for Kotlin Multiplatform is incorrect. See the documentation for more details."`
+    );
+  });
+
+  test('incorrect object kotlinMultiplatform config, replaced apple distDir', () => {
+    const config = getFullTargetConfig();
+    delete config.kotlinMultiplatform.appleDistDirRegex;
+    config.kotlinMultiplatform.anotherParam = 'unused';
+    expect(() => createMavenTarget(config)).toThrowErrorMatchingInlineSnapshot(
+      `"Required apple configuration for Kotlin Multiplatform is incorrect. See the documentation for more details."`
     );
   });
 
@@ -179,6 +217,15 @@ describe('Maven target configuration', () => {
   test('correct object android config, with additional props', () => {
     const config = getFullTargetConfig();
     config.android.additionalProp = 'not relevant';
+    const mvnTarget = createMavenTarget(config);
+    const androidConfig: any = mvnTarget.mavenConfig.android;
+    expect(config.android).toMatchObject(androidConfig);
+    expect(androidConfig.additionalProp).not.toBeDefined();
+  });
+
+  test('correct object kotlinMultiplatform config, with additional props', () => {
+    const config = getFullTargetConfig();
+    config.kotlinMultiplatform.additionalProp = 'not relevant';
     const mvnTarget = createMavenTarget(config);
     const androidConfig: any = mvnTarget.mavenConfig.android;
     expect(config.android).toMatchObject(androidConfig);
@@ -209,6 +256,8 @@ describe('Maven target configuration', () => {
     expect(typeof mvnTarget.config.android.distDirRegex).toBe('string');
     expect(typeof mvnTarget.config.android.fileReplaceeRegex).toBe('string');
     expect(typeof mvnTarget.config.android.fileReplacerStr).toBe('string');
+    expect(typeof mvnTarget.config.kotlinMultiplatform.rootDistDirRegex).toBe('string');
+    expect(typeof mvnTarget.config.kotlinMultiplatform.appleDistDirRegex).toBe('string');
   });
 
   test('import GPG private key if one is present in the environment', () => {

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -228,7 +228,7 @@ describe('Maven target configuration', () => {
     config.kotlinMultiplatform.additionalProp = 'not relevant';
     const mvnTarget = createMavenTarget(config);
     const kotlinMultiplatformConfig: any = mvnTarget.mavenConfig.kotlinMultiplatform;
-    expect(config.android).toMatchObject(kotlinMultiplatformConfig);
+    expect(config.kotlinMultiplatform).toMatchObject(kotlinMultiplatformConfig);
     expect(kotlinMultiplatformConfig.additionalProp).not.toBeDefined();
   });
 

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -153,17 +153,10 @@ export class MavenTarget extends BaseTarget {
   }
 
   private getKotlinMultiplatformSettings(): KotlinMultiplatformFields {
-    if (this.config.kotlinMultiplatform === false) {
+    if (this.config.kotlinMultiplatform === false || !this.config.kotlinMultiplatform) {
       return {
         kotlinMultiplatform: false,
       };
-    }
-
-    if (!this.config.kotlinMultiplatform) {
-      throw new ConfigurationError(
-        'Required Kotlin Multiplatform configuration was not found in the configuration file. ' +
-          'See the documentation for more details'
-      );
     }
 
     if (
@@ -181,7 +174,6 @@ export class MavenTarget extends BaseTarget {
         'Required apple configuration for Kotlin Multiplatform is incorrect. See the documentation for more details.'
       );
     }
-
 
     return {
       kotlinMultiplatform: {

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -427,6 +427,9 @@ export class MavenTarget extends BaseTarget {
   }
 
   private async uploadPomDistribution(distDir: string): Promise<void> {
+    if (this.mavenConfig.kotlinMultiplatform !== false) {
+      this.uploadKmpPomDistribution(distDir)
+    } else {
       const {
         targetFile,
         javadocFile,
@@ -477,7 +480,7 @@ export class MavenTarget extends BaseTarget {
    * @returns record of required files.
    */
   private async getFilesForKmpMavenPomDist(distDir: string): Promise<Record<string, string | string[]>> {
-    const files = this.getFilesForMavenPomDist(distDir)
+    const files = this.getFilesForMavenPomDist(distDir) as Record<string, string | string[]>
     const moduleName = parse(distDir).base;
     if (this.mavenConfig.kotlinMultiplatform !== false) {
       const isRootDistDir = this.mavenConfig.kotlinMultiplatform.rootDistDirRegex.test(

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -340,8 +340,8 @@ export class MavenTarget extends BaseTarget {
       sideArtifacts += klibFiles
       for (let i = 0; i < klibFiles.length; i++) {
         types += ',klib'
+        classifiers += ',cinterop'
       }
-      classifiers += ',cinterop'
     }
 
     // Maven central is very flaky, so retrying with an exponential delay in

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -58,12 +58,12 @@ type AndroidFields = {
 
 type KotlinMultiplatformFields = {
   kotlinMultiplatform:
-  | false
-  | {
-    appleDistDirRegex: RegExp;
-    rootDistDirRegex: RegExp;
-  }
-}
+    | false
+    | {
+        appleDistDirRegex: RegExp;
+        rootDistDirRegex: RegExp;
+      };
+};
 
 type TargetSettingType = SecretsType | OptionsType;
 
@@ -71,7 +71,8 @@ type TargetSettingType = SecretsType | OptionsType;
  * Config options for the "maven" target.
  */
 export type MavenTargetConfig = Record<TargetSettingType, string> &
-  AndroidFields & KotlinMultiplatformFields;
+  AndroidFields &
+  KotlinMultiplatformFields;
 
 type PartialTargetConfig = Array<{ name: string; value: string | undefined }>;
 
@@ -153,23 +154,22 @@ export class MavenTarget extends BaseTarget {
   }
 
   private getKotlinMultiplatformSettings(): KotlinMultiplatformFields {
-    if (this.config.kotlinMultiplatform === false || !this.config.kotlinMultiplatform) {
+    if (
+      this.config.kotlinMultiplatform === false ||
+      !this.config.kotlinMultiplatform
+    ) {
       return {
         kotlinMultiplatform: false,
       };
     }
 
-    if (
-      !this.config.kotlinMultiplatform.rootDistDirRegex
-    ) {
+    if (!this.config.kotlinMultiplatform.rootDistDirRegex) {
       throw new ConfigurationError(
         'Required root configuration for Kotlin Multiplatform is incorrect. See the documentation for more details.'
       );
     }
 
-    if (
-      !this.config.kotlinMultiplatform.appleDistDirRegex
-    ) {
+    if (!this.config.kotlinMultiplatform.appleDistDirRegex) {
       throw new ConfigurationError(
         'Required apple configuration for Kotlin Multiplatform is incorrect. See the documentation for more details.'
       );
@@ -177,10 +177,14 @@ export class MavenTarget extends BaseTarget {
 
     return {
       kotlinMultiplatform: {
-        appleDistDirRegex: stringToRegexp(this.config.kotlinMultiplatform.appleDistDirRegex),
-        rootDistDirRegex: stringToRegexp(this.config.kotlinMultiplatform.rootDistDirRegex)
+        appleDistDirRegex: stringToRegexp(
+          this.config.kotlinMultiplatform.appleDistDirRegex
+        ),
+        rootDistDirRegex: stringToRegexp(
+          this.config.kotlinMultiplatform.rootDistDirRegex
+        ),
       },
-     }
+    };
   }
 
   private getAndroidSettings(): AndroidFields {
@@ -366,16 +370,6 @@ export class MavenTarget extends BaseTarget {
 
   private async uploadKmpPomDistribution(distDir: string): Promise<void> {
     if (this.mavenConfig.kotlinMultiplatform !== false) {
-      const {
-        targetFile,
-        javadocFile,
-        sourcesFile,
-        klibFiles,
-        allFile,
-        metadataFile,
-        moduleFile,
-        pomFile,
-      } = await this.getFilesForKmpMavenPomDist(distDir)
       const moduleName = parse(distDir).base;
       const isRootDistDir = this.mavenConfig.kotlinMultiplatform.rootDistDirRegex.test(
         moduleName
@@ -383,32 +377,13 @@ export class MavenTarget extends BaseTarget {
       const isAppleDistDir = this.mavenConfig.kotlinMultiplatform.appleDistDirRegex.test(
         moduleName
       );
-
-      let sideArtifacts = `${javadocFile},${sourcesFile}`;
-      let classifiers = 'javadoc,sources';
-      let types = 'jar,jar';
-
-      if (isRootDistDir) {
-        sideArtifacts += `,${allFile}`;
-        types += ',jar';
-        classifiers += ',all';
-      } else if (isAppleDistDir) {
-        if (klibFiles) {
-          sideArtifacts += klibFiles;
-          for (let i = 0; i < klibFiles.length; i++) {
-            types += ',klib';
-            classifiers += ',cinterop';
-          }
-        }
-        sideArtifacts += `,${metadataFile}`;
-        types += ',jar';
-        classifiers += ',metadata';
-      }
-
-      // .module files should be available in every KMP artifact
-      sideArtifacts += `,${moduleFile}`;
-      types += ',module';
-      classifiers += ',module';
+      const files = await this.getFilesForKmpMavenPomDist(distDir);
+      const { targetFile, pomFile } = files;
+      const {
+        sideArtifacts,
+        classifiers,
+        types,
+      } = this.transformKmpSideArtifacts(isRootDistDir, isAppleDistDir, files);
 
       await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
         'gpg:sign-and-deploy-file',
@@ -426,9 +401,90 @@ export class MavenTarget extends BaseTarget {
     }
   }
 
+  /**
+ * Transforms the Kotlin Multiplatform side artifacts into the format required by the publish plugin.
+ *
+ * The "files" Record should contain the following fields:
+ *  - javadocFile
+    - sourcesFile
+    - klibFiles
+    - allFile
+    - metadataFile
+    - moduleFile
+    - kotlinToolingMetadataFile
+ *
+ * Depending on the values of the `isRootDistDir` and `isAppleDistDir` parameters, this function generates
+ * a set of "side artifacts" (javadoc, sources, klib files, metadata, and .module files), as well as a set
+ * of "classifiers" and "types" that are required by the publish plugin.
+ *
+ * @param isRootDistDir boolean indicating whether the distDir is the root distDir
+ * @param isAppleDistDir boolean indicating whether the distDir is the Apple distDir
+ * @param files an object containing the input files, as described above
+ * @returns a Record with three fields:
+ *    - sideArtifacts: a comma-separated string listing the paths to all generated "side artifacts"
+ *    - classifiers: a comma-separated string listing the classifiers for each generated artifact
+ *    - types: a comma-separated string listing the types for each generated artifact
+ */
+  public transformKmpSideArtifacts(
+    isRootDistDir: boolean,
+    isAppleDistDir: boolean,
+    files: Record<string, string | string[]>
+  ): Record<string, string | string[]> {
+    const {
+      javadocFile,
+      sourcesFile,
+      klibFiles,
+      allFile,
+      metadataFile,
+      moduleFile,
+      kotlinToolingMetadataFile,
+    } = files;
+    let sideArtifacts = `${javadocFile},${sourcesFile}`;
+    let classifiers = 'javadoc,sources';
+    let types = 'jar,jar';
+
+    if (isRootDistDir) {
+      sideArtifacts += `,${allFile},${kotlinToolingMetadataFile}`;
+      types += ',jar,json';
+      classifiers += ',all,kotlin-tooling-metadata';
+    } else if (isAppleDistDir) {
+      if (klibFiles) {
+        sideArtifacts += `,${klibFiles}`;
+
+        // In order to upload cinterop klib files we need to extract the classifier from the file name.
+        // e.g: "sentry-kotlin-multiplatform-iosarm64-0.0.1-cinterop-Sentry.klib",
+        // the classifier is "cinterop-Sentry".
+        for (let i = 0; i < klibFiles.length; i++) {
+          const input = klibFiles[i];
+          const start = input.indexOf('cinterop');
+          const end = input.indexOf('.klib', start);
+          const classifier = input.substring(start, end);
+
+          types += ',klib';
+          classifiers += `,${classifier}`;
+        }
+      }
+      sideArtifacts += `,${metadataFile}`;
+      types += ',jar';
+      classifiers += ',metadata';
+    }
+
+    // .module files should be available in every KMP artifact
+    sideArtifacts += `,${moduleFile}`;
+    types += ',module';
+    // .module files in this case shouldn't have a classifier
+    classifiers += ',';
+
+    return {
+      sideArtifacts,
+      classifiers,
+      types,
+    };
+  }
+
   private async uploadPomDistribution(distDir: string): Promise<void> {
     if (this.mavenConfig.kotlinMultiplatform !== false) {
-      this.uploadKmpPomDistribution(distDir)
+      this.uploadKmpPomDistribution(distDir);
     } else {
       const {
         targetFile,
@@ -472,15 +528,20 @@ export class MavenTarget extends BaseTarget {
     };
   }
 
-    /**
+  /**
    * Retrieves a record of all the required files by Maven CLI to upload
    * Kotlin Multiplatform (KMP) artifacts.
    *
    * @param distDir directory of the distribution.
    * @returns record of required files.
    */
-  private async getFilesForKmpMavenPomDist(distDir: string): Promise<Record<string, string | string[]>> {
-    const files = this.getFilesForMavenPomDist(distDir) as Record<string, string | string[]>
+  private async getFilesForKmpMavenPomDist(
+    distDir: string
+  ): Promise<Record<string, string | string[]>> {
+    const files = this.getFilesForMavenPomDist(distDir) as Record<
+      string,
+      string | string[]
+    >;
     const moduleName = parse(distDir).base;
     if (this.mavenConfig.kotlinMultiplatform !== false) {
       const isRootDistDir = this.mavenConfig.kotlinMultiplatform.rootDistDirRegex.test(
@@ -491,6 +552,10 @@ export class MavenTarget extends BaseTarget {
       );
       if (isRootDistDir) {
         files['allFile'] = join(distDir, `${moduleName}-all.jar`);
+        files['kotlinToolingMetadataFile'] = join(
+          distDir,
+          `${moduleName}-kotlin-tooling-metadata.json`
+        );
       } else if (isAppleDistDir) {
         files['metadataFile'] = join(distDir, `${moduleName}-metadata.jar`);
         const cinteropFiles = (await fsPromises.readdir(distDir))
@@ -537,7 +602,7 @@ export class MavenTarget extends BaseTarget {
         moduleName
       );
       if (isAppleDistDir) {
-        return `${moduleName}.klib`
+        return `${moduleName}.klib`;
       }
     }
     return `${moduleName}.jar`;

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -57,7 +57,7 @@ type AndroidFields = {
 };
 
 type KotlinMultiplatformFields = {
-  kotlinMultiplatform:
+  kmp:
     | false
     | {
         appleDistDirRegex: RegExp;
@@ -154,35 +154,28 @@ export class MavenTarget extends BaseTarget {
   }
 
   private getKotlinMultiplatformSettings(): KotlinMultiplatformFields {
-    if (
-      this.config.kotlinMultiplatform === false ||
-      !this.config.kotlinMultiplatform
-    ) {
+    if (this.config.kmp === false || !this.config.kmp) {
       return {
-        kotlinMultiplatform: false,
+        kmp: false,
       };
     }
 
-    if (!this.config.kotlinMultiplatform.rootDistDirRegex) {
+    if (!this.config.kmp.rootDistDirRegex) {
       throw new ConfigurationError(
         'Required root configuration for Kotlin Multiplatform is incorrect. See the documentation for more details.'
       );
     }
 
-    if (!this.config.kotlinMultiplatform.appleDistDirRegex) {
+    if (!this.config.kmp.appleDistDirRegex) {
       throw new ConfigurationError(
         'Required apple configuration for Kotlin Multiplatform is incorrect. See the documentation for more details.'
       );
     }
 
     return {
-      kotlinMultiplatform: {
-        appleDistDirRegex: stringToRegexp(
-          this.config.kotlinMultiplatform.appleDistDirRegex
-        ),
-        rootDistDirRegex: stringToRegexp(
-          this.config.kotlinMultiplatform.rootDistDirRegex
-        ),
+      kmp: {
+        appleDistDirRegex: stringToRegexp(this.config.kmp.appleDistDirRegex),
+        rootDistDirRegex: stringToRegexp(this.config.kmp.rootDistDirRegex),
       },
     };
   }
@@ -369,12 +362,12 @@ export class MavenTarget extends BaseTarget {
   }
 
   private async uploadKmpPomDistribution(distDir: string): Promise<void> {
-    if (this.mavenConfig.kotlinMultiplatform !== false) {
+    if (this.mavenConfig.kmp !== false) {
       const moduleName = parse(distDir).base;
-      const isRootDistDir = this.mavenConfig.kotlinMultiplatform.rootDistDirRegex.test(
+      const isRootDistDir = this.mavenConfig.kmp.rootDistDirRegex.test(
         moduleName
       );
-      const isAppleDistDir = this.mavenConfig.kotlinMultiplatform.appleDistDirRegex.test(
+      const isAppleDistDir = this.mavenConfig.kmp.appleDistDirRegex.test(
         moduleName
       );
       const files = await this.getFilesForKmpMavenPomDist(distDir);
@@ -483,7 +476,7 @@ export class MavenTarget extends BaseTarget {
   }
 
   private async uploadPomDistribution(distDir: string): Promise<void> {
-    if (this.mavenConfig.kotlinMultiplatform !== false) {
+    if (this.mavenConfig.kmp !== false) {
       this.uploadKmpPomDistribution(distDir);
     } else {
       const {
@@ -543,11 +536,11 @@ export class MavenTarget extends BaseTarget {
       string | string[]
     >;
     const moduleName = parse(distDir).base;
-    if (this.mavenConfig.kotlinMultiplatform !== false) {
-      const isRootDistDir = this.mavenConfig.kotlinMultiplatform.rootDistDirRegex.test(
+    if (this.mavenConfig.kmp !== false) {
+      const isRootDistDir = this.mavenConfig.kmp.rootDistDirRegex.test(
         moduleName
       );
-      const isAppleDistDir = this.mavenConfig.kotlinMultiplatform.appleDistDirRegex.test(
+      const isAppleDistDir = this.mavenConfig.kmp.appleDistDirRegex.test(
         moduleName
       );
       if (isRootDistDir) {
@@ -597,8 +590,8 @@ export class MavenTarget extends BaseTarget {
         );
       }
     }
-    if (this.mavenConfig.kotlinMultiplatform !== false) {
-      const isAppleDistDir = this.mavenConfig.kotlinMultiplatform.appleDistDirRegex.test(
+    if (this.mavenConfig.kmp !== false) {
+      const isAppleDistDir = this.mavenConfig.kmp.appleDistDirRegex.test(
         moduleName
       );
       if (isAppleDistDir) {

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -401,7 +401,7 @@ export class MavenTarget extends BaseTarget {
         types += ',jar';
         classifiers += ',all';
       } else if (isAppleDistDir) {
-        sideArtifacts += klibFiles
+        sideArtifacts += klibFiles;
         for (let i = 0; i < klibFiles.length; i++) {
           types += ',klib';
           classifiers += ',cinterop';

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -364,7 +364,7 @@ export class MavenTarget extends BaseTarget {
     ]);
   }
 
-  private async uploadPomDistribution(distDir: string): Promise<void> {
+  private async uploadKmpPomDistribution(distDir: string): Promise<void> {
     if (this.mavenConfig.kotlinMultiplatform !== false) {
       const {
         targetFile,
@@ -423,7 +423,10 @@ export class MavenTarget extends BaseTarget {
         `--settings`,
         `${this.mavenConfig.mavenSettingsPath}`,
       ]);
-    } else {
+    }
+  }
+
+  private async uploadPomDistribution(distDir: string): Promise<void> {
       const {
         targetFile,
         javadocFile,
@@ -456,7 +459,7 @@ export class MavenTarget extends BaseTarget {
    * @param distDir directory of the distribution.
    * @returns record of required files.
    */
-  private getFilesForMavenPomDist(distDir: string): Record<string, string | string[]> {
+  private getFilesForMavenPomDist(distDir: string): Record<string, string> {
     const moduleName = parse(distDir).base;
     return {
       targetFile: join(distDir, this.getTargetFilename(distDir)),

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -399,23 +399,20 @@ export class MavenTarget extends BaseTarget {
       sourcesFile: join(distDir, `${moduleName}-sources.jar`),
       pomFile: join(distDir, 'pom-default.xml'),
     };
-    const allFile = join(distDir, `${moduleName.toLowerCase()}-all.jar`)
-    if (existsSync(allFile)) {
-      Object.assign(files, { allFile })
+    if (existsSync(join(distDir, `${moduleName.toLowerCase()}-all.jar`))) {
+      Object.assign(files, { allFile: join(distDir, `${moduleName}-all.jar`)})
     }
-    const moduleFile = join(distDir, `${moduleName.toLowerCase()}.module`)
-    if (existsSync(moduleFile)) {
-      Object.assign(files, { moduleFile })
+    if (existsSync(join(distDir, `${moduleName.toLowerCase()}.module`))) {
+      Object.assign(files, { moduleFile: join(distDir, `${moduleName}.module`) })
     }
-    const metadataFile = join(distDir, `${moduleName.toLowerCase()}-metadata.jar`)
-    if (existsSync(metadataFile)) {
-      Object.assign(files, { metadataFile })
+    if (existsSync(join(distDir, `${moduleName.toLowerCase()}-metadata.jar`))) {
+      Object.assign(files, { metadataFile: join(distDir, `${moduleName}-metadata.jar`) })
     }
     if (existsSync(join(distDir, `${moduleName.toLowerCase()}.klib`))) {
       const cinteropFiles: string[] = []
       readdirSync(distDir).forEach(file => {
         if (file.includes('cinterop')) {
-          cinteropFiles.push(join(distDir, file.toLowerCase()))
+          cinteropFiles.push(join(distDir, file))
         }
       });
       Object.assign(files, { klibFiles: cinteropFiles })


### PR DESCRIPTION
This introduces some additions to be able to support a Kotlin Multiplatform publish. 

Additional artifacts include: `*.klib, *-all.jar, *-metadata.jar, *.module`.

Example artifacts of [Kermit](https://github.com/touchlab/Kermit):
 - ios artifacts: https://repo1.maven.org/maven2/co/touchlab/kermit-sentry-iosarm64/1.2.0-M2/
 - root artifacts: https://repo1.maven.org/maven2/co/touchlab/kermit-sentry/1.2.0-M2/

For context: for a KMP publish all platforms  need to be published and the root artifact contains metadata, see: https://github.com/getsentry/sentry-kotlin-multiplatform/pull/37#issuecomment-1219123937

The generated gpg command example:
root artifact:
```
"-Dfile=/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-mSNdRu/sentry-kotlin-multiplatform-0.0.1/sentry-kotlin-multiplatform-0.0.1.jar" 
"-Dfiles=/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-mSNdRu/sentry-kotlin-multiplatform-0.0.1/sentry-kotlin-multiplatform-0.0.1-javadoc.jar,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-mSNdRu/sentry-kotlin-multiplatform-0.0.1/sentry-kotlin-multiplatform-0.0.1-sources.jar,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-mSNdRu/sentry-kotlin-multiplatform-0.0.1/sentry-kotlin-multiplatform-0.0.1-all.jar,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-mSNdRu/sentry-kotlin-multiplatform-0.0.1/sentry-kotlin-multiplatform-0.0.1.module" 
"-Dclassifiers=javadoc,sources,all,module" 
"-Dtypes=jar,jar,jar,module" 
...
``` 

ios artifact:
```
"-Dfile=/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosArm64-0.0.1.klib" 
"-Dfiles=/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosArm64-0.0.1-javadoc.jar,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosArm64-0.0.1-sources.jar/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosarm64-0.0.1-cinterop-Sentry.NSException.klib,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosarm64-0.0.1-cinterop-Sentry.Scope.klib,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosarm64-0.0.1-cinterop-Sentry.klib,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosArm64-0.0.1-metadata.jar,/var/folders/j2/r3dsjfkx4pj5n0v8jjlb6lv80000gn/T/craft-QEa8yL/sentry-kotlin-multiplatform-iosArm64-0.0.1/sentry-kotlin-multiplatform-iosArm64-0.0.1.module" 
"-Dclassifiers=javadoc,sources,cinterop,cinterop,cinterop,metadata,module"
"-Dtypes=jar,jar,klib,klib,klib,jar,module"
...
```