### PR TITLE
feat: Handle existing NPM packages

### DIFF
--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -209,6 +209,16 @@ export class NpmTarget extends BaseTarget {
       // Disable output buffering because NPM/Yarn can ask us for one-time passwords
       return spawnProcess(bin, args, spawnOptions, {
         showStdout: true,
+      }).catch(error => {
+        // When publishing a list of packages fails for only one package,
+        // you can never fix this by re-running publish because it will then _always_ fail due to existing versions.
+        // Instead, in this case we want to simply ignore the already existing package and continue.
+        if (error.message?.includes('You cannot publish over the previously published versions:')) {
+          console.warn(error);
+          return Promise.resolve();
+        }
+
+        return Promise.reject(error);
       });
     });
   }


### PR DESCRIPTION
When publishing a JS monorepo, if something goes wrong in the publish process, it can happen that only _some_ packages are released, but others aren't. So you can e.g. have a state for the monorepo packages:

* package-1@1.0.2
* package-2@1.0.2 --> after this publish, something fails
* package-3@1.0.1

Now there is no way to fix the 1.0.2 release, because any rerun of this will fail when trying to publish package-1 because 1.0.2 already exists for it. See for example: https://github.com/getsentry/publish/actions/runs/5584823217/jobs/10206737755

This PR adds some special casing for this specific error, in which case we simply ignore and skip this. I don't have a great way of testing this directly, if there are any ideas let me know.