### PR TITLE
feat: Add `createdAt` key to json in registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.18.0
 
-- feat: Registry target now adds key `created` with current timestamp to json file
+- feat: Registry target now adds key `createdAt` with current timestamp to json file
 
 ## 1.17.2
 
@@ -112,7 +112,7 @@
 
 ### Various fixes & improvements
 
-- ref: Pin cocoapods version  (#496) by @brustolin
+- ref: Pin cocoapods version (#496) by @brustolin
 
 ## 1.6.0
 
@@ -128,14 +128,14 @@
 - build(deps): bump semver from 6.3.0 to 6.3.1 (#470) by @dependabot
 - build(deps): bump @babel/traverse from 7.22.5 to 7.23.2 (#494) by @dependabot
 - ref: remove volta from CI (#493) by @asottile-sentry
-- fix: Handle `{major}.json` and `{minor}.json`  symlinks when publishing older versions (#483) by @cleptric
+- fix: Handle `{major}.json` and `{minor}.json` symlinks when publishing older versions (#483) by @cleptric
 - Bump symbol collector 1.12.0 (#491) by @bruno-garcia
 
 ## 1.4.4
 
 ### Various fixes & improvements
 
-- fix(brew): Replace version in artifact names with '__VERSION__' to access checksums from mustache (#488) by @romtsn
+- fix(brew): Replace version in artifact names with '**VERSION**' to access checksums from mustache (#488) by @romtsn
 
 ## 1.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 1.18.0
-
-- feat: Registry target now adds key `createdAt` with current timestamp to json file
-
 ## 1.17.2
 
 - No documented changes.
@@ -112,7 +108,7 @@
 
 ### Various fixes & improvements
 
-- ref: Pin cocoapods version (#496) by @brustolin
+- ref: Pin cocoapods version  (#496) by @brustolin
 
 ## 1.6.0
 
@@ -128,14 +124,14 @@
 - build(deps): bump semver from 6.3.0 to 6.3.1 (#470) by @dependabot
 - build(deps): bump @babel/traverse from 7.22.5 to 7.23.2 (#494) by @dependabot
 - ref: remove volta from CI (#493) by @asottile-sentry
-- fix: Handle `{major}.json` and `{minor}.json` symlinks when publishing older versions (#483) by @cleptric
+- fix: Handle `{major}.json` and `{minor}.json`  symlinks when publishing older versions (#483) by @cleptric
 - Bump symbol collector 1.12.0 (#491) by @bruno-garcia
 
 ## 1.4.4
 
 ### Various fixes & improvements
 
-- fix(brew): Replace version in artifact names with '**VERSION**' to access checksums from mustache (#488) by @romtsn
+- fix(brew): Replace version in artifact names with '__VERSION__' to access checksums from mustache (#488) by @romtsn
 
 ## 1.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.18.0
+
+- feat: Registry target now adds key `created` with current timestamp to json file
+
 ## 1.17.2
 
 - No documented changes.

--- a/src/targets/__tests__/registry.test.ts
+++ b/src/targets/__tests__/registry.test.ts
@@ -1,0 +1,35 @@
+import { RegistryConfig, RegistryTarget } from '../registry';
+import { NoneArtifactProvider } from '../../artifact_providers/none';
+import { RegistryPackageType } from '../../utils/registry';
+
+describe('getUpdatedManifest', () => {
+  const target = new RegistryTarget(
+    { name: 'pypi' },
+    new NoneArtifactProvider(),
+    { owner: 'testSourceOwner', repo: 'testSourceRepo' }
+  );
+
+  it('check if createdAt exists', async () => {
+    const registryConfig: RegistryConfig = {
+      type: RegistryPackageType.SDK,
+      canonicalName: 'example-package',
+    };
+    const packageManifest = {
+      canonical: 'example-package',
+    };
+    const canonical = 'example-package';
+    const version = '1.2.3';
+    const revision = 'abc123';
+
+    const updatedManifest = await target.getUpdatedManifest(
+      registryConfig,
+      packageManifest,
+      canonical,
+      version,
+      revision
+    );
+
+    // check if property createdAt exists
+    expect(updatedManifest).toHaveProperty('createdAt');
+  });
+});

--- a/src/targets/__tests__/registry.test.ts
+++ b/src/targets/__tests__/registry.test.ts
@@ -1,8 +1,21 @@
+jest.mock('../../utils/githubApi.ts');
+import { getGitHubClient } from '../../utils/githubApi';
 import { RegistryConfig, RegistryTarget } from '../registry';
 import { NoneArtifactProvider } from '../../artifact_providers/none';
 import { RegistryPackageType } from '../../utils/registry';
 
 describe('getUpdatedManifest', () => {
+  let mockClient: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockClient = jest.fn();
+    (getGitHubClient as jest.MockedFunction<
+      typeof getGitHubClient
+      // @ts-ignore we only need to mock a subset
+    >).mockReturnValue({ graphql: mockClient });
+  });
+
   const target = new RegistryTarget(
     { name: 'pypi' },
     new NoneArtifactProvider(),

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -362,8 +362,11 @@ export class RegistryTarget extends BaseTarget {
       );
     }
     // Update the manifest
-    const updatedManifest: { [key: string]: any } = { ...packageManifest, version };
-    updatedManifest.created = new Date().toISOString();
+    const updatedManifest: { [key: string]: any } = {
+      ...packageManifest,
+      version,
+    };
+    updatedManifest.createdAt = new Date().toISOString();
 
     // Add file links if it's a generic app (legacy)
     if (registryConfig.type === RegistryPackageType.APP) {

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -362,11 +362,15 @@ export class RegistryTarget extends BaseTarget {
       );
     }
     // Update the manifest
-    const updatedManifest: { [key: string]: any } = {
+    const updatedManifest: {
+      version: string;
+      createdAt: string;
+      [key: string]: any;
+    } = {
       ...packageManifest,
       version,
+      createdAt: new Date().toISOString(),
     };
-    updatedManifest.createdAt = new Date().toISOString();
 
     // Add file links if it's a generic app (legacy)
     if (registryConfig.type === RegistryPackageType.APP) {

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -362,7 +362,8 @@ export class RegistryTarget extends BaseTarget {
       );
     }
     // Update the manifest
-    const updatedManifest = { ...packageManifest, version };
+    const updatedManifest: { [key: string]: any } = { ...packageManifest, version };
+    updatedManifest.created = new Date().toISOString();
 
     // Add file links if it's a generic app (legacy)
     if (registryConfig.type === RegistryPackageType.APP) {


### PR DESCRIPTION
We want to use the data from our release registry more, one info that is missing today is the timestamp of when something was released.
Yes, in theory, it exists in git, but just for convenience, we want to add a key `createdAt` into every JSON that the Registry target writes for easier access later.