### PR TITLE
Bump CocoaPods from 1.13.0 to 1.14.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 # Gemfile
-# activesupport 7.1.1 is broken, and cocoapods doesn't have a pinned
-# dependency on activesupport, so we need to pin it here until it's released,
-# see https://github.com/CocoaPods/CocoaPods/issues/12081.
-gem "activesupport", "= 7.0.8"
-gem "cocoapods", "= 1.13.0"
+# Pin CocoaPods Version to avoid that bugs in CocoaPods like
+# https://github.com/CocoaPods/CocoaPods/issues/12081 break our release
+# workflow.
+gem "cocoapods", "= 1.14.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,4 @@
 GEM
-  remote: https://index.rubygems.org/
   specs:
     CFPropertyList (3.0.6)
       rexml
@@ -15,12 +14,12 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.1.0)
-    cocoapods (1.13.0)
+    cocoapods (1.14.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.13.0)
+      cocoapods-core (= 1.14.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.6.0, < 2.0)
+      cocoapods-downloader (>= 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.6.0, < 2.0)
@@ -33,7 +32,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.13.0)
+    cocoapods-core (1.14.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -44,7 +43,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.6.3)
+    cocoapods-downloader (2.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -57,7 +56,7 @@ GEM
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.16.3)
+    ffi (1.16.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -89,5 +88,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (= 7.0.8)
-  cocoapods (= 1.13.0)
+  cocoapods (= 1.14.2)
+
+BUNDLED WITH
+   2.4.20


### PR DESCRIPTION
We had to pin CocoaPods to v 1.13.0 and set activesupport to 7.0.8 because of a bug in activesupport. That bug is fixed with CocoaPods 1.14.2, so we can bump the version.

This is related to https://github.com/getsentry/craft/pull/496.