### PR TITLE
fix(maven): move `importGPGKey` function call from constructor to `publish`

### DIFF
--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -260,10 +260,11 @@ describe('Maven target configuration', () => {
     expect(typeof mvnTarget.config.kmp.appleDistDirRegex).toBe('string');
   });
 
-  test('import GPG private key if one is present in the environment', () => {
+  test('import GPG private key if one is present in the environment', async () => {
     setTargetSecretsInEnv();
     process.env.GPG_PRIVATE_KEY = DEFAULT_OPTION_VALUE;
-    createMavenTarget(getFullTargetConfig());
+    const mvnTarget = createMavenTarget(getFullTargetConfig());
+    await mvnTarget.publish('1.0.0', 'r3v1s10n');
     expect(importGPGKey).toHaveBeenCalledWith(DEFAULT_OPTION_VALUE);
   });
 });
@@ -371,7 +372,9 @@ describe('upload', () => {
       .fn()
       .mockResolvedValueOnce('artifact/download/path');
     mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(false);
-    mvnTarget.getPomFileInDist = jest.fn().mockResolvedValueOnce('pom-default.xml');
+    mvnTarget.getPomFileInDist = jest
+      .fn()
+      .mockResolvedValueOnce('pom-default.xml');
 
     await mvnTarget.upload('r3v1s10n');
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -263,7 +263,12 @@ describe('Maven target configuration', () => {
   test('import GPG private key if one is present in the environment', async () => {
     setTargetSecretsInEnv();
     process.env.GPG_PRIVATE_KEY = DEFAULT_OPTION_VALUE;
+    const callOrder: string[] = [];
     const mvnTarget = createMavenTarget(getFullTargetConfig());
+    mvnTarget.upload = jest.fn(async () => void callOrder.push('upload'));
+    mvnTarget.closeAndReleaseRepository = jest.fn(
+      async () => void callOrder.push('closeAndReleaseRepository')
+    );
     await mvnTarget.publish('1.0.0', 'r3v1s10n');
     expect(importGPGKey).toHaveBeenCalledWith(DEFAULT_OPTION_VALUE);
   });

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -378,6 +378,7 @@ describe('upload', () => {
       .mockResolvedValueOnce('artifact/download/path');
     mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(false);
     mvnTarget.getPomFileInDist = jest.fn().mockResolvedValueOnce('pom-default.xml');
+
     await mvnTarget.upload('r3v1s10n');
 
     expect(retrySpawnProcess).toHaveBeenCalledTimes(1);

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -377,10 +377,7 @@ describe('upload', () => {
       .fn()
       .mockResolvedValueOnce('artifact/download/path');
     mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(false);
-    mvnTarget.getPomFileInDist = jest
-      .fn()
-      .mockResolvedValueOnce('pom-default.xml');
-
+    mvnTarget.getPomFileInDist = jest.fn().mockResolvedValueOnce('pom-default.xml');
     await mvnTarget.upload('r3v1s10n');
 
     expect(retrySpawnProcess).toHaveBeenCalledTimes(1);

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -296,9 +296,7 @@ export class MavenTarget extends BaseTarget {
       this.logger.debug('Found POM: ', pomFile);
       await this.uploadPomDistribution(distDir);
     } else {
-      this.logger.warn(
-        `No BOM/POM file found in: ${distDir}, skipping directory`
-      );
+      this.logger.warn(`No BOM/POM file found in: ${distDir}, skipping directory`);
     }
   }
 
@@ -347,7 +345,7 @@ export class MavenTarget extends BaseTarget {
     } catch (error) {
       this.logger.warn(
         `Could not determine if path corresponds to a BOM file: ${pomFilepath}\n` +
-          'Error:\n',
+        'Error:\n',
         error
       );
       return false;
@@ -521,15 +519,9 @@ export class MavenTarget extends BaseTarget {
    * this function renames module.json to dist.module,
    * making it fit for mvn publishing.
    */
-  public async fixModuleFileName(
-    distDir: string,
-    moduleFile: string
-  ): Promise<void> {
+  public async fixModuleFileName(distDir: string, moduleFile: string): Promise<void> {
     const fallbackFile = join(distDir, 'module.json');
-    if (
-      !(await this.fileExists(moduleFile)) &&
-      (await this.fileExists(fallbackFile))
-    ) {
+    if (!await this.fileExists(moduleFile) && await this.fileExists(fallbackFile)) {
       await fsPromises.rename(fallbackFile, moduleFile);
     }
   }
@@ -579,7 +571,7 @@ export class MavenTarget extends BaseTarget {
       javadocFile: join(distDir, `${moduleName}-javadoc.jar`),
       sourcesFile: join(distDir, `${moduleName}-sources.jar`),
       pomFile: join(distDir, 'pom-default.xml'),
-      moduleFile: join(distDir, `${moduleName}.module`),
+      moduleFile: join(distDir, `${moduleName}.module`)
     };
   }
 

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -91,10 +91,6 @@ export class MavenTarget extends BaseTarget {
   ) {
     super(config, artifactProvider);
     this.mavenConfig = this.getMavenConfig();
-
-    if (process.env.GPG_PRIVATE_KEY) {
-      await importGPGKey(process.env.GPG_PRIVATE_KEY);
-    }
   }
 
   /**
@@ -236,6 +232,9 @@ export class MavenTarget extends BaseTarget {
    * @param revision Git commit SHA to be published.
    */
   public async publish(_version: string, revison: string): Promise<void> {
+    if (process.env.GPG_PRIVATE_KEY) {
+      await importGPGKey(process.env.GPG_PRIVATE_KEY);
+    }
     await this.upload(revison);
     await this.closeAndReleaseRepository();
   }
@@ -297,7 +296,9 @@ export class MavenTarget extends BaseTarget {
       this.logger.debug('Found POM: ', pomFile);
       await this.uploadPomDistribution(distDir);
     } else {
-      this.logger.warn(`No BOM/POM file found in: ${distDir}, skipping directory`);
+      this.logger.warn(
+        `No BOM/POM file found in: ${distDir}, skipping directory`
+      );
     }
   }
 
@@ -346,7 +347,7 @@ export class MavenTarget extends BaseTarget {
     } catch (error) {
       this.logger.warn(
         `Could not determine if path corresponds to a BOM file: ${pomFilepath}\n` +
-        'Error:\n',
+          'Error:\n',
         error
       );
       return false;
@@ -520,9 +521,15 @@ export class MavenTarget extends BaseTarget {
    * this function renames module.json to dist.module,
    * making it fit for mvn publishing.
    */
-  public async fixModuleFileName(distDir: string, moduleFile: string): Promise<void> {
+  public async fixModuleFileName(
+    distDir: string,
+    moduleFile: string
+  ): Promise<void> {
     const fallbackFile = join(distDir, 'module.json');
-    if (!await this.fileExists(moduleFile) && await this.fileExists(fallbackFile)) {
+    if (
+      !(await this.fileExists(moduleFile)) &&
+      (await this.fileExists(fallbackFile))
+    ) {
       await fsPromises.rename(fallbackFile, moduleFile);
     }
   }
@@ -572,7 +579,7 @@ export class MavenTarget extends BaseTarget {
       javadocFile: join(distDir, `${moduleName}-javadoc.jar`),
       sourcesFile: join(distDir, `${moduleName}-sources.jar`),
       pomFile: join(distDir, 'pom-default.xml'),
-      moduleFile: join(distDir, `${moduleName}.module`)
+      moduleFile: join(distDir, `${moduleName}.module`),
     };
   }
 

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -93,7 +93,7 @@ export class MavenTarget extends BaseTarget {
     this.mavenConfig = this.getMavenConfig();
 
     if (process.env.GPG_PRIVATE_KEY) {
-      importGPGKey(process.env.GPG_PRIVATE_KEY);
+      await importGPGKey(process.env.GPG_PRIVATE_KEY);
     }
   }
 


### PR DESCRIPTION
## Context
We have recently set up a multiple maven target setup in one of our repos: https://github.com/getsentry/sentry-kotlin-multiplatform/blob/main/.craft.yml

and noticed an error during publish that indicates an error within the `importGPGKey` function: https://github.com/getsentry/publish/actions/runs/10250810494/job/28357374501#step:11:166

## Fix

The `importGPGKey` function returns a promise but is not being awaited in the constructor (which is problematic when multiple targets are instantiated) and it cannot be awaited in a constructor so we move it to the publish call site