### PR TITLE
Install .NET 9 SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN : \
   && echo 'deb https://packages.erlang-solutions.com/debian bullseye contrib' >> /etc/apt/sources.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
+    dotnet-sdk-9.0 \
     dotnet-sdk-8.0 \
     dotnet-sdk-7.0 \
     docker-ce-cli \


### PR DESCRIPTION
.NET 9 was released 4 days ago: https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview

The `main` branch still relies on older .NET versions, so keeping the current ones, and installing .NET 9

Once we merge this into `main`, we can remove the older versions.

* https://github.com/getsentry/sentry-dotnet/pull/3591

Unblocks: https://github.com/getsentry/publish/issues/4608 (an alpha release from a branch that will merge onto itself)

FYI @jamescrosswell