### PR TITLE
cleanup(github): Remove mentions of unused annotatedTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,6 @@ contains any one of `preview`, `pre`, `rc`, `dev`,`alpha`, `beta`, `unstable`,
 | ----------------- | -------------------------------------------------------------------------------------------- |
 | `tagPrefix`       | **optional**. Prefix for new git tags (e.g. "v"). Empty by default.                          |
 | `previewReleases` | **optional**. Automatically detect and create preview releases. `true` by default.           |
-| `annotatedTag`    | **optional**. Creates an annotated tag, set to false for lightweight tag. `true` by default. |
 
 **Example:**
 
@@ -541,7 +540,6 @@ targets:
   - name: github
     tagPrefix: v
     previewReleases: false
-    annotatedTag: false
 ```
 
 ### NPM (`npm`)

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -47,7 +47,6 @@ export class UpmTarget extends BaseTarget {
       name: 'github',
       tagPrefix: config.tagPrefix,
       previewReleases: false,
-      annotatedTag: true,
       owner: config.releaseRepoOwner,
       repo: config.releaseRepoName,
     };


### PR DESCRIPTION
`annotatedTag` option has been removed at some point, and might only cause confusion now.