### PR TITLE
install net7 in addition to net8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsof
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-8.0 \
+    dotnet-sdk-7.0 \
     docker-ce-cli \
     erlang \
     elixir \


### PR DESCRIPTION
> dotnet: Install the [7.0.100] .NET SDK or update [/github/workspace/__repo__/global.json] to match an installed SDK.

https://github.com/getsentry/publish/actions/runs/6962570877/job/18946542580

To release patches from the `main` branch we still need net7.

net8 is required for the feature branch/new major 4.0.0 that's going out with betas.

https://github.com/getsentry/publish/actions/runs/6962570877/job/18946542580