### PR TITLE
ref: allow all mounted directories to be considered "safe"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/sta
   && tar xf /tmp/flutter_linux_3.7.1-stable.tar.xz \
   && rm /tmp/flutter_linux_3.7.1-stable.tar.xz
 
+# craft does `git` things against mounted directories as root
+RUN git config --global --add safe.directory '*'
+
 COPY dist/craft /usr/local/bin/craft
 RUN chmod +x /usr/local/bin/craft
 ARG SOURCE_COMMIT


### PR DESCRIPTION
prevent these errors in github actions:

```console
[info] Publishing version: "3.27.1"
[debug] Working directory: /github/workspace/__repo__
Error:  fatal: detected dubious ownership in repository at '/github/workspace/__repo__'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace/__repo__

  To add an exception for this directory, call:
  
  git config --global --add safe.directory /github/workspace/__repo__
```

this setting isn't great, as written -- but this restores the previous behaviour to unblock releases -- perhaps a better, more well scoped list can be determined instead in the future