### PR TITLE
fix(utils): Ensure `isPreviewRelease` identifies `-dump` as a preview release

### DIFF
--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -120,12 +120,19 @@ describe('parseVersion', () => {
 });
 
 describe('isPreviewRelease', () => {
-  test('accepts semver preview release', () => {
-    expect(isPreviewRelease('2.3.4-preview1')).toBe(true);
-  });
+  test.each(['preview', 'pre', 'alpha.0', 'beta', 'rc.1', 'dev'])(
+    'accepts semver preview release',
+    previewSuffix => {
+      expect(isPreviewRelease(`2.3.4-${previewSuffix}1`)).toBe(true);
+    }
+  );
 
   test('accepts Python-style preview release', () => {
     expect(isPreviewRelease('2.3.4rc0')).toBe(true);
+  });
+
+  test('accepts dump preview release', () => {
+    expect(isPreviewRelease('2.3.4-dump1')).toBe(true);
   });
 
   test('does not accept non-preview release', () => {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -104,7 +104,7 @@ export function versionGreaterOrEqualThan(v1: SemVer, v2: SemVer): boolean {
 /**
  * A regular expression to detect that a version is a pre-release version.
  */
-export const PREVIEW_RELEASE_REGEX = /(?:[^a-z])(preview|pre|rc|dev|alpha|beta|unstable|a|b)(?:[^a-z]|$)/i;
+export const PREVIEW_RELEASE_REGEX = /(?:[^a-z])(preview|pre|rc|dev|alpha|beta|unstable|a|b|dump)(?:[^a-z]|$)/i;
 
 /**
  * Checks that the provided string is a pre-release version.


### PR DESCRIPTION
came up in: https://github.com/getsentry/sentry-docs/issues/11716

This PR adds `dump` to our pre-release detection regex, so that `isPreviewRelease()` check returns `true` for versions like `1.2.3-dump(.)1`. 

We had an internal discussion about choosing a more "wholistic" approach to detecting preview releases, like for example checking if there's any suffix to a typical semver `<major>.<minor>.<patch>` version. I'm also happy to implement this but I'm probably missing some context as to why we chose to opt in specific strings in the past. Perhaps the answer is that we can also handle non-semver version strings? Anyway, this should at least avoid the case brought up in https://github.com/getsentry/sentry-docs/issues/11716.