### PR TITLE
feat(build): Bump Dockerfile base image to node:20-bookworm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16']
+        node: ['14', '16', '20']
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-bullseye
+FROM node:20-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
   DOTNET_CLI_TELEMETRY_OPTOUT=1 \
@@ -20,14 +20,15 @@ RUN apt-get -qq update \
     twine \
     jq \
     unzip \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
     maven \
     elixir \
-  && curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
+  # TODO bump packages.microsoft.com to debian/12 when microsoft updates the package
+  && curl -fsSL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
   && dpkg -i /tmp/packages-microsoft-prod.deb \
   && rm /tmp/packages-microsoft-prod.deb \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-  && echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list \
+  && echo 'deb [arch=amd64] https://download.docker.com/linux/debian bookworm stable' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-7.0 \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: 'gcr.io/kaniko-project/executor:v1.5.1'
+  - name: 'gcr.io/kaniko-project/executor:v1.12.1'
     args:
       - '--cache=true'
       - '--use-new-run'
@@ -9,7 +9,7 @@ steps:
       - '-f'
       - 'builder.dockerfile'
   - name: 'us.gcr.io/$PROJECT_ID/craft:builder-$COMMIT_SHA'
-  - name: 'gcr.io/kaniko-project/executor:v1.5.1'
+  - name: 'gcr.io/kaniko-project/executor:v1.12.1'
     args:
       - '--cache=true'
       - '--use-new-run'


### PR DESCRIPTION
needed this because `elixir` version on bullseye was too old.

### version diff

ran the following inside container on both master and this branch
```bash
node --version
npm --version
dirmngr --version
ruby --version
gem --version
twine --version
java --version
mvn --version
iex --version
hex --version
dotnet --version
docker --version
cargo --version
gem info cocoapods
dart --version
flutter --version
```

```diff
➜  bump_craft_dockerfile diff -u old new
--- old	2023-07-12 17:06:57
+++ new	2023-07-12 17:18:55
@@ -1,24 +1,25 @@
-v14.21.3
-6.14.18
-dirmngr (GnuPG) 2.2.27
-Copyright (C) 2021 Free Software Foundation, Inc.
+v20.4.0
+9.7.2
+dirmngr (GnuPG) 2.2.40
+Copyright (C) 2022 g10 Code GmbH
 License GNU GPL-3.0-or-later <https://gnu.org/licenses/gpl.html>
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.
-ruby 2.7.4p191 (2021-07-07 revision a21a3b7d23) [x86_64-linux-gnu]
-3.2.5
-twine version 3.3.0 (pkginfo: 1.4.2, requests: 2.25.1, setuptools: 52.0.0, requests-toolbelt: 0.9.1, tqdm: 4.57.0)
-openjdk 11.0.18 2023-01-17
-OpenJDK Runtime Environment (build 11.0.18+10-post-Debian-1deb11u1)
-OpenJDK 64-Bit Server VM (build 11.0.18+10-post-Debian-1deb11u1, mixed mode, sharing)
-Apache Maven 3.6.3
+ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux-gnu]
+3.3.15
+twine version 4.0.2 (importlib-metadata: 4.12.0, keyring: 23.9.3, pkginfo: 1.8.2, requests: 2.28.1, requests-
+toolbelt: 0.10.1, urllib3: 1.26.12)
+openjdk 17.0.7 2023-04-18
+OpenJDK Runtime Environment (build 17.0.7+7-Debian-1deb12u1)
+OpenJDK 64-Bit Server VM (build 17.0.7+7-Debian-1deb12u1, mixed mode, sharing)
+Apache Maven 3.8.7
 Maven home: /usr/share/maven
-Java version: 11.0.18, vendor: Debian, runtime: /usr/lib/jvm/java-11-openjdk-amd64
+Java version: 17.0.7, vendor: Debian, runtime: /usr/lib/jvm/java-17-openjdk-amd64
 Default locale: en_US, platform encoding: ANSI_X3.4-1968
 OS name: "linux", version: "5.15.49-linuxkit-pr", arch: "amd64", family: "unix"
-Erlang/OTP 23 [erts-11.1.8] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]
+Erlang/OTP 25 [erts-13.1.5] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]

-IEx 1.10.3 (compiled with Erlang/OTP 22)
+IEx 1.14.0 (compiled with Erlang/OTP 24)
 bash: hex: command not found
 7.0.306
 Docker version 24.0.4, build 3713ee1
@@ -30,7 +31,7 @@
     Authors: Eloy Duran, Fabio Pelosin, Kyle Fuller, Samuel Giddins
     Homepage: https://github.com/CocoaPods/CocoaPods
     License: MIT
-    Installed at: /var/lib/gems/2.7.0
+    Installed at: /var/lib/gems/3.1.0

     The Cocoa library package manager.
 Dart SDK version: 3.0.0 (stable) (Thu May 4 01:11:00 2023 -0700) on "linux_x64"
```
