### PR TITLE
chore: Comment why we can't use cocoapods 1.16.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@
 # Pin CocoaPods Version to avoid that bugs in CocoaPods like
 # https://github.com/CocoaPods/CocoaPods/issues/12081 break our release
 # workflow.
-# 1.16.2 has a bug that breaks the release workflow
+# 1.16.2 has a bug that breaks the release workflow. Publishing with craft then
+# fails with:
+# - ERROR | [iOS] unknown: Encountered an unknown error (Unable to locate the
+#   executable `rsync`) during validation.
+# This could be related to https://github.com/CocoaPods/CocoaPods/issues/12674.
 # Therefore, we stick to 1.14.2.
 gem "cocoapods", "= 1.14.2"


### PR DESCRIPTION
Explain why we can't use cocoapods 1.16.2 and link a related GH issue.

Follow up on https://github.com/getsentry/craft/pull/569.