### PR TITLE
Make Flutter available in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
   COCOAPODS_ALLOW_ROOT=1 \
   CARGO_HOME=/root/.cargo \
   RUSTUP_HOME=/root/.rustup \
-  PATH=${PATH}:/root/.cargo/bin:/usr/lib/dart/bin
+  PATH=${PATH}:/root/.cargo/bin:/tmp/flutter/bin
 
 RUN apt-get -qq update \
   && apt-get install -y --no-install-recommends \
@@ -28,13 +28,13 @@ RUN apt-get -qq update \
   && rm /tmp/packages-microsoft-prod.deb \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
   && echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list \
-  && curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg \
-  && echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list \
+  && curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.1-stable.tar.xz -o /tmp/flutter_linux_3.7.1-stable.tar.xz \
+  && tar xf /tmp/flutter_linux_3.7.1-stable.tar.xz
+  &&
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-7.0 \
     docker-ce-cli \
-    dart \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --  --profile minimal -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get -qq update \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
   && echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list \
   && curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.1-stable.tar.xz -o /tmp/flutter_linux_3.7.1-stable.tar.xz \
-  && tar xf /tmp/flutter_linux_3.7.1-stable.tar.xz
-  &&
+  && tar xf /tmp/flutter_linux_3.7.1-stable.tar.xz \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-7.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN apt-get -qq update \
   && rm /tmp/packages-microsoft-prod.deb \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
   && echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list \
-  && curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.1-stable.tar.xz -o /tmp/flutter_linux_3.7.1-stable.tar.xz \
-  && tar xf /tmp/flutter_linux_3.7.1-stable.tar.xz \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-7.0 \
@@ -47,6 +45,10 @@ RUN apt-get -qq update \
   && unzip /tmp/sym-collector.zip -d /usr/local/bin/ \
   && rm /tmp/sym-collector.zip \
   && chmod +x /usr/local/bin/SymbolCollector.Console
+
+RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.1-stable.tar.xz -o /tmp/flutter_linux_3.7.1-stable.tar.xz \
+  && tar xf /tmp/flutter_linux_3.7.1-stable.tar.xz \
+  && rm /tmp/flutter_linux_3.7.1-stable.tar.xz
 
 COPY dist/craft /usr/local/bin/craft
 RUN chmod +x /usr/local/bin/craft


### PR DESCRIPTION
Closes https://github.com/getsentry/craft/issues/452

Install Flutter in the docker image.
Removing Dart because Flutter ships Dart already and they should be compatible.