### PR TITLE
fix(github): Fix making github releases latest or not

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -425,6 +425,7 @@ export class GitHubTarget extends BaseTarget {
         : 'No previous release found'
     );
 
+    // Preview versions should never be marked as latest
     const isPreview =
       this.githubConfig.previewReleases && isPreviewRelease(version);
     const makeLatest = isPreview

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -111,8 +111,7 @@ export class GitHubTarget extends BaseTarget {
   public async createDraftRelease(
     version: string,
     revision: string,
-    changes?: Changeset,
-    options: { makeLatest: boolean } = { makeLatest: true }
+    changes?: Changeset
   ): Promise<GitHubRelease> {
     const tag = versionToTag(version, this.githubConfig.tagPrefix);
     this.logger.info(`Git tag: "${tag}"`);
@@ -135,7 +134,6 @@ export class GitHubTarget extends BaseTarget {
       prerelease: isPreview,
       repo: this.githubConfig.repo,
       tag_name: tag,
-      make_latest: options.makeLatest ? 'true' : 'false',
       target_commitish: revision,
       ...changes,
     });
@@ -435,10 +433,7 @@ export class GitHubTarget extends BaseTarget {
     const draftRelease = await this.createDraftRelease(
       version,
       revision,
-      changelog,
-      {
-        makeLatest,
-      }
+      changelog
     );
 
     await Promise.all(

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -338,6 +338,7 @@ export class GitHubTarget extends BaseTarget {
     await this.github.repos.updateRelease({
       ...this.githubConfig,
       release_id: release.id,
+      // This is a string on purpose - see https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
       make_latest: options.makeLatest ? 'true' : 'false',
       draft: false,
     });


### PR DESCRIPTION
This PR updates the github release creation to ensure that the release is correctly marked as latest.

We used to set this for when we created the release draft, but according to https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release, this cannot actually be set on drafts. Instead, we need to set it when we publish the release.

There is also an option `legacy`, which, according to the docs, _seems_ like it may also work:

> `legacy` specifies that the latest release should be determined based on the release creation date and higher semantic version.

But since this option is a legacy option, _and_ since the behavior is a bit under-specced (e.g. if it determines based on creation date, it may be wrong, if it always uses semantic version, it may be correct), we decided to implement this consistently for ourselves.