### PR TITLE
ref: add python3-packaging explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -qq update \
     dirmngr \
     gnupg \
     git \
+    python3-packaging \
     ruby-full \
     twine \
     jq \


### PR DESCRIPTION
this is needed by the sentry-pypi target

re-does #474 -- reverted in #475