### PR TITLE
Skip duplicate nuget packages

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -73,6 +73,7 @@ export class NugetTarget extends BaseTarget {
       '${NUGET_API_TOKEN}',
       '--source',
       this.nugetConfig.serverUrl,
+      '--skip-duplicate'
     ]);
   }
 


### PR DESCRIPTION
Since `Sentry.Android.AssemblyReader` will rarely need to be modified, we've elected to [version it independently](https://github.com/getsentry/sentry-dotnet/blob/089d7020c2a220afbb87a0357c5abaaf99f37b3e/src/Sentry.Android.AssemblyReader/Sentry.Android.AssemblyReader.csproj#L6-L7) from the other packages that typically get published with each release of sentry-dotnet.  

Craft will attempt to publish all nuget packages, and currently it will fail if any of them already exist.  We can pass a `--skip-duplicate` flag to `dotnet nuget push` so that we continue without failure.

This is probably a good idea regardless of the versioning issue, as presently if we get *any* error after the first package is published, we won't be able to succeed the publishing step on retry, without bumping the version.