### PR TITLE
fix(github): Increase artifact polling interval and max retries

### DIFF
--- a/src/artifact_providers/__tests__/github.test.ts
+++ b/src/artifact_providers/__tests__/github.test.ts
@@ -1,21 +1,13 @@
 jest.mock('../../utils/githubApi.ts');
-import { getGitHubClient } from '../../utils/githubApi';
-import {
-  GitHubArtifactProvider,
-  ArtifactItem,
-  lazyRequest,
-  lazyRequestCallback,
-} from '../github';
+import { getGitHubClient} from '../../utils/githubApi';
+import { GitHubArtifactProvider, ArtifactItem, lazyRequest, lazyRequestCallback} from '../github';
 import { sleep } from '../../utils/async';
 
 class TestGitHubArtifactProvider extends GitHubArtifactProvider {
   public testGetRevisionArtifact(revision: string): Promise<ArtifactItem> {
     return this.getRevisionArtifact(revision);
   }
-  public testSearchForRevisionArtifact(
-    revision: string,
-    getRevisionDate: lazyRequestCallback<string>
-  ): Promise<ArtifactItem | null> {
+  public testSearchForRevisionArtifact(revision: string, getRevisionDate: lazyRequestCallback<string>): Promise<ArtifactItem|null> {
     return this.searchForRevisionArtifact(revision, getRevisionDate);
   }
 }
@@ -26,11 +18,11 @@ describe('GitHub Artifact Provider', () => {
   let githubArtifactProvider: TestGitHubArtifactProvider;
   let mockClient: {
     actions: {
-      listArtifactsForRepo: jest.Mock;
-    };
+      listArtifactsForRepo: jest.Mock,
+    },
     git: {
-      getCommit: jest.Mock;
-    };
+      getCommit: jest.Mock,
+    },
   };
   let mockedSleep;
 
@@ -54,7 +46,7 @@ describe('GitHub Artifact Provider', () => {
 
     mockedSleep = sleep as jest.Mock;
     mockedSleep.mockImplementation(() => {
-      return new Promise(resolve => setTimeout(resolve, 10));
+      return new Promise((resolve) => setTimeout(resolve, 10));
     });
   });
 
@@ -121,56 +113,54 @@ describe('GitHub Artifact Provider', () => {
         status: 200,
         data: {
           committer: {
-            date: '2021-05-12T21:45:04Z',
+            date: "2021-05-12T21:45:04Z",
           },
         },
+      })
+      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          // NOTE: 101 here will force pagination to be handled.
+          total_count: 101,
+          artifacts: [
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      }).mockResolvedValueOnce({
+        status: 200,
+        data: {
+          total_count: 101,
+          artifacts: [
+            {
+              id: 60233710,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
+              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
+              expired: false,
+              created_at: '2021-05-12T21:50:35Z',
+              updated_at: '2021-05-12T21:50:38Z',
+              expires_at: '2021-08-10T21:50:31Z',
+            },
+          ],
+        },
       });
