### PR TITLE
feat: use dotnet 8 SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && chmod +x /usr/local/bin/SymbolCollector.Console
 
 # Install .NET SDK
-ENV DOTNET_SDK_VERSION=8.0.100-rc.2.23502.2
+ENV DOTNET_SDK_VERSION="8.0.100-rc.2.23502.2"
 RUN curl -fSL --output dotnet.tar.gz "https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz" \
   && dotnet_sha512='45f09e7b031f4cf5b4dcead240fe47e2e3731d97d22aa96d3a02a087322658606cc22792053c3784c44f15d7c9bad0ac9dbda90def7b4e197f2955dca9a5bb6c' \
   && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,19 +27,19 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get -qq update \
   && apt-get install -y --no-install-recommends \
-  apt-transport-https \
-  build-essential \
-  curl \
-  dirmngr \
-  gnupg \
-  git \
-  python3-packaging \
-  ruby-full \
-  twine \
-  jq \
-  unzip \
-  openjdk-11-jdk \
-  maven \
+    apt-transport-https \
+    build-essential \
+    curl \
+    dirmngr \
+    gnupg \
+    git \
+    python3-packaging \
+    ruby-full \
+    twine \
+    jq \
+    unzip \
+    openjdk-11-jdk \
+    maven \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -54,9 +54,9 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
-  docker-ce-cli \
-  erlang \
-  elixir \
+    docker-ce-cli \
+    erlang \
+    elixir \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --  --profile minimal -y \
@@ -73,7 +73,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
 
 # Install .NET SDK
 ENV DOTNET_SDK_VERSION=8.0.100-rc.2.23502.2
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$(DOTNET_SDK_VERSION)/dotnet-sdk-$(DOTNET_SDK_VERSION)-linux-x64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz "https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz" \
   && dotnet_sha512='45f09e7b031f4cf5b4dcead240fe47e2e3731d97d22aa96d3a02a087322658606cc22792053c3784c44f15d7c9bad0ac9dbda90def7b4e197f2955dca9a5bb6c' \
   && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
   && mkdir -p /usr/share/dotnet \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN export YARN_CACHE_FOLDER="$(mktemp -d)" \
 COPY . .
 
 RUN \
-   NODE_ENV=production \
+  NODE_ENV=production \
   NODE_PATH=/usr/local/lib/node_modules \
   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/lib/node_modules/.bin" \
   yarn --modules-folder /usr/local/lib/node_modules build
@@ -27,19 +27,19 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get -qq update \
   && apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    build-essential \
-    curl \
-    dirmngr \
-    gnupg \
-    git \
-    python3-packaging \
-    ruby-full \
-    twine \
-    jq \
-    unzip \
-    openjdk-11-jdk \
-    maven \
+  apt-transport-https \
+  build-essential \
+  curl \
+  dirmngr \
+  gnupg \
+  git \
+  python3-packaging \
+  ruby-full \
+  twine \
+  jq \
+  unzip \
+  openjdk-11-jdk \
+  maven \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -54,9 +54,9 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
-    docker-ce-cli \
-    erlang \
-    elixir \
+  docker-ce-cli \
+  erlang \
+  elixir \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --  --profile minimal -y \
@@ -73,7 +73,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
 
 # Install .NET SDK
 ENV DOTNET_SDK_VERSION=8.0.100-rc.2.23502.2
-RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$(DOTNET_SDK_VERSION)/dotnet-sdk-$(DOTNET_SDK_VERSION)-linux-x64.tar.gz \
   && dotnet_sha512='45f09e7b031f4cf5b4dcead240fe47e2e3731d97d22aa96d3a02a087322658606cc22792053c3784c44f15d7c9bad0ac9dbda90def7b4e197f2955dca9a5bb6c' \
   && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
   && mkdir -p /usr/share/dotnet \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN export YARN_CACHE_FOLDER="$(mktemp -d)" \
 COPY . .
 
 RUN \
