### PR TITLE
feat: Allow to configure `latestTargetBranch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,19 @@ for a release is `{releaseBranchPrefix}/{version}`. The prefix defaults to
 releaseBranchPrefix: publish
 ```
 
+### Latest Branch Name
+
+If configured, only tag releases as "latest" when merging into this branch.
+This can be useful to make sure that releases from e.g. a `v1` branch do not get tagged as "latest".
+Note that not all targets may use this.
+
+```yaml
+latestTargetBranch: main
+```
+
+If you specific `minVersion: '1.8.0'` or above, this will default to use the default branch.
+If your `minVersion` is older, the previous behavior (of always tagging as latest, for any branch) will continue to be used.
+
 ### Changelog Policies
 
 `craft` can help you to maintain change logs for your projects. At the moment,

--- a/src/schemas/projectConfig.schema.ts
+++ b/src/schemas/projectConfig.schema.ts
@@ -35,6 +35,7 @@ const projectConfigJsonSchema = {
     preReleaseCommand: { type: 'string' },
     postReleaseCommand: { type: 'string' },
     releaseBranchPrefix: { type: 'string' },
+    latestTargetBranch: { type: 'string' },
     changelog: { type: 'string' },
     changelogPolicy: {
       title: 'ChangelogPolicy',

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -13,6 +13,7 @@ export interface CraftProjectConfig {
   preReleaseCommand?: string;
   postReleaseCommand?: string;
   releaseBranchPrefix?: string;
+  latestTargetBranch?: string;
   changelog?: string;
   changelogPolicy?: ChangelogPolicy;
   minVersion?: string;

--- a/src/targets/__tests__/upm.test.ts
+++ b/src/targets/__tests__/upm.test.ts
@@ -60,7 +60,7 @@ describe('UPM Target', () => {
 
     test('publish', () => {
       return expect(
-        upmTarget.publish('version', 'revision')
+        upmTarget.publish('version', 'revision', true)
       ).resolves.not.toThrow();
     });
   });

--- a/src/targets/base.ts
+++ b/src/targets/base.ts
@@ -60,11 +60,12 @@ export class BaseTarget {
    *
    * @param version New version to be released
    * @param revision Git commit SHA to be published
+   * @param isLatest If this release should be marked as "latest"
    */
   public async publish(
     _version: string,
-
-    _revision: string
+    _revision: string,
+    _isLatest: boolean
   ): Promise<void> {
     throw new Error('Not implemented');
     return;

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -106,6 +106,7 @@ export class GitHubTarget extends BaseTarget {
   public async createDraftRelease(
     version: string,
     revision: string,
+    isLatest: boolean,
     changes?: Changeset
   ): Promise<GitHubRelease> {
     const tag = versionToTag(version, this.githubConfig.tagPrefix);
@@ -130,6 +131,7 @@ export class GitHubTarget extends BaseTarget {
       repo: this.githubConfig.repo,
       tag_name: tag,
       target_commitish: revision,
+      make_latest: isLatest && !isPreview ? 'true' : 'false',
       ...changes,
     });
     return data;
@@ -259,7 +261,7 @@ export class GitHubTarget extends BaseTarget {
     release: GitHubRelease,
     path: string,
     contentType?: string,
-    retries = 3,
+    retries = 3
   ): Promise<{ url: string; size: number }> {
     const contentTypeProcessed = contentType || DEFAULT_CONTENT_TYPE;
     const stats = statSync(path);
@@ -369,8 +371,13 @@ export class GitHubTarget extends BaseTarget {
    *
    * @param version New version to be released
    * @param revision Git commit SHA to be published
+   * @param isLatest If this release should be marked as latest
    */
-  public async publish(version: string, revision: string): Promise<any> {
+  public async publish(
+    version: string,
+    revision: string,
+    isLatest: boolean
+  ): Promise<any> {
     if (this.githubConfig.tagOnly) {
       this.logger.info(
         `Not creating a GitHub release because "tagOnly" flag was set.`
@@ -395,6 +402,7 @@ export class GitHubTarget extends BaseTarget {
     const draftRelease = await this.createDraftRelease(
       version,
       revision,
+      isLatest,
       changelog
     );
 

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -92,8 +92,13 @@ export class UpmTarget extends BaseTarget {
    *
    * @param version New version to be released
    * @param revision Git commit SHA to be published
+   * @param isLatest If this release should be marked as latest
    */
-  public async publish(version: string, revision: string): Promise<any> {
+  public async publish(
+    version: string,
+    revision: string,
+    isLatest: boolean
+  ): Promise<any> {
     this.logger.info('Fetching artifact...');
     const packageFile = await this.fetchArtifact(revision);
     if (!packageFile) {
@@ -147,6 +152,7 @@ export class UpmTarget extends BaseTarget {
           const draftRelease = await this.githubTarget.createDraftRelease(
             version,
             targetRevision,
+            isLatest,
             changes
           );
           await this.githubTarget.publishRelease(draftRelease);


### PR DESCRIPTION
This PR allows to add a new top-level config `latestTargetBranch`, which can be set to a branch name.

Only when merging into this branch name, will targets try to set the given release as "latest". 

Going forward, if your minVersion > 1.8.0, the default behavior will be to use the default branch as default value for this. For older minVersion, the current behavior will remain (=every release will be tagged as latest).

I have implemented this for:

* npm
* github

A few targets try to do this automatically already (e.g. registry or awsLambdaLayer update `latest.json` based on the previous version number). We can also add this for further targets that do this later (I don't know how all of them work) - but this is very much additive so we're safe to ignore this were it's not supported yet (=behavior will just remain the same).

Closes https://github.com/getsentry/craft/issues/498