-      mockClient.actions.listArtifactsForRepo
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            // NOTE: 101 here will force pagination to be handled.
-            total_count: 101,
-            artifacts: [
-              {
-                id: 60232691,
-                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-                size_in_bytes: 6511029,
-                url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-                archive_download_url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-                expired: false,
-                created_at: '2021-05-12T21:45:04Z',
-                updated_at: '2021-05-12T21:45:07Z',
-                expires_at: '2021-08-10T21:45:00Z',
-              },
-            ],
-          },
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            total_count: 101,
-            artifacts: [
-              {
-                id: 60233710,
-                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
-                name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
-                size_in_bytes: 6511029,
-                url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
-                archive_download_url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
-                expired: false,
-                created_at: '2021-05-12T21:50:35Z',
-                updated_at: '2021-05-12T21:50:38Z',
-                expires_at: '2021-08-10T21:50:31Z',
-              },
-            ],
-          },
-        });
       await expect(
         githubArtifactProvider.testGetRevisionArtifact(
           '1b843f2cbb20fdda99ef749e29e75e43e6e43b38'
@@ -320,56 +310,52 @@ describe('GitHub Artifact Provider', () => {
 
   describe('searchForRevisionArtifact', () => {
     test('it should get the artifact from second page', async () => {
-      mockClient.actions.listArtifactsForRepo
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            // NOTE: 101 here will force pagination to be handled.
-            total_count: 101,
-            artifacts: [
-              {
-                id: 60232691,
-                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-                size_in_bytes: 6511029,
-                url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-                archive_download_url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-                expired: false,
-                created_at: '2021-05-12T21:45:04Z',
-                updated_at: '2021-05-12T21:45:07Z',
-                expires_at: '2021-08-10T21:45:00Z',
-              },
-            ],
-          },
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            total_count: 101,
-            artifacts: [
-              {
-                id: 60233710,
-                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
-                name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
-                size_in_bytes: 6511029,
-                url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
-                archive_download_url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
-                expired: false,
-                created_at: '2021-05-12T21:50:35Z',
-                updated_at: '2021-05-12T21:50:38Z',
-                expires_at: '2021-08-10T21:50:31Z',
-              },
-            ],
-          },
-        });
+      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          // NOTE: 101 here will force pagination to be handled.
+          total_count: 101,
+          artifacts: [
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      }).mockResolvedValueOnce({
+        status: 200,
+        data: {
+          total_count: 101,
+          artifacts: [
+            {
+              id: 60233710,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
+              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
+              expired: false,
+              created_at: '2021-05-12T21:50:35Z',
+              updated_at: '2021-05-12T21:50:38Z',
+              expires_at: '2021-08-10T21:50:31Z',
+            },
+          ],
+        },
+      });
 
-      const getRevisionDateCallback = jest
-        .fn()
-        .mockResolvedValueOnce('2020-05-12T21:45:04Z');
+      const getRevisionDateCallback = jest.fn().mockResolvedValueOnce("2020-05-12T21:45:04Z");
 
       await expect(
         githubArtifactProvider.testSearchForRevisionArtifact(
@@ -397,78 +383,73 @@ describe('GitHub Artifact Provider', () => {
     });
 
     test('it should return null if all pages are processed', async () => {
-      mockClient.actions.listArtifactsForRepo
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            // NOTE: 201 here will force pagination to be handled.
-            total_count: 201,
-            artifacts: [
-              {
-                id: 60232691,
-                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-                size_in_bytes: 6511029,
-                url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-                archive_download_url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-                expired: false,
-                created_at: '2021-05-12T21:45:04Z',
-                updated_at: '2021-05-12T21:45:07Z',
-                expires_at: '2021-08-10T21:45:00Z',
-              },
-            ],
-          },
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            total_count: 201,
-            artifacts: [
-              {
-                id: 60232691,
-                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-                size_in_bytes: 6511029,
-                url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-                archive_download_url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-                expired: false,
-                created_at: '2021-05-12T21:45:04Z',
-                updated_at: '2021-05-12T21:45:07Z',
-                expires_at: '2021-08-10T21:45:00Z',
-              },
-            ],
-          },
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: {
-            total_count: 201,
-            artifacts: [
-              {
-                id: 60232691,
-                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-                size_in_bytes: 6511029,
-                url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-                archive_download_url:
-                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-                expired: false,
-                created_at: '2021-05-12T21:45:04Z',
-                updated_at: '2021-05-12T21:45:07Z',
-                expires_at: '2021-08-10T21:45:00Z',
-              },
-            ],
-          },
-        });
+      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          // NOTE: 201 here will force pagination to be handled.
+          total_count: 201,
+          artifacts: [
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      }).mockResolvedValueOnce({
+        status: 200,
+        data: {
+          total_count: 201,
+          artifacts: [
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      }).mockResolvedValueOnce({
+        status: 200,
+        data: {
+          total_count: 201,
+          artifacts: [
+            {
+              id: 60232691,
+              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+              size_in_bytes: 6511029,
+              url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+              archive_download_url:
+                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+              expired: false,
+              created_at: '2021-05-12T21:45:04Z',
+              updated_at: '2021-05-12T21:45:07Z',
+              expires_at: '2021-08-10T21:45:00Z',
+            },
+          ],
+        },
+      });
 
-      const getRevisionDateCallback = jest
-        .fn()
-        .mockResolvedValueOnce('2020-05-12T21:45:04Z');
+      const getRevisionDateCallback = jest.fn().mockResolvedValueOnce("2020-05-12T21:45:04Z");
 
       await expect(
         githubArtifactProvider.testSearchForRevisionArtifact(
@@ -505,9 +486,7 @@ describe('GitHub Artifact Provider', () => {
         },
       });
 
-      const getRevisionDateCallback = jest
-        .fn()
-        .mockResolvedValueOnce('2021-05-12T21:45:04Z');
+      const getRevisionDateCallback = jest.fn().mockResolvedValueOnce( "2021-05-12T21:45:04Z");
 
       await expect(
         githubArtifactProvider.testSearchForRevisionArtifact(

--- a/src/artifact_providers/__tests__/github.test.ts
+++ b/src/artifact_providers/__tests__/github.test.ts
@@ -1,13 +1,21 @@
 jest.mock('../../utils/githubApi.ts');
-import { getGitHubClient} from '../../utils/githubApi';
-import { GitHubArtifactProvider, ArtifactItem, lazyRequest, lazyRequestCallback} from '../github';
+import { getGitHubClient } from '../../utils/githubApi';
+import {
+  GitHubArtifactProvider,
+  ArtifactItem,
+  lazyRequest,
+  lazyRequestCallback,
+} from '../github';
 import { sleep } from '../../utils/async';
 
 class TestGitHubArtifactProvider extends GitHubArtifactProvider {
   public testGetRevisionArtifact(revision: string): Promise<ArtifactItem> {
     return this.getRevisionArtifact(revision);
   }
-  public testSearchForRevisionArtifact(revision: string, getRevisionDate: lazyRequestCallback<string>): Promise<ArtifactItem|null> {
+  public testSearchForRevisionArtifact(
+    revision: string,
+    getRevisionDate: lazyRequestCallback<string>
+  ): Promise<ArtifactItem | null> {
     return this.searchForRevisionArtifact(revision, getRevisionDate);
   }
 }
@@ -18,11 +26,11 @@ describe('GitHub Artifact Provider', () => {
   let githubArtifactProvider: TestGitHubArtifactProvider;
   let mockClient: {
     actions: {
-      listArtifactsForRepo: jest.Mock,
-    },
+      listArtifactsForRepo: jest.Mock;
+    };
     git: {
-      getCommit: jest.Mock,
-    },
+      getCommit: jest.Mock;
+    };
   };
   let mockedSleep;
 
@@ -46,7 +54,7 @@ describe('GitHub Artifact Provider', () => {
 
     mockedSleep = sleep as jest.Mock;
     mockedSleep.mockImplementation(() => {
-      return new Promise((resolve) => setTimeout(resolve, 10));
+      return new Promise(resolve => setTimeout(resolve, 10));
     });
   });
 
@@ -113,54 +121,56 @@ describe('GitHub Artifact Provider', () => {
         status: 200,
         data: {
           committer: {
-            date: "2021-05-12T21:45:04Z",
+            date: '2021-05-12T21:45:04Z',
           },
         },
-      })
-      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          // NOTE: 101 here will force pagination to be handled.
-          total_count: 101,
-          artifacts: [
-            {
-              id: 60232691,
-              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-              size_in_bytes: 6511029,
-              url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-              expired: false,
-              created_at: '2021-05-12T21:45:04Z',
-              updated_at: '2021-05-12T21:45:07Z',
-              expires_at: '2021-08-10T21:45:00Z',
-            },
-          ],
-        },
-      }).mockResolvedValueOnce({
-        status: 200,
-        data: {
-          total_count: 101,
-          artifacts: [
-            {
-              id: 60233710,
-              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
-              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
-              size_in_bytes: 6511029,
-              url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
-              expired: false,
-              created_at: '2021-05-12T21:50:35Z',
-              updated_at: '2021-05-12T21:50:38Z',
-              expires_at: '2021-08-10T21:50:31Z',
-            },
-          ],
-        },
       });
+      mockClient.actions.listArtifactsForRepo
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            // NOTE: 101 here will force pagination to be handled.
+            total_count: 101,
+            artifacts: [
+              {
+                id: 60232691,
+                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+                size_in_bytes: 6511029,
+                url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+                expired: false,
+                created_at: '2021-05-12T21:45:04Z',
+                updated_at: '2021-05-12T21:45:07Z',
+                expires_at: '2021-08-10T21:45:00Z',
+              },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            total_count: 101,
+            artifacts: [
+              {
+                id: 60233710,
+                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
+                name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+                size_in_bytes: 6511029,
+                url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
+                expired: false,
+                created_at: '2021-05-12T21:50:35Z',
+                updated_at: '2021-05-12T21:50:38Z',
+                expires_at: '2021-08-10T21:50:31Z',
+              },
+            ],
+          },
+        });
       await expect(
         githubArtifactProvider.testGetRevisionArtifact(
           '1b843f2cbb20fdda99ef749e29e75e43e6e43b38'
@@ -239,7 +249,7 @@ describe('GitHub Artifact Provider', () => {
             `);
     });
 
-    test('it should throw when no artifacts are found after 3 retries', async () => {
+    test('it should throw when no artifacts are found after 10 retries', async () => {
       mockClient.actions.listArtifactsForRepo.mockResolvedValue({
         status: 200,
         data: {
@@ -253,11 +263,11 @@ describe('GitHub Artifact Provider', () => {
           '1b843f2cbb20fdda99ef749e29e75e43e6e43b38'
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Can't find any artifacts for revision "1b843f2cbb20fdda99ef749e29e75e43e6e43b38" (tries: 3)"`
+        `"Can't find any artifacts for revision "1b843f2cbb20fdda99ef749e29e75e43e6e43b38" (tries: 10)"`
       );
 
-      expect(mockClient.actions.listArtifactsForRepo).toBeCalledTimes(3);
-      expect(sleep).toBeCalledTimes(2);
+      expect(mockClient.actions.listArtifactsForRepo).toBeCalledTimes(10);
+      expect(sleep).toBeCalledTimes(9);
     });
 
     test('it should throw when no artifacts with the name can be found', async () => {
@@ -302,60 +312,64 @@ describe('GitHub Artifact Provider', () => {
           '3c2e87573d3bd16f61cf08fece0638cc47a4fc22'
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Can't find any artifacts for revision "3c2e87573d3bd16f61cf08fece0638cc47a4fc22" (tries: 3)"`
+        `"Can't find any artifacts for revision "3c2e87573d3bd16f61cf08fece0638cc47a4fc22" (tries: 10)"`
       );
-      expect(sleep).toBeCalledTimes(2);
+      expect(sleep).toBeCalledTimes(9);
     });
   });
 
   describe('searchForRevisionArtifact', () => {
     test('it should get the artifact from second page', async () => {
-      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          // NOTE: 101 here will force pagination to be handled.
-          total_count: 101,
-          artifacts: [
-            {
-              id: 60232691,
-              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-              size_in_bytes: 6511029,
-              url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-              expired: false,
-              created_at: '2021-05-12T21:45:04Z',
-              updated_at: '2021-05-12T21:45:07Z',
-              expires_at: '2021-08-10T21:45:00Z',
-            },
-          ],
-        },
-      }).mockResolvedValueOnce({
-        status: 200,
-        data: {
-          total_count: 101,
-          artifacts: [
-            {
-              id: 60233710,
-              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
-              name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
-              size_in_bytes: 6511029,
-              url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
-              expired: false,
-              created_at: '2021-05-12T21:50:35Z',
-              updated_at: '2021-05-12T21:50:38Z',
-              expires_at: '2021-08-10T21:50:31Z',
-            },
-          ],
-        },
-      });
+      mockClient.actions.listArtifactsForRepo
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            // NOTE: 101 here will force pagination to be handled.
+            total_count: 101,
+            artifacts: [
+              {
+                id: 60232691,
+                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+                size_in_bytes: 6511029,
+                url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+                expired: false,
+                created_at: '2021-05-12T21:45:04Z',
+                updated_at: '2021-05-12T21:45:07Z',
+                expires_at: '2021-08-10T21:45:00Z',
+              },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            total_count: 101,
+            artifacts: [
+              {
+                id: 60233710,
+                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMzcxMA==',
+                name: '1b843f2cbb20fdda99ef749e29e75e43e6e43b38',
+                size_in_bytes: 6511029,
+                url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60233710/zip',
+                expired: false,
+                created_at: '2021-05-12T21:50:35Z',
+                updated_at: '2021-05-12T21:50:38Z',
+                expires_at: '2021-08-10T21:50:31Z',
+              },
+            ],
+          },
+        });
 
-      const getRevisionDateCallback = jest.fn().mockResolvedValueOnce("2020-05-12T21:45:04Z");
+      const getRevisionDateCallback = jest
+        .fn()
+        .mockResolvedValueOnce('2020-05-12T21:45:04Z');
 
       await expect(
         githubArtifactProvider.testSearchForRevisionArtifact(
@@ -383,73 +397,78 @@ describe('GitHub Artifact Provider', () => {
     });
 
     test('it should return null if all pages are processed', async () => {
-      mockClient.actions.listArtifactsForRepo.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          // NOTE: 201 here will force pagination to be handled.
-          total_count: 201,
-          artifacts: [
-            {
-              id: 60232691,
-              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-              size_in_bytes: 6511029,
-              url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-              expired: false,
-              created_at: '2021-05-12T21:45:04Z',
-              updated_at: '2021-05-12T21:45:07Z',
-              expires_at: '2021-08-10T21:45:00Z',
-            },
-          ],
-        },
-      }).mockResolvedValueOnce({
-        status: 200,
-        data: {
-          total_count: 201,
-          artifacts: [
-            {
-              id: 60232691,
-              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-              size_in_bytes: 6511029,
-              url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-              expired: false,
-              created_at: '2021-05-12T21:45:04Z',
-              updated_at: '2021-05-12T21:45:07Z',
-              expires_at: '2021-08-10T21:45:00Z',
-            },
-          ],
-        },
-      }).mockResolvedValueOnce({
-        status: 200,
-        data: {
-          total_count: 201,
-          artifacts: [
-            {
-              id: 60232691,
-              node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
-              name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
-              size_in_bytes: 6511029,
-              url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
-              archive_download_url:
-                'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
-              expired: false,
-              created_at: '2021-05-12T21:45:04Z',
-              updated_at: '2021-05-12T21:45:07Z',
-              expires_at: '2021-08-10T21:45:00Z',
-            },
-          ],
-        },
-      });
+      mockClient.actions.listArtifactsForRepo
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            // NOTE: 201 here will force pagination to be handled.
+            total_count: 201,
+            artifacts: [
+              {
+                id: 60232691,
+                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+                size_in_bytes: 6511029,
+                url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+                expired: false,
+                created_at: '2021-05-12T21:45:04Z',
+                updated_at: '2021-05-12T21:45:07Z',
+                expires_at: '2021-08-10T21:45:00Z',
+              },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            total_count: 201,
+            artifacts: [
+              {
+                id: 60232691,
+                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+                size_in_bytes: 6511029,
+                url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+                expired: false,
+                created_at: '2021-05-12T21:45:04Z',
+                updated_at: '2021-05-12T21:45:07Z',
+                expires_at: '2021-08-10T21:45:00Z',
+              },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            total_count: 201,
+            artifacts: [
+              {
+                id: 60232691,
+                node_id: 'MDg6QXJ0aWZhY3Q2MDIzMjY5MQ==',
+                name: 'e4bcfe450e0460ec5f20b20868664171effef6f9',
+                size_in_bytes: 6511029,
+                url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691',
+                archive_download_url:
+                  'https://api.github.com/repos/getsentry/craft/actions/artifacts/60232691/zip',
+                expired: false,
+                created_at: '2021-05-12T21:45:04Z',
+                updated_at: '2021-05-12T21:45:07Z',
+                expires_at: '2021-08-10T21:45:00Z',
+              },
+            ],
+          },
+        });
 
-      const getRevisionDateCallback = jest.fn().mockResolvedValueOnce("2020-05-12T21:45:04Z");
+      const getRevisionDateCallback = jest
+        .fn()
+        .mockResolvedValueOnce('2020-05-12T21:45:04Z');
 
       await expect(
         githubArtifactProvider.testSearchForRevisionArtifact(
@@ -486,7 +505,9 @@ describe('GitHub Artifact Provider', () => {
         },
       });
 
-      const getRevisionDateCallback = jest.fn().mockResolvedValueOnce( "2021-05-12T21:45:04Z");
+      const getRevisionDateCallback = jest
+        .fn()
+        .mockResolvedValueOnce('2021-05-12T21:45:04Z');
 
       await expect(
         githubArtifactProvider.testSearchForRevisionArtifact(

--- a/src/artifact_providers/github.ts
+++ b/src/artifact_providers/github.ts
@@ -18,9 +18,9 @@ import {
 import { extractZipArchive } from '../utils/system';
 import { sleep } from '../utils/async';
 
-const MAX_TRIES = 3;
+const MAX_TRIES = 10;
 const MILLISECONDS = 1000;
-const ARTIFACTS_POLLING_INTERVAL = 10 * MILLISECONDS;
+const ARTIFACTS_POLLING_INTERVAL = 30 * MILLISECONDS;
 
 export type ArtifactItem = RestEndpointMethodTypes['actions']['listArtifactsForRepo']['response']['data']['artifacts'][0];
 


### PR DESCRIPTION
As outlined in [#482 by @BYK ](https://github.com/getsentry/craft/issues/482#issuecomment-1664067774) we should increase the time we wait for the build artifacts so that the publishing process doesn't fail if GH didn't upload artifacts within 30s.

closes #482