### PR TITLE
chore(Dockerfile): bump dotnet 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
-    dotnet-sdk-7.0 \
+    dotnet-sdk-8.0 \
     docker-ce-cli \
     erlang \
     elixir \


### PR DESCRIPTION
Trying to publish .NET SDK version 4.0.0 [is failing](https://github.com/getsentry/publish/actions/runs/6804835357/job/18503160030) due to missing .NET 8 SDK on the craft target.

```
dotnet: Install the [8.0.100-rc.2.23502.2] .NET SDK or update [/github/workspace/__repo__/global.json] to match an installed SDK.
dotnet: 
dotnet: Learn about SDK resolution:
dotnet: https://aka.ms/dotnet/sdk-not-found
dotnet: 

  
  STDOUT: dotnet: 7.0.402 [/usr/share/dotnet/sdk]
  dotnet:
  
  
  STDERR:dotnet: The command could not be loaded, possibly because:
  dotnet:   * You intended to execute a .NET application:
  dotnet:       The application '--version' does not exist.
  dotnet:   * You intended to execute a .NET SDK command:
  dotnet:       A compatible .NET SDK was not found.
  dotnet:
  dotnet: Requested SDK version: 8.0.100-rc.2.23502.2
  dotnet: global.json file: global.json
  dotnet:
  dotnet: Installed SDKs:
  dotnet:
  dotnet: Install the [8.0.100-rc.2.23502.2] .NET SDK or update [global.json] to match an installed SDK.
  dotnet:
  dotnet: Learn about SDK resolution:
  dotnet: https://aka.ms/dotnet/sdk-not-found
  dotnet:
```

We should be able to publish with the current .NET SDK version, so it's a separate thing to fix. Not sure how we're getting a `global.json` with net8.0-rc2 in there.
But anyway once .NET 8 is out we'll want to bump this (next Monday).