### PR TITLE
fix(brew): Replace version in artifact names with '__VERSION__' to access checksums from mustache

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,11 @@ contains the following variables:
 - `version`: The new version
 - `revision`: The tag's commit SHA
 - `checksums`: A map containing sha256 checksums for every release asset. Use
-  the full filename to access the sha, e.g. `checksums.MyProgram-x86`
+  the full filename to access the sha, e.g. `checksums.MyProgram-x86`. If the
+  filename contains dots (`.`), they are being replaced with `__`. If the
+  filename contains the currently released version, it is replaced with `latest`.
+  For example, `sentry-wizard-3.9.3.tgz` checksums will be accessible by the key
+  `checksums.sentry-wizard-latest__tgz`.
 
 **Environment**
 

--- a/README.md
+++ b/README.md
@@ -652,9 +652,9 @@ contains the following variables:
 - `checksums`: A map containing sha256 checksums for every release asset. Use
   the full filename to access the sha, e.g. `checksums.MyProgram-x86`. If the
   filename contains dots (`.`), they are being replaced with `__`. If the
-  filename contains the currently released version, it is replaced with `latest`.
-  For example, `sentry-wizard-3.9.3.tgz` checksums will be accessible by the key
-  `checksums.sentry-wizard-latest__tgz`.
+  filename contains the currently released version, it is replaced with `__VERSION__`.
+  For example, `sentry-wizard-v3.9.3.tgz` checksums will be accessible by the key
+  `checksums.sentry-wizard-v__VERSION____tgz`.
 
 **Environment**
 

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -163,7 +163,7 @@ export class BrewTarget extends BaseTarget {
     const checksums: any = {};
 
     await mapLimit(filesList, MAX_DOWNLOAD_CONCURRENCY, async file => {
-      const key = file.filename.replace(version, 'latest');
+      const key = file.filename.replace(version, '__VERSION__');
       checksums[key] = await this.artifactProvider.getChecksum(
         file,
         HashAlgorithm.SHA256,

--- a/src/targets/brew.ts
+++ b/src/targets/brew.ts
@@ -163,7 +163,8 @@ export class BrewTarget extends BaseTarget {
     const checksums: any = {};
 
     await mapLimit(filesList, MAX_DOWNLOAD_CONCURRENCY, async file => {
-      checksums[file.filename] = await this.artifactProvider.getChecksum(
+      const key = file.filename.replace(version, 'latest');
+      checksums[key] = await this.artifactProvider.getChecksum(
         file,
         HashAlgorithm.SHA256,
         HashOutputFormat.Hex


### PR DESCRIPTION
This PR is a prerequisite for publishing sentry-wizard to brew (see https://github.com/getsentry/sentry-wizard/pull/406)

When artifact names contain versions (e.g. [sentry-wizard-v3.10.0.tgz](https://github.com/getsentry/sentry-wizard/releases/tag/v3.10.0)), it's not possible to access their checksums when publishing to brew, because mustache does not support nested variables. The template for brew formula would have to look something like this, but I couldn't find how to make it work for mustache:

```
sha256 "{{checksums.sentry-wizard-v{{version}}.tgz}}"
```

So this PR is simply replacing the version with `__VERSION__`, if it appears to be in the name of the artifact, when building the checksums dictionary.

Also updated readme to clarify the restrictions on the keys for checksums for the brew target.

Part of https://github.com/getsentry/sentry-wizard/issues/346