### PR TITLE
feat(github): Allow to push a tag without a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,10 +528,11 @@ contains any one of `preview`, `pre`, `rc`, `dev`,`alpha`, `beta`, `unstable`,
 
 **Configuration**
 
-| Option            | Description                                                                                  |
-| ----------------- | -------------------------------------------------------------------------------------------- |
-| `tagPrefix`       | **optional**. Prefix for new git tags (e.g. "v"). Empty by default.                          |
-| `previewReleases` | **optional**. Automatically detect and create preview releases. `true` by default.           |
+| Option            | Description                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------ |
+| `tagPrefix`       | **optional**. Prefix for new git tags (e.g. "v"). Empty by default.                              |
+| `previewReleases` | **optional**. Automatically detect and create preview releases. `true` by default.               |
+| `tagOnly`         | **optional**. If set to `true`, only create a tag (without a GitHub release).`false` by default. |
 
 **Example:**
 
@@ -617,7 +618,7 @@ like [getsentry/pypi]
 
 **Configuration**
 
-| Option             | Description                                                        |
+| Option             | Description                          |
 | ------------------ | ------------------------------------ |
 | `internalPypiRepo` | GitHub repo containing pypi metadata |
 


### PR DESCRIPTION
_(The background and motivation for this change is in #445, but I've decided not to implement that proposal fully right now, and instead make a smaller step first.)_

This PR introduces a `tagOnly` option for `github` target. If set to `true`, then we don't create a full GitHub release, and instead only create a tag in the remote repository. The default is `false`.