### PR TITLE
Emit dotnet and nuget version info

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -94,6 +94,15 @@ export class NugetTarget extends BaseTarget {
       );
     }
 
+    // Emit the .NET version for informational purposes.
+    this.logger.info('.NET Version:');
+    await spawnProcess(NUGET_DOTNET_BIN, ['--version']);
+
+    // Also emit the nuget version, which is informative and works around a bug.
+    // See https://github.com/NuGet/Home/issues/12159#issuecomment-1278360511
+    this.logger.info('Nuget Version:');
+    await spawnProcess(NUGET_DOTNET_BIN, ['nuget', '--version']);
+
     await Promise.all(
       packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);


### PR DESCRIPTION
Adds `dotnet --version` and `dotnet nuget --version` info to the publish output, and (hopefully) works around the bug that is failing this workflow:

https://github.com/getsentry/publish/actions/runs/3716669257/jobs/6303253135#step:10:176