### PR TITLE
Revert changes since 1.2.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16', '20']
+        node: ['14', '16']
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm
+FROM node:14-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive \
   DOTNET_CLI_TELEMETRY_OPTOUT=1 \
@@ -20,15 +20,14 @@ RUN apt-get -qq update \
     twine \
     jq \
     unzip \
-    openjdk-17-jdk \
+    openjdk-11-jdk \
     maven \
     elixir \
-  # TODO bump packages.microsoft.com to debian/12 when microsoft updates the package
-  && curl -fsSL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
+  && curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
   && dpkg -i /tmp/packages-microsoft-prod.deb \
   && rm /tmp/packages-microsoft-prod.deb \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-  && echo 'deb [arch=amd64] https://download.docker.com/linux/debian bookworm stable' >> /etc/apt/sources.list \
+  && echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-7.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get -qq update \
     openjdk-17-jdk \
     maven \
     elixir \
-    erlang-dev \
   # TODO bump packages.microsoft.com to debian/12 when microsoft updates the package
   && curl -fsSL https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
   && dpkg -i /tmp/packages-microsoft-prod.deb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get -qq update \
     dirmngr \
     gnupg \
     git \
-    python3-packaging \
     ruby-full \
     twine \
     jq \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: 'gcr.io/kaniko-project/executor:v1.12.1'
+  - name: 'gcr.io/kaniko-project/executor:v1.5.1'
     args:
       - '--cache=true'
       - '--use-new-run'
@@ -9,7 +9,7 @@ steps:
       - '-f'
       - 'builder.dockerfile'
   - name: 'us.gcr.io/$PROJECT_ID/craft:builder-$COMMIT_SHA'
-  - name: 'gcr.io/kaniko-project/executor:v1.12.1'
+  - name: 'gcr.io/kaniko-project/executor:v1.5.1'
     args:
       - '--cache=true'
       - '--use-new-run'

--- a/src/targets/hex.ts
+++ b/src/targets/hex.ts
@@ -82,7 +82,6 @@ export class HexTarget extends BaseTarget {
         const spawnOptions = { cwd: directory };
         const spawnProcessOptions = { showStdout: true };
         await spawnProcess(MIX_BIN, ['local.hex', '--force'], spawnOptions, spawnProcessOptions);
-        await spawnProcess(MIX_BIN, ['local.rebar', '--force'], spawnOptions, spawnProcessOptions);
         await spawnProcess(MIX_BIN, ['deps.get'], spawnOptions, spawnProcessOptions);
         await spawnProcess(MIX_BIN, ['hex.publish', '--yes'], spawnOptions, spawnProcessOptions);
       },


### PR DESCRIPTION
It seems publishing with 1.3.0 is broken - see https://getsentry.atlassian.net/browse/INC-456. 

Reverting all changes since 1.2.3 for now, so we can re-release this as 1.4.0 and then figure this out with more time.