### PR TITLE
sentry-pypi: get the commit id, not the tree

### DIFF
--- a/src/targets/sentryPypi.ts
+++ b/src/targets/sentryPypi.ts
@@ -99,7 +99,7 @@ export class SentryPypiTarget extends BaseTarget {
       )) as Buffer).toString('UTF-8').trim();
       const commit = ((await spawnProcess(
         'git',
-        ['-C', directory, 'rev-parse', 'HEAD:'],
+        ['-C', directory, 'rev-parse', 'HEAD'],
         {},
         { enableInDryRunMode: true }
       )) as Buffer).toString('UTF-8').trim();


### PR DESCRIPTION
should fix:

```
[debug] POST /repos/getsentry/pypi/git/commits - 422 in 216ms
Error:  Parent SHA does not exist or is not a commit object
  at /usr/local/bin/craft:425:45299
  at processTicksAndRejections (internal/process/task_queues.js:95:5)
  at async y.doExecute (/usr/local/bin/craft:427:74896)
```