### PR TITLE
Upgrade Flutter from 3.10.0 to 3.13.0 in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN : \
   && chmod +x /usr/local/bin/SymbolCollector.Console
 
 # https://docs.flutter.dev/get-started/install/linux#install-flutter-manually
-RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.10.0-stable.tar.xz -o /opt/flutter.tar.xz \
+RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.0-stable.tar.xz -o /opt/flutter.tar.xz \
   && tar xf /opt/flutter.tar.xz -C /opt \
   && rm /opt/flutter.tar.xz
 


### PR DESCRIPTION
Currently Flutter `3.10.0` is packaged with Dart `3.0.0`.
Now we require Dart `3.1.0` which is packaged starting with Flutter `3.13.0`

See: https://github.com/getsentry/publish/actions/runs/9548988953/job/26317502315#step:11:104