### PR TITLE
test(utils): Add additional tests for version helper functions

### DIFF
--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -42,6 +42,10 @@ describe('isValidVersion', () => {
     expect(isValidVersion('1.2.3rc1')).toBe(true);
   });
 
+  test('accepts valid Python-style post release version', () => {
+    expect(isValidVersion('1.2.3-1')).toBe(true);
+  });
+
   test('does not accept leading "v"', () => {
     expect(isValidVersion('v1.2.3')).toBe(false);
   });
@@ -110,6 +114,15 @@ describe('parseVersion', () => {
     });
   });
 
+  test('parses a Python-style post release version', () => {
+    expect(parseVersion('1.2.3-1')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      pre: '1',
+    });
+  });
+
   test('does not parse an invalid version', () => {
     expect(parseVersion('v1.2')).toBeNull();
   });
@@ -120,9 +133,12 @@ describe('parseVersion', () => {
 });
 
 describe('isPreviewRelease', () => {
-  test('accepts semver preview release', () => {
-    expect(isPreviewRelease('2.3.4-preview1')).toBe(true);
-  });
+  test.each(['preview', 'pre', 'alpha.0', 'beta', 'rc.1', 'dev'])(
+    'accepts semver preview release',
+    previewSuffix => {
+      expect(isPreviewRelease(`2.3.4-${previewSuffix}1`)).toBe(true);
+    }
+  );
 
   test('accepts Python-style preview release', () => {
     expect(isPreviewRelease('2.3.4rc0')).toBe(true);
@@ -134,6 +150,10 @@ describe('isPreviewRelease', () => {
 
   test('does not accept non-release strings', () => {
     expect(isPreviewRelease('4-preview')).toBe(false);
+  });
+
+  test('does not accept Python-style post release', () => {
+    expect(isPreviewRelease('1.2.3-1')).toBe(false);
   });
 });
 

--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -119,6 +119,8 @@ describe('parseVersion', () => {
       major: 1,
       minor: 2,
       patch: 3,
+      // we misinterpret the post release number as `pre` but this is fine as we
+      // have specific checks for what we consider a preview release
       pre: '1',
     });
   });


### PR DESCRIPTION
This PR adds some tests for version helper functions used in multiple craft targets.

This came up after investigating https://github.com/getsentry/sentry-docs/issues/11716 where I found out that we have a specific list of pre-release suffix identifiers that we consider a pre-release, instead of considering every kind of `-x` suffix as a pre-release. 

Specifically, as mentioned in https://github.com/getsentry/craft/pull/561#discussion_r1836934373,  we don't consider the (shorthand) python post release pattern (TIL) a pre-release, although `parseVersion` actually puts it into the returned `.pre` property. 

Tests added:
- `parseVersion` parses Python post release values
- `isValidVersion` returns `true` for Python post releases
- `isPreviewVersion` returns `false` for Python post releases
- More tests for `isPreviewVersion` returning `true` for allowed identifiers  

I don't have strong feelings on getting this merged, so feel free to reject it but I figured I might as well open a PR after having added these tests locally. 