### PR TITLE
fix(maven): properly handle non-maven github artifacts

### DIFF
--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -422,6 +422,8 @@ describe('upload', () => {
       .mockResolvedValueOnce('artifact/download/path');
     mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce('path/to/bomfile');
     mvnTarget.getPomFileInDist = jest.fn().mockResolvedValueOnce(undefined);
+    mvnTarget.folderExists = jest.fn().mockResolvedValueOnce(true);
+    mvnTarget.fileExists = jest.fn().mockResolvedValueOnce(true);
 
     await mvnTarget.upload('r3v1s10n');
 


### PR DESCRIPTION
Apparently maven artifact zip files contain a top level folder within the zip file, matching the basename of the zipped artifact. This PR ensures artifacts are unzipped without polluting each other and properly ignoring non-maven zip files without failing.