### PR TITLE
fix(maven): Do not try to publish `.module` file when does not exist

### DIFF
--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -428,7 +428,7 @@ describe('upload', () => {
       .mockResolvedValueOnce('artifact/download/path');
     mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(false);
     mvnTarget.getPomFileInDist = jest.fn().mockResolvedValueOnce('pom-default.xml');
-    mvnTarget.fixModuleFileName = jest.fn().mockResolvedValueOnce(true);
+    mvnTarget.fileExists = jest.fn().mockResolvedValue(true);
 
     await mvnTarget.upload('r3v1s10n');
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -360,7 +360,7 @@ describe('transform KMP artifacts', () => {
 describe('upload', () => {
   const tmpDirName = 'tmpDir';
 
-  test('upload POM', async () => {
+  test('upload POM for Maven', async () => {
     // simple mock to always use the same temporary directory,
     // instead of creating a new one
     (withTempDir as jest.MockedFunction<typeof withTempDir>).mockImplementation(
@@ -378,6 +378,57 @@ describe('upload', () => {
       .mockResolvedValueOnce('artifact/download/path');
     mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(false);
     mvnTarget.getPomFileInDist = jest.fn().mockResolvedValueOnce('pom-default.xml');
+
+    await mvnTarget.upload('r3v1s10n');
+
+    expect(retrySpawnProcess).toHaveBeenCalledTimes(1);
+    const callArgs = (retrySpawnProcess as jest.MockedFunction<
+      typeof retrySpawnProcess
+    >).mock.calls[0];
+
+    expect(callArgs).toHaveLength(2);
+    expect(callArgs[0]).toEqual(DEFAULT_OPTION_VALUE);
+
+    const cmdArgs = callArgs[1] as string[];
+    expect(cmdArgs).toHaveLength(11);
+    expect(cmdArgs[0]).toBe('gpg:sign-and-deploy-file');
+    expect(cmdArgs[1]).toMatch(new RegExp(`-Dfile=${tmpDirName}.+`));
+    expect(cmdArgs[2]).toMatch(
+      new RegExp(
+        `-Dfiles=${tmpDirName}.+-javadoc\\.jar,${tmpDirName}.+-sources\\.jar`
+      )
+    );
+    expect(cmdArgs[3]).toBe(`-Dclassifiers=javadoc,sources`);
+    expect(cmdArgs[4]).toBe(`-Dtypes=jar,jar`);
+    expect(cmdArgs[5]).toMatch(
+      new RegExp(`-DpomFile=${tmpDirName}.+pom-default\\.xml`)
+    );
+    expect(cmdArgs[6]).toBe(`-DrepositoryId=${DEFAULT_OPTION_VALUE}`);
+    expect(cmdArgs[7]).toBe(`-Durl=${DEFAULT_OPTION_VALUE}`);
+    expect(cmdArgs[8]).toBe(`-Dgpg.passphrase=${DEFAULT_OPTION_VALUE}`);
+    expect(cmdArgs[9]).toBe('--settings');
+    expect(cmdArgs[10]).toBe(DEFAULT_OPTION_VALUE);
+  });
+
+  test('upload POM for Gradle', async () => {
+    // simple mock to always use the same temporary directory,
+    // instead of creating a new one
+    (withTempDir as jest.MockedFunction<typeof withTempDir>).mockImplementation(
+      async cb => {
+        return await cb(tmpDirName);
+      }
+    );
+
+    const mvnTarget = createMavenTarget();
+    mvnTarget.getArtifactsForRevision = jest
+      .fn()
+      .mockResolvedValueOnce([{ filename: 'mockArtifact.zip' }]);
+    mvnTarget.artifactProvider.downloadArtifact = jest
+      .fn()
+      .mockResolvedValueOnce('artifact/download/path');
+    mvnTarget.isBomFile = jest.fn().mockResolvedValueOnce(false);
+    mvnTarget.getPomFileInDist = jest.fn().mockResolvedValueOnce('pom-default.xml');
+    mvnTarget.fixModuleFileName = jest.fn().mockResolvedValueOnce(true);
 
     await mvnTarget.upload('r3v1s10n');
 

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -518,16 +518,12 @@ export class MavenTarget extends BaseTarget {
    * In case module.json exists but dist.module doesn't,
    * this function renames module.json to dist.module,
    * making it fit for mvn publishing.
-   *
-   * @returns true if the module.json file exists and was renamed, false otherwise
    */
-  public async fixModuleFileName(distDir: string, moduleFile: string): Promise<boolean> {
+  public async fixModuleFileName(distDir: string, moduleFile: string): Promise<void> {
     const fallbackFile = join(distDir, 'module.json');
     if (!await this.fileExists(moduleFile) && await this.fileExists(fallbackFile)) {
       await fsPromises.rename(fallbackFile, moduleFile);
-      return true;
     }
-    return false;
   }
 
   private async uploadPomDistribution(distDir: string): Promise<void> {
@@ -541,7 +537,8 @@ export class MavenTarget extends BaseTarget {
         pomFile,
         moduleFile,
       } = this.getFilesForMavenPomDist(distDir);
-      const hasModule = await this.fixModuleFileName(distDir, moduleFile);
+      await this.fixModuleFileName(distDir, moduleFile);
+      const hasModule = await this.fileExists(moduleFile);
 
       // Maven central is very flaky, so retrying with an exponential delay in
       // in case it fails.


### PR DESCRIPTION
We have some repositories that do not use Gradle for publishing and therefore do not have the `.module` file, so we''re just checking for its presence before mentioning it to the `./mvnw gpg...` command