### PR TITLE
fix(docker): install buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN : \
     dotnet-sdk-8.0 \
     dotnet-sdk-7.0 \
     docker-ce-cli \
+    docker-buildx-plugin \
     erlang \
     elixir \
   && apt-get clean \


### PR DESCRIPTION
https://github.com/getsentry/craft/pull/556 did not add buildx to the docker image - testing was done with a local install of craft using docker buildx on the host mac

failure surfaced here https://github.com/getsentry/publish/actions/runs/11374854272/job/31644383372

(the error says `docker: unknown flag: --tag` but it comes from `['buildx', 'imagetools', 'create', '--tag', targetImage, sourceImage],`)

previous success on sep 16 which was before that pr merged: https://github.com/getsentry/publish/actions/runs/10892013864/job/30224172979

this will probably fix but ci doesn't cover any of this