### PR TITLE
fix(github): Guard against missing release

### DIFF
--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -127,7 +127,7 @@ export class GitHubTarget extends BaseTarget {
       };
     }
 
-    let latestRelease: { tag_name: string } | undefined = undefined;
+    let latestRelease: { tag_name: string } | undefined;
     try {
       latestRelease = (
         await this.github.repos.getLatestRelease({

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -135,8 +135,12 @@ export class GitHubTarget extends BaseTarget {
           repo: this.githubConfig.repo,
         })
       ).data;
-    } catch {
-      // no release yet
+    } catch (error) {
+      // if the error is a 404 error, it means that no release exists yet
+      // all other errors should be rethrown
+      if (error.status !== 404) {
+        throw error;
+      }
     }
 
     const isLatest = isPreview

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -127,10 +127,17 @@ export class GitHubTarget extends BaseTarget {
       };
     }
 
-    const { data: latestRelease } = await this.github.repos.getLatestRelease({
-      owner: this.githubConfig.owner,
-      repo: this.githubConfig.repo,
-    });
+    let latestRelease: { tag_name: string } | undefined = undefined;
+    try {
+      latestRelease = (
+        await this.github.repos.getLatestRelease({
+          owner: this.githubConfig.owner,
+          repo: this.githubConfig.repo,
+        })
+      ).data;
+    } catch {
+      // no release yet
+    }
 
     const isLatest = isPreview
       ? false


### PR DESCRIPTION
Fixes https://github.com/getsentry/craft/pull/503#discussion_r1852239403

Note: We already have a test covering that `getLatestRelease()` accepts undefined.