### PR TITLE
feat: Support initial manifest.json files for new SDK releases

### DIFF
--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_REGISTRY_REMOTE,
   getPackageManifest,
   updateManifestSymlinks,
+  removeInitialManifest,
   RegistryPackageType,
 } from '../utils/registry';
 import { isDryRun } from '../utils/helpers';
@@ -394,7 +395,7 @@ export class RegistryTarget extends BaseTarget {
     revision: string
   ): Promise<void> {
     const canonicalName = registryConfig.canonicalName;
-    const { versionFilePath, packageManifest } = await getPackageManifest(
+    const { isInitial, versionFilePath, packageManifest } = await getPackageManifest(
       localRepo.dir,
       registryConfig.type,
       canonicalName,
@@ -415,6 +416,14 @@ export class RegistryTarget extends BaseTarget {
       versionFilePath,
       packageManifest.version || undefined
     );
+
+    if (isInitial) {
+      await removeInitialManifest(
+        localRepo.dir,
+        registryConfig.type,
+        canonicalName,
+      )
+    }
   }
 
   private async cloneRegistry(directory: string): Promise<SimpleGit> {
@@ -482,6 +491,7 @@ export class RegistryTarget extends BaseTarget {
           dir,
           git: await this.cloneRegistry(dir),
         };
+
         await Promise.all(
           items.map(registryConfig =>
             this.updateVersionInRegistry(

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -19,7 +19,8 @@ export enum RegistryPackageType {
  * Gets the package manifest version in the given directory.
  *
  * @param baseDir Base directory for the registry clone
- * @param packageDirPath The package directory.
+ * @param type The type of the registry package.
+ * @param canonical The app's canonical name.
  * @param version The package version.
  */
 export async function getPackageManifest(
@@ -27,20 +28,34 @@ export async function getPackageManifest(
   type: RegistryPackageType,
   canonicalName: string,
   version: string
-): Promise<{ versionFilePath: string; packageManifest: any }> {
+): Promise<{ isInitial: boolean, versionFilePath: string; packageManifest: any }> {
   const packageDirPath = getPackageDirPath(type, canonicalName);
   const versionFilePath = path.join(baseDir, packageDirPath, `${version}.json`);
   if (existsSync(versionFilePath)) {
     reportError(`Version file for "${version}" already exists. Aborting.`);
   }
+
+  // If there was no prior releases, we use `manifest.json` file as a template
+  // and remove it after the initial release.
+  const initialManifestPath = path.join(baseDir, packageDirPath, 'manifest.json');
   const packageManifestPath = path.join(baseDir, packageDirPath, 'latest.json');
+
+  if (existsSync(initialManifestPath)) {
+    logger.debug('Reading the initial configuration from', initialManifestPath);
+
+    return {
+      isInitial: true,
+      versionFilePath,
+      packageManifest: JSON.parse(await fsPromises.readFile(initialManifestPath, { encoding: 'utf-8' }))
+    };
+  }
+
   logger.debug('Reading the current configuration from', packageManifestPath);
+
   return {
+    isInitial: false,
     versionFilePath,
-    packageManifest:
-      JSON.parse(
-        await fsPromises.readFile(packageManifestPath, { encoding: 'utf-8' })
-      ) || {},
+    packageManifest: JSON.parse(await fsPromises.readFile(packageManifestPath, { encoding: 'utf-8' }))
   };
 }
 
@@ -70,3 +85,24 @@ export const DEFAULT_REGISTRY_REMOTE = new GitHubRemote(
   'getsentry',
   'sentry-release-registry'
 );
+
+/**
+ * Remove the initial manifest.json from the package directory.
+ *
+ * @param baseDir Base directory for the registry clone
+ * @param type The type of the registry package.
+ * @param canonical The app's canonical name.
+ */
+ export async function removeInitialManifest(
+  baseDir: string,
+  type: RegistryPackageType,
+  canonicalName: string
+) {
+  const packageDirPath = getPackageDirPath(type, canonicalName);
+   const initialManifestPath = path.join(baseDir, packageDirPath, 'manifest.json');
+
+  if (existsSync(initialManifestPath)) {
+    logger.debug('Removing the initial configuration from', initialManifestPath);
+    await fsPromises.unlink(initialManifestPath);
+  }
+}


### PR DESCRIPTION
With this feature, we are able to update https://github.com/getsentry/sentry-release-registry readme and allow people to add `manifest.json` file with `0.0.0` version instead of a specific "existing" release.
It will perform a correct release flow for the initial release and clean up the `manifest.json` file afterwards.