### PR TITLE
build: Revert "build: Bump Dockerfile base image to node:20-bookworm (#511)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['20']
+        node: ['14', '16']
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm as builder
+FROM node:14-buster-slim as builder
 
 WORKDIR /usr/local/lib
 
@@ -15,7 +15,7 @@ RUN \
   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/lib/node_modules/.bin" \
   yarn --modules-folder /usr/local/lib/node_modules build
 
-FROM node:20-bookworm
+FROM node:14-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive \
   DOTNET_CLI_TELEMETRY_OPTOUT=1 \
@@ -38,18 +38,18 @@ RUN apt-get -qq update \
     twine \
     jq \
     unzip \
-    openjdk-17-jdk \
+    openjdk-11-jdk \
     maven \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 COPY Gemfile Gemfile.lock ./
 
-RUN curl -fsSL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
+RUN curl -fsSL https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb \
   && dpkg -i /tmp/packages-microsoft-prod.deb \
   && rm /tmp/packages-microsoft-prod.deb \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-  && echo 'deb [arch=amd64] https://download.docker.com/linux/debian bookworm stable' >> /etc/apt/sources.list \
+  && echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list \
   && curl -fsSL https://packages.erlang-solutions.com/debian/erlang_solutions.asc | apt-key add - \
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \


### PR DESCRIPTION
This reverts commit 58ef1840bd4de556964c2549fa75e7fee271d8d5.

After updating, we saw publishing failures in `sentry-android-gradle-plugin` and `sentry-cli`. Logs attached for posterity.

[gradle-plugin-4.3.0.zip](https://github.com/getsentry/craft/files/14222150/gradle-plugin-4.3.0.zip)
[sentry-cli-2.28.1.zip](https://github.com/getsentry/craft/files/14222151/sentry-cli-2.28.1.zip)
[sentry-cli-2.28.2.zip](https://github.com/getsentry/craft/files/14222152/sentry-cli-2.28.2.zip)
