### PR TITLE
ref: handle comparison of two numeric pre releases

### DIFF
--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -182,6 +182,13 @@ describe('versionGreaterOrEqualThan', () => {
     expect(versionGreaterOrEqualThan(v2, v1)).toBe(true);
   });
 
+  test('can compare pre parts', () => {
+    const v1 = parseVersion('1.2.3-1')!;
+    const v2 = parseVersion('1.2.3-2')!;
+    expect(versionGreaterOrEqualThan(v1, v2)).toBe(false);
+    expect(versionGreaterOrEqualThan(v2, v1)).toBe(true);
+  });
+
   test('throws an exception if there are build parts', () => {
     const v1 = semVerFactory(0, 1, 2, undefined, 'build123');
     const v2 = semVerFactory(0, 1, 2);

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -81,20 +81,17 @@ export function parseVersion(text: string): SemVer | null {
 export function versionGreaterOrEqualThan(v1: SemVer, v2: SemVer): boolean {
   if (v1.major !== v2.major) {
     return v1.major > v2.major;
-  }
-  if (v1.minor !== v2.minor) {
+  } else if (v1.minor !== v2.minor) {
     return v1.minor > v2.minor;
-  }
-  if (v1.patch !== v2.patch) {
+  } else if (v1.patch !== v2.patch) {
     return v1.patch > v2.patch;
-  }
-  if (!v1.pre && v2.pre) {
+  } else if (!v1.pre && v2.pre) {
     return true;
-  }
-  if (v1.pre && !v2.pre) {
+  } else if (v1.pre && !v2.pre) {
     return false;
-  }
-  if (v1.build || v2.build || v1.pre || v2.pre) {
+  } else if (v1.pre && v2.pre && v1.pre !== v2.pre && /^\d+$/.test(v1.pre) && /^\d+$/.test(v2.pre)) {
+    return v1.pre > v2.pre;
+  } else if (v1.build || v2.build || v1.pre || v2.pre) {
     throw new Error(
       `Cannot compare the two versions: "${JSON.stringify(
         v1


### PR DESCRIPTION
fixes the problem found here: https://github.com/getsentry/publish/issues/3360#issuecomment-1927658029