### PR TITLE
remove dotnet 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ RUN : \
   && apt-get install -y --no-install-recommends \
     dotnet-sdk-9.0 \
     dotnet-sdk-8.0 \
-    dotnet-sdk-7.0 \
     docker-ce-cli \
     docker-buildx-plugin \
     erlang \


### PR DESCRIPTION
.NET 9 was added here: https://github.com/getsentry/craft/pull/564/
.NET 8 still needed to publish v4

.NET 7 can go away