### PR TITLE
feat: Add #body-in-changelog option to PR/commit bodies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false
+    "source.organizeImports": "never"
   },
   "editor.formatOnType": true,
   "editor.formatOnSave": true,

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ contains any one of `preview`, `pre`, `rc`, `dev`,`alpha`, `beta`, `unstable`,
 
 | Name           | Description                                                        |
 | -------------- | ------------------------------------------------------------------ |
-| `GITHUB_TOKEN` | Personal GitHub API token (see https://github.com/settings/tokens) |
+| `GITHUB_TOKEN` | Personal GitHub API token (see <https://github.com/settings/tokens>) |
 
 **Configuration**
 
@@ -617,7 +617,7 @@ like [getsentry/pypi]
 
 | Name           | Description                                                        |
 | -------------- | ------------------------------------------------------------------ |
-| `GITHUB_TOKEN` | Personal GitHub API token (see https://github.com/settings/tokens) |
+| `GITHUB_TOKEN` | Personal GitHub API token (see <https://github.com/settings/tokens>) |
 
 **Configuration**
 
@@ -829,7 +829,7 @@ targets:
 
 ### Sentry Release Registry (`registry`)
 
-The target will update the Sentry release registry repo(https://github.com/getsentry/sentry-release-registry/) with the latest version of the
+The target will update the Sentry release registry repo(<https://github.com/getsentry/sentry-release-registry/>) with the latest version of the
 project `craft` is used with. The release registry repository will be checked out
 locally, and then the new version file will be created there, along with the necessary
 symbolic links.

--- a/src/utils/__tests__/changelog.test.ts
+++ b/src/utils/__tests__/changelog.test.ts
@@ -5,7 +5,7 @@ import { getGitHubClient } from '../githubApi';
 jest.mock('../git');
 import { getChangesSince } from '../git';
 
-import { SimpleGit } from 'simple-git';
+import type { SimpleGit } from 'simple-git';
 
 import {
   findChangeset,
@@ -13,6 +13,7 @@ import {
   prependChangeset,
   generateChangesetFromGit,
   SKIP_CHANGELOG_MAGIC_WORD,
+  BODY_IN_CHANGELOG_MAGIC_WORD,
 } from '../changelog';
 
 describe('findChangeset', () => {
@@ -702,6 +703,103 @@ describe('generateChangesetFromGit', () => {
         '',
         '### Various fixes & improvements',
         '',
+        '- Fix the clacking sound on gear changes (#950) by @alice',
+      ].join('\n'),
+    ],
+    [
+      `should expand commits & prs with the magic ${BODY_IN_CHANGELOG_MAGIC_WORD}`,
+      [
+        {
+          hash: 'abcdef1234567890',
+          title: 'Upgraded the kernel',
+          body: SKIP_CHANGELOG_MAGIC_WORD,
+        },
+        {
+          hash: 'bcdef1234567890a',
+          title: 'Upgraded the manifold (#123)',
+          body: '',
+          pr: {
+            local: '123',
+            remote: {
+              number: '123',
+              author: { login: 'alice' },
+              milestone: '1',
+            },
+          },
+        },
+        {
+          hash: 'cdef1234567890ab',
+          title: 'Refactored the crankshaft',
+          body: '',
+          pr: {
+            remote: {
+              number: '456',
+              author: { login: 'bob' },
+              body: `This is important and we'll include the __body__ for attention. ${BODY_IN_CHANGELOG_MAGIC_WORD}`,
+              milestone: '1',
+            },
+          },
+        },
+        {
+          hash: 'def1234567890abc',
+          title: 'Upgrade the HUD (#789)',
+          body: '',
+          pr: {
+            local: '789',
+            remote: {
+              number: '789',
+              author: { login: 'charlie' },
+              milestone: '5',
+            },
+          },
+        },
+        {
+          hash: 'ef1234567890abcd',
+          title: 'Upgrade the steering wheel (#900)',
+          body: `Some very important update ${BODY_IN_CHANGELOG_MAGIC_WORD}`,
+          pr: { local: '900' },
+        },
+        {
+          hash: 'f1234567890abcde',
+          title: 'Fix the clacking sound on gear changes (#950)',
+          body: '',
+          pr: {
+            local: '950',
+            remote: { number: '950', author: { login: 'alice' } },
+          },
+        },
+      ],
+      {
+        '1': {
+          title: 'Better drivetrain',
+          description:
+            'We have upgraded the drivetrain for a smoother and more performant driving experience. Enjoy!',
+          state: 'CLOSED',
+        },
+        '5': {
+          title: 'Better driver experience',
+          description:
+            'We are working on making your driving experience more pleasant and safer.',
+          state: 'OPEN',
+        },
+      },
+      [
+        '### Better drivetrain',
+        '',
+        'We have upgraded the drivetrain for a smoother and more performant driving experience. Enjoy!',
+        '',
+        'By: @alice (#123), @bob (#456)',
+        '',
+        '### Better driver experience (ongoing)',
+        '',
+        'We are working on making your driving experience more pleasant and safer.',
+        '',
+        'By: @charlie (#789)',
+        '',
+        '### Various fixes & improvements',
+        '',
+        '- Upgrade the steering wheel (#900)',
+        '  Some very important update ',
         '- Fix the clacking sound on gear changes (#950) by @alice',
       ].join('\n'),
     ],


### PR DESCRIPTION
Right now this is manually done by the getsentry/sentry-python team. I thought it was a good opportunity improve automatic changelog generation. Thanks to @sentrivana for the idea.
