### PR TITLE
Bump symbol collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get -qq update \
   && cargo install cargo-hack \
   && gem install cocoapods \
   # Install https://github.com/getsentry/symbol-collector
-  && symbol_collector_url=$(curl -s https://api.github.com/repos/getsentry/symbol-collector/releases/tags/1.5.3 | \
+  && symbol_collector_url=$(curl -s https://api.github.com/repos/getsentry/symbol-collector/releases/tags/1.8.0 | \
   jq -r '.assets[].browser_download_url | select(endswith("symbolcollector-console-linux-x64.zip"))') \
   && curl -sL $symbol_collector_url -o "/tmp/sym-collector.zip" \
   && unzip /tmp/sym-collector.zip -d /usr/local/bin/ \


### PR DESCRIPTION
The [release 1.8.0](https://github.com/getsentry/symbol-collector/releases/tag/1.8.0) contains some fixes
Including to this issue that's still coming from `craft` runs: 

https://sentry.io/organizations/sentry/issues/3061145532/?project=5953213

Does CI smoke test the commands? I tested the Android and macOS builds of 1.8.0 but not on Linux.