### PR TITLE
chore: update flutter to the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN : \
   && chmod +x /usr/local/bin/SymbolCollector.Console
 
 # https://docs.flutter.dev/get-started/install/linux#install-flutter-manually
-RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.13.0-stable.tar.xz -o /opt/flutter.tar.xz \
+RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.22.0-stable.tar.xz -o /opt/flutter.tar.xz \
   && tar xf /opt/flutter.tar.xz -C /opt \
   && rm /opt/flutter.tar.xz
 


### PR DESCRIPTION
This is required because we have an implicit dependency on a new core packate:web

```
Target of URI doesn't exist: 'package:web/web.dart'. Try creating the file referenced by the URI, or try using a URI for a file that does exist. - uri_does_not_exist
``` 