### PR TITLE
feat: Allow prereleases in UPM target

### DIFF
--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -46,7 +46,6 @@ export class UpmTarget extends BaseTarget {
     const githubTargetConfig = {
       name: 'github',
       tagPrefix: config.tagPrefix,
-      previewReleases: false,
       owner: config.releaseRepoOwner,
       repo: config.releaseRepoName,
     };


### PR DESCRIPTION
When I added the UPM target `preview releases` were not even a thing I considered. There's no reason to force this to `false`.