### PR TITLE
fix: version test for equal pre-release versions

### DIFF
--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -195,6 +195,25 @@ describe('versionGreaterOrEqualThan', () => {
     expect(() => versionGreaterOrEqualThan(v1, v2)).toThrowError();
     expect(() => versionGreaterOrEqualThan(v2, v1)).toThrowError();
   });
+
+  test('can compare pre parts that are the same', () => {
+    let v1 = parseVersion('1.2.3-dev.0')!;
+    let v2 = parseVersion('1.2.3-dev.0')!;
+    expect(versionGreaterOrEqualThan(v1, v2)).toBe(true);
+    expect(versionGreaterOrEqualThan(v2, v1)).toBe(true);
+
+    v1 = parseVersion('1.2.3-dev.0+A')!;
+    v2 = parseVersion('1.2.3-dev.0+A')!;
+    expect(versionGreaterOrEqualThan(v1, v2)).toBe(true);
+    expect(versionGreaterOrEqualThan(v2, v1)).toBe(true);
+  });
+
+  test('can compare pre parts that are the same but have different builds', () => {
+    const v1 = parseVersion('1.2.3-dev.0+buildA')!;
+    const v2 = parseVersion('1.2.3-dev.0+buildB')!;
+    expect(versionGreaterOrEqualThan(v1, v2)).toBe(false);
+    expect(versionGreaterOrEqualThan(v2, v1)).toBe(false);
+  });
 });
 
 describe('getPackage', () => {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -89,6 +89,8 @@ export function versionGreaterOrEqualThan(v1: SemVer, v2: SemVer): boolean {
     return true;
   } else if (v1.pre && !v2.pre) {
     return false;
+  } else if (v1.pre && v2.pre && v1.pre === v2.pre) {
+    return v1.build === v2.build;
   } else if (v1.pre && v2.pre && v1.pre !== v2.pre && /^\d+$/.test(v1.pre) && /^\d+$/.test(v2.pre)) {
     return v1.pre > v2.pre;
   } else if (v1.build || v2.build || v1.pre || v2.pre) {
@@ -157,7 +159,6 @@ export function getPackageVersion(): string {
  * Returns the stringified version of the passed SemVer object.
  */
 export function semVerToString(s: SemVer) {
-  return `${s.major}.${s.minor}.${s.patch}${s.pre ? `-${s.pre}` : ''}${
-    s.build ? `+${s.build}` : ''
-  }`;
+  return `${s.major}.${s.minor}.${s.patch}${s.pre ? `-${s.pre}` : ''}${s.build ? `+${s.build}` : ''
+    }`;
 }


### PR DESCRIPTION
I've hit this when testing the compiled craft locally - it comes with version 1.11.0-dev.0 and even though you specify that as minVersion in .craft.yml, the check fails without the changes I've made here.