### PR TITLE
fix(aws-lambda): Remove `lambda:ListLayerVersions` permission as it breaks publishing

### DIFF
--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -83,13 +83,6 @@ export class AwsLambdaLayerManager {
       Action: 'lambda:GetLayerVersion',
       Principal: '*',
     });
-    await lambda.addLayerVersionPermission({
-      LayerName: this.layerName,
-      VersionNumber: publishedLayer.Version,
-      StatementId: 'public',
-      Action: 'lambda:ListLayerVersions',
-      Principal: '*',
-    });
 
     if (this.verboseInfo) {
       logger.info(`Published layer in ${region} for ${this.runtime.name}:


### PR DESCRIPTION
Since adding the `lambda:ListLayerVersions`, node layers have not been published correctly: https://github.com/getsentry/publish/actions/runs/12293170800/job/34305323121#step:11:1175

The python layers have not been released yet with version `2.3.0` of craft so are not affected.