### PR TITLE
chore: Bump .NET SDK 8 RC2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,12 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-7.0 \
-    dotnet-sdk-8.0.100-rc2 \
     docker-ce-cli \
     erlang \
     elixir \
+  && curl -L https://aka.ms/install-dotnet-preview -o install-dotnet-preview.sh \
+  && chmod +x install-dotnet-preview.sh \
+  && ./install-dotnet-preview.sh \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --  --profile minimal -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-7.0 \
+    dotnet-sdk-8.0.100-rc2 \
     docker-ce-cli \
     erlang \
     elixir \


### PR DESCRIPTION
The .NET SDK would like to release an alpha for the upcoming .NET 8 release and requires the .NET 8 RC2 to be available for that.

Once the actual release goes live we can drop .NET 7 in favor of 8.