### PR TITLE
feat(github): Only set `latest` when new version > old version

### DIFF
--- a/src/targets/__tests__/github.test.ts
+++ b/src/targets/__tests__/github.test.ts
@@ -1,0 +1,63 @@
+import { isLatestRelease } from '../github';
+
+describe('isLatestRelease', () => {
+  it('works with missing latest release', () => {
+    const latestRelease = undefined;
+    const version = '1.2.3';
+
+    const actual = isLatestRelease(latestRelease, version);
+    expect(actual).toBe(true);
+  });
+
+  it('works with unparseable latest release', () => {
+    const latestRelease = { tag_name: 'foo' };
+    const version = '1.2.3';
+
+    const actual = isLatestRelease(latestRelease, version);
+    expect(actual).toBe(true);
+  });
+
+  it('works with unparseable new version', () => {
+    const latestRelease = { tag_name: 'v1.0.0' };
+    const version = 'foo';
+
+    const actual = isLatestRelease(latestRelease, version);
+    expect(actual).toBe(true);
+  });
+
+  describe('with v-prefix', () => {
+    it('detects larger new version', () => {
+      const latestRelease = { tag_name: 'v1.1.0' };
+      const version = '1.2.0';
+
+      const actual = isLatestRelease(latestRelease, version);
+      expect(actual).toBe(true);
+    });
+
+    it('detects smaller new version', () => {
+      const latestRelease = { tag_name: 'v1.1.0' };
+      const version = '1.0.1';
+
+      const actual = isLatestRelease(latestRelease, version);
+      expect(actual).toBe(false);
+    });
+  });
+
+  describe('without v-prefix', () => {
+    it('detects larger new version', () => {
+      const latestRelease = { tag_name: '1.1.0' };
+      const version = '1.2.0';
+
+      const actual = isLatestRelease(latestRelease, version);
+      expect(actual).toBe(true);
+    });
+
+    it('detects smaller new version', () => {
+      const latestRelease = { tag_name: '1.1.0' };
+      const version = '1.0.1';
+
+      const actual = isLatestRelease(latestRelease, version);
+      expect(actual).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Automatically set `latest` for github releases only when the new version > the current latest version.
If we can't find a current latest, or something else goes wrong, we default to setting as latest.

Supersedes https://github.com/getsentry/craft/pull/502