### PR TITLE
fix: Publishing podspec depending on other podspec

### DIFF
--- a/src/targets/cocoapods.ts
+++ b/src/targets/cocoapods.ts
@@ -99,7 +99,7 @@ export class CocoapodsTarget extends BaseTarget {
         await spawnProcess(COCOAPODS_BIN, ['setup']);
         await spawnProcess(
           COCOAPODS_BIN,
-          ['trunk', 'push', fileName, '--allow-warnings'],
+          ['trunk', 'push', fileName, '--allow-warnings --synchronous'],
           {
             cwd: directory,
             env: {


### PR DESCRIPTION
Publishing a podspec depending on another recently published podspec failed with `None of your spec
sources contain a spec satisfying the dependency`; see [CI](https://github.com/getsentry/publish/actions/runs/3759470548/jobs/6389071876). This is fixed now by using the --synchronous flag when publishing, recommended in https://github.com/CocoaPods/CocoaPods/issues/9497.