### PR TITLE
Support nuget snupkg artifacts

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -14,7 +14,7 @@ export const NUGET_DOTNET_BIN = process.env.NUGET_DOTNET_BIN || 'dotnet';
 export const DEFAULT_NUGET_SERVER_URL = 'https://api.nuget.org/v3/index.json';
 
 /** A regular expression used to find the package tarball */
-const DEFAULT_NUGET_REGEX = /^.*\d\.\d.*\.nupkg$/;
+const DEFAULT_NUGET_REGEX = /^.*\d\.\d.*\.s?nupkg$/;
 
 /** Nuget target configuration options */
 export interface NugetTargetOptions {

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -115,7 +115,7 @@ export class NugetTarget extends BaseTarget {
         // name as the .nupkg file, then download it to the same location.
         // It will be picked up automatically when pushing the .nupkg.
         const symbolFileName = file.filename.replace('.nupkg', '.snupkg');
-        const symbolFile = symbolFiles.find(f => f.filename == symbolFileName);
+        const symbolFile = symbolFiles.find(f => f.filename === symbolFileName);
         if (symbolFile) {
           await this.artifactProvider.downloadArtifact(symbolFile);
         }

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -15,6 +15,7 @@ export const DEFAULT_NUGET_SERVER_URL = 'https://api.nuget.org/v3/index.json';
 
 /** A regular expression used to find the package tarball */
 const DEFAULT_NUGET_REGEX = /^.*\d\.\d.*\.nupkg$/;
+const SYMBOLS_NUGET_REGEX = /^.*\d\.\d.*\.snupkg$/;
 
 /** Nuget target configuration options */
 export interface NugetTargetOptions {
@@ -87,6 +88,9 @@ export class NugetTarget extends BaseTarget {
     const packageFiles = await this.getArtifactsForRevision(revision, {
       includeNames: DEFAULT_NUGET_REGEX,
     });
+    const symbolFiles = await this.getArtifactsForRevision(revision, {
+      includeNames: SYMBOLS_NUGET_REGEX,
+    });
 
     if (!packageFiles.length) {
       reportError(
@@ -106,8 +110,19 @@ export class NugetTarget extends BaseTarget {
     await Promise.all(
       packageFiles.map(async (file: RemoteArtifact) => {
         const path = await this.artifactProvider.downloadArtifact(file);
+
+        // If an artifact containing a .snupkg file exists with the same base
+        // name as the .nupkg file, then download it to the same location.
+        // It will be picked up automatically when pushing the .nupkg.
+        const symbolFileName = file.filename.replace('.nupkg', '.snupkg');
+        const symbolFile = symbolFiles.find(f => f.filename == symbolFileName);
+        if (symbolFile) {
+          await this.artifactProvider.downloadArtifact(symbolFile);
+        }
+
         this.logger.info(
-          `Uploading file "${file.filename}" via "dotnet nuget"`
+          `Uploading file "${file.filename}" via "dotnet nuget"` +
+          (symbolFile ? `, including symbol file "${symbolFile.filename}"` : '')
         );
         return this.uploadAsset(path);
       })


### PR DESCRIPTION
Adds support for publishing [Nuget Symbol Package files](https://learn.microsoft.com/nuget/create-packages/symbol-packages-snupkg) (`.snupkg` extension).

We'll need this to publish the .NET SDK repo, now that we start using them with https://github.com/getsentry/sentry-dotnet/pull/2166.
