### PR TITLE
Downgrade CocoaPods from 1.16.2 to 1.14.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@
 # Pin CocoaPods Version to avoid that bugs in CocoaPods like
 # https://github.com/CocoaPods/CocoaPods/issues/12081 break our release
 # workflow.
-gem "cocoapods", "= 1.16.2"
+# 1.16.2 has a bug that breaks the release workflow
+# Therefore, we stick to 1.14.2.
+gem "cocoapods", "= 1.14.2"


### PR DESCRIPTION
Rollback to 1.14.2 because 1.16.2 isn't working.