### PR TITLE
sentry-pypi: fix trailing whitespace in git output

### DIFF
--- a/src/targets/sentryPypi.ts
+++ b/src/targets/sentryPypi.ts
@@ -96,13 +96,13 @@ export class SentryPypiTarget extends BaseTarget {
         ['-C', directory, 'rev-parse', 'HEAD:'],
         {},
         { enableInDryRunMode: true }
-      )) as Buffer).toString('UTF-8');
+      )) as Buffer).toString('UTF-8').trim();
       const commit = ((await spawnProcess(
         'git',
         ['-C', directory, 'rev-parse', 'HEAD:'],
         {},
         { enableInDryRunMode: true }
-      )) as Buffer).toString('UTF-8');
+      )) as Buffer).toString('UTF-8').trim();
       return [contents, tree, commit];
     });
 


### PR DESCRIPTION
I *think* this'll fix:
```
[debug] POST /repos/getsentry/pypi/git/trees - 422 in 208ms
Error:  base_tree is not a valid tree oid
  at /usr/local/bin/craft:425:45299
  at processTicksAndRejections (internal/process/task_queues.js:95:5)
  at async y.doExecute (/usr/local/bin/craft:427:74896)
```