-    NODE_ENV=production \
+   NODE_ENV=production \
   NODE_PATH=/usr/local/lib/node_modules \
   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/lib/node_modules/.bin" \
   yarn --modules-folder /usr/local/lib/node_modules build

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
-    dotnet-sdk-7.0 \
     docker-ce-cli \
     erlang \
     elixir \
@@ -76,7 +75,9 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
 RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100-rc.2.23502.2/dotnet-sdk-8.0.100-rc.2.23502.2-linux-x64.tar.gz \
   && dotnet_sha512='45f09e7b031f4cf5b4dcead240fe47e2e3731d97d22aa96d3a02a087322658606cc22792053c3784c44f15d7c9bad0ac9dbda90def7b4e197f2955dca9a5bb6c' \
   && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
-  && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+  && mkdir -p /usr/share/dotnet \
+  && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+  && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
   && rm dotnet.tar.gz \
   # Trigger first run experience by running arbitrary cmd
   && dotnet help

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,10 +76,8 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
 RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100-rc.2.23502.2/dotnet-sdk-8.0.100-rc.2.23502.2-linux-x64.tar.gz \
   && dotnet_sha512='45f09e7b031f4cf5b4dcead240fe47e2e3731d97d22aa96d3a02a087322658606cc22792053c3784c44f15d7c9bad0ac9dbda90def7b4e197f2955dca9a5bb6c' \
   && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
-  && mkdir -p /usr/share/dotnet \
   && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
   && rm dotnet.tar.gz \
-  && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
   # Trigger first run experience by running arbitrary cmd
   && dotnet help
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN export YARN_CACHE_FOLDER="$(mktemp -d)" \
 COPY . .
 
 RUN \
-  NODE_ENV=production \
+    NODE_ENV=production \
   NODE_PATH=/usr/local/lib/node_modules \
   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/lib/node_modules/.bin" \
   yarn --modules-folder /usr/local/lib/node_modules build

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && chmod +x /usr/local/bin/SymbolCollector.Console
 
 # Install .NET SDK
-ENV DOTNET_SDK_VERSION="8.0.100-rc.2.23502.2"
-RUN curl -fSL --output dotnet.tar.gz "https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz" \
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100-rc.2.23502.2/dotnet-sdk-8.0.100-rc.2.23502.2-linux-x64.tar.gz \
   && dotnet_sha512='45f09e7b031f4cf5b4dcead240fe47e2e3731d97d22aa96d3a02a087322658606cc22792053c3784c44f15d7c9bad0ac9dbda90def7b4e197f2955dca9a5bb6c' \
   && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
   && mkdir -p /usr/share/dotnet \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
-    dotnet-sdk-7.0 \
     docker-ce-cli \
     erlang \
     elixir \
@@ -71,6 +70,18 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && unzip /tmp/sym-collector.zip -d /usr/local/bin/ \
   && rm /tmp/sym-collector.zip \
   && chmod +x /usr/local/bin/SymbolCollector.Console
+
+# Install .NET SDK
+ENV DOTNET_SDK_VERSION=8.0.100-rc.2.23502.2
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+  && dotnet_sha512='45f09e7b031f4cf5b4dcead240fe47e2e3731d97d22aa96d3a02a087322658606cc22792053c3784c44f15d7c9bad0ac9dbda90def7b4e197f2955dca9a5bb6c' \
+  && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+  && mkdir -p /usr/share/dotnet \
+  && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+  && rm dotnet.tar.gz \
+  && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+  # Trigger first run experience by running arbitrary cmd
+  && dotnet help
 
 # https://docs.flutter.dev/get-started/install/linux#install-flutter-manually
 RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.10.0-stable.tar.xz -o /opt/flutter.tar.xz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
+    dotnet-sdk-7.0 \
     docker-ce-cli \
     erlang \
     elixir \


### PR DESCRIPTION
Updates to .NET 8 SDK which is currently on RC.2 (needed to release sentry-dotnet v4.0.0.alpha)