### PR TITLE
feat: add skipValidation to dart publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1157,8 +1157,9 @@ For this target to work correctly, either `dart` must be installed on the system
 
 | Option        | Description                                                                                                                                                                                     |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dartCliPath` | **optional** Path to the Dart CLI. It must be executable by the calling process. Defaults to `dart`.                                                                                            |
-| `packages`    | **optional** List of directories to be released, relative to the root. Useful when a single repository contains multiple packages. When skipped, root directory is assumed as the only package. |
+| `dartCliPath`    | **optional** Path to the Dart CLI. It must be executable by the calling process. Defaults to `dart`.                                                                                            |
+| `packages`       | **optional** List of directories to be released, relative to the root. Useful when a single repository contains multiple packages. When skipped, root directory is assumed as the only package. |
+| `skipValidation` | **optional** Whether to skip validation, which is useful if there are known issues but you need to make a release anyway. |
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -1159,7 +1159,8 @@ For this target to work correctly, either `dart` must be installed on the system
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dartCliPath`    | **optional** Path to the Dart CLI. It must be executable by the calling process. Defaults to `dart`.                                                                                            |
 | `packages`       | **optional** List of directories to be released, relative to the root. Useful when a single repository contains multiple packages. When skipped, root directory is assumed as the only package. |
-| `skipValidation` | **optional** Whether to skip validation, which is useful if there are known issues but you need to make a release anyway. |
+| `skipValidation` | **optional** Publishes the package without going through validation steps, such as analyzer & dependency checks. This is useful in particular situations when package maintainers know why the validation fails and wish to side step the issue. For example, there may be analyzer issues due to not following the current (latest) dart SDK recommendation because the package needs to maintain the package compatibility with an old SDK version. 
+This option should be used with caution and only after testing and verifying the reported issue shouldn't affect the package. It is advisable to do an alpha pre-release to further reduce the chance of a potential negative impact. |
 
 **Example**
 

--- a/src/targets/__tests__/pubDev.test.ts
+++ b/src/targets/__tests__/pubDev.test.ts
@@ -99,6 +99,7 @@ describe('PubDev target configuration', () => {
       PUBDEV_REFRESH_TOKEN: DEFAULT_OPTION_VALUE,
       dartCliPath: 'dart',
       packages: ['.'],
+      skipValidation: false,
     });
   });
 
@@ -114,6 +115,7 @@ describe('PubDev target configuration', () => {
         dos: undefined,
         tres: undefined,
       },
+      skipValidation: true
     });
 
     expect(target.pubDevConfig).toStrictEqual({
@@ -121,6 +123,7 @@ describe('PubDev target configuration', () => {
       PUBDEV_REFRESH_TOKEN: 'refresh',
       dartCliPath: '/custom/path/dart',
       packages: ['uno', 'dos', 'tres'],
+      skipValidation: true,
     });
   });
 });
@@ -383,6 +386,25 @@ dependency_overrides:
     expect(spawnProcessMock).toHaveBeenCalledWith(
       'dart',
       ['pub', 'publish', '--force'],
+      {
+        cwd: `${TMP_DIR}/${pkg}`,
+      },
+      { showStdout: true }
+    );
+  });
+
+  test('should call `dart` cli with skip-validation if requesteed', async () => {
+    const pkg = 'uno';
+    const target = createPubDevTarget({ skipValidation: true });
+    await target.publishPackage(TMP_DIR, pkg);
+
+    const spawnProcessMock = spawnProcess as jest.MockedFunction<
+      typeof spawnProcess
+    >;
+
+    expect(spawnProcessMock).toHaveBeenCalledWith(
+      'dart',
+      ['pub', 'publish', '--force', '--skip-validation'],
       {
         cwd: `${TMP_DIR}/${pkg}`,
       },

--- a/src/targets/pubDev.ts
+++ b/src/targets/pubDev.ts
@@ -24,6 +24,8 @@ export interface PubDevTargetOptions {
   dartCliPath: string;
   /** List of directories to be released. Useful when a single repository contains multiple packages. */
   packages: string[];
+  /** Whether to skip validation */
+  skipValidation: boolean;
 }
 
 /**
@@ -69,6 +71,7 @@ export class PubDevTarget extends BaseTarget {
         ? Object.keys(this.config.packages)
         : ['.'],
       ...this.getTargetSecrets(),
+      skipValidation: this.config.skipValidation ?? false,
     };
 
     this.checkRequiredSoftware(config);
@@ -210,6 +213,10 @@ export class PubDevTarget extends BaseTarget {
           `Cannot remove dependency_overrides key from pubspec.yaml: ${e}`
         );
       }
+    }
+
+    if (this.pubDevConfig.skipValidation) {
+      args.push('--skip-validation');
     }
 
     await spawnProcess(


### PR DESCRIPTION
This will be necessary for a while because we keep the new dart core package `package:web` dependency implicit in order to keep the pacakge compatible with old Dart/Flutter SDK users. Some context in https://github.com/getsentry/sentry-dart/pull/2113