### PR TITLE
fix:(GitHub Auth): Deprecate getAuthUsername

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/craft",
-  "version": "2.3.4",
+  "version": "2.4.0-dev.0",
   "description": "The universal sentry workflow CLI",
   "main": "dist/craft",
   "repository": "https://github.com/getsentry/craft",

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -141,7 +141,6 @@ export class AwsLambdaLayerTarget extends BaseTarget {
     await withTempDir(
       async directory => {
         const git = simpleGit(directory);
-        /** Add the GitHub token to the git auth header */
         this.logger.info(
           `Cloning ${remote.getRemoteString()} to ${directory}...`
         );

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -6,7 +6,6 @@ import simpleGit from 'simple-git';
 import {
   getGitHubClient,
   GitHubRemote,
-  getGitHubAuthHeader,
 } from '../utils/githubApi';
 
 import { TargetConfig } from '../schemas/project_config';
@@ -143,11 +142,10 @@ export class AwsLambdaLayerTarget extends BaseTarget {
       async directory => {
         const git = simpleGit(directory);
         /** Add the GitHub token to the git auth header */
-        await git.raw(getGitHubAuthHeader());
         this.logger.info(
           `Cloning ${remote.getRemoteString()} to ${directory}...`
         );
-        await git.clone(remote.getRemoteString(), directory);
+        await git.clone(remote.getRemoteStringWithAuth(), directory);
 
         if (!isDryRun()) {
           await this.publishRuntimes(

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -224,7 +224,6 @@ export class GhPagesTarget extends BaseTarget {
     const remote = new GitHubRemote(
       githubOwner,
       githubRepo,
-      getGitHubApiToken()
     );
 
     await withTempDir(

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -8,7 +8,6 @@ import { GitHubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
-  getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
   getGitHubAuthHeader,

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -10,7 +10,6 @@ import { withTempDir } from '../utils/files';
 import {
   getGitHubClient,
   GitHubRemote,
-  getGitHubAuthHeader,
 } from '../utils/githubApi';
 import { isDryRun } from '../utils/helpers';
 import { extractZipArchive } from '../utils/system';
@@ -147,13 +146,11 @@ export class GhPagesTarget extends BaseTarget {
     archivePath: string,
     version: string
   ): Promise<void> {
-    const git = simpleGit(directory);
-    /** Add the GitHub token to the git auth header */
-    await git.raw(getGitHubAuthHeader());
     this.logger.info(
       `Cloning "${remote.getRemoteString()}" to "${directory}"...`
     );
-    await git.clone(remote.getRemoteString(), directory);
+    await simpleGit().clone(remote.getRemoteStringWithAuth(), directory);
+    const git = simpleGit(directory);
     this.logger.debug(`Checking out branch: "${branch}"`);
     try {
       await git.checkout([branch]);

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -6,7 +6,6 @@ import { GitHubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
-  getGitHubAuthHeader,
   getGitHubClient,
   GitHubRemote,
 } from '../utils/githubApi';
@@ -429,11 +428,10 @@ export class RegistryTarget extends BaseTarget {
 
     const git = simpleGit(directory);
     /** Add the GitHub token to the git auth header */
-    await git.raw(getGitHubAuthHeader());
     this.logger.info(
       `Cloning "${remote.getRemoteString()}" to "${directory}"...`
     );
-    await git.clone(remote.getRemoteString(), directory, [
+    await git.clone(remote.getRemoteStringWithAuth(), directory, [
       '--filter=tree:0',
       '--single-branch',
     ]);

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -427,7 +427,6 @@ export class RegistryTarget extends BaseTarget {
     const remote = this.remote;
 
     const git = simpleGit(directory);
-    /** Add the GitHub token to the git auth header */
     this.logger.info(
       `Cloning "${remote.getRemoteString()}" to "${directory}"...`
     );

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -6,8 +6,7 @@ import { GitHubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
-  getAuthUsername,
-  getGitHubApiToken,
+  getGitHubAuthHeader,
   getGitHubClient,
   GitHubRemote,
 } from '../utils/githubApi';
@@ -427,14 +426,14 @@ export class RegistryTarget extends BaseTarget {
 
   private async cloneRegistry(directory: string): Promise<SimpleGit> {
     const remote = this.remote;
-    const username = await getAuthUsername(this.github);
-    remote.setAuth(username, getGitHubApiToken());
 
     const git = simpleGit(directory);
+    /** Add the GitHub token to the git auth header */
+    await git.raw(getGitHubAuthHeader());
     this.logger.info(
       `Cloning "${remote.getRemoteString()}" to "${directory}"...`
     );
-    await git.clone(remote.getRemoteStringWithAuth(), directory, [
+    await git.clone(remote.getRemoteString(), directory, [
       '--filter=tree:0',
       '--single-branch',
     ]);

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -110,7 +110,6 @@ export class UpmTarget extends BaseTarget {
     const remote = new GitHubRemote(
       this.config.releaseRepoOwner,
       this.config.releaseRepoName,
-      getGitHubApiToken()
     );
     const remoteAddr = remote.getRemoteString();
     this.logger.debug(`Target release repository: ${remoteAddr}`);

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -1,6 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
+  getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
 } from '../utils/githubApi';
@@ -108,6 +109,7 @@ export class UpmTarget extends BaseTarget {
     const remote = new GitHubRemote(
       this.config.releaseRepoOwner,
       this.config.releaseRepoName,
+      getGitHubApiToken()
     );
     const remoteAddr = remote.getRemoteString();
     this.logger.debug(`Target release repository: ${remoteAddr}`);

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -1,7 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
-  getGitHubAuthHeader,
   getGitHubClient,
   GitHubRemote,
 } from '../utils/githubApi';
@@ -116,10 +115,8 @@ export class UpmTarget extends BaseTarget {
     await withTempDir(
       async directory => {
         const git = simpleGit(directory);
-        /** Add the GitHub token to the git auth header */
-        await git.raw(getGitHubAuthHeader());
         this.logger.info(`Cloning ${remoteAddr} to ${directory}...`);
-        await git.clone(remote.getRemoteString(), directory);
+        await git.clone(remote.getRemoteStringWithAuth(), directory);
 
         this.logger.info('Clearing the repository.');
         await git.rm(['-r', '-f', '.']);

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -1,7 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
-  getGitHubApiToken,
   getGitHubAuthHeader,
   getGitHubClient,
   GitHubRemote,

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -12,10 +12,6 @@ export class GitHubRemote {
   public readonly owner: string;
   /** GitHub repository name */
   public readonly repo: string;
-  /** GitHub username */
-  protected username?: string;
-  /** GitHub personal authentication token */
-  protected apiToken?: string;
   /** GitHub hostname */
   protected readonly GITHUB_HOSTNAME: string = 'github.com';
   /** Protocol prefix */
@@ -26,8 +22,6 @@ export class GitHubRemote {
   public constructor(
     owner: string,
     repo: string,
-    username?: string,
-    apiToken?: string
   ) {
     this.owner = owner;
     this.repo = repo;

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -45,7 +45,7 @@ export class GitHubRemote {
   /**
    * Returns an HTTP-based git remote with embedded HTTP basic auth
    *
-   * Using dummy username as it does not matter for cloning
+   * Using placeholder username as it does not matter for cloning
    *
    * It MAY contain sensitive information (e.g. API tokens)
    */

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -31,20 +31,9 @@ export class GitHubRemote {
   ) {
     this.owner = owner;
     this.repo = repo;
-    if (apiToken) {
-      this.setAuth(apiToken);
-    }
     this.url = `/${this.owner}/${this.repo}/`;
   }
 
-  /**
-   * Sets authentication arguments: GitHubAPI token
-   *
-   * @param apiToken GitHub API token
-   */
-  public setAuth(apiToken: string): void {
-    this.apiToken = apiToken;
-  }
 
   /**
    * Returns an HTTP-based git remote

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -12,6 +12,8 @@ export class GitHubRemote {
   public readonly owner: string;
   /** GitHub repository name */
   public readonly repo: string;
+  /** GitHub personal authentication token */
+  protected apiToken?: string;
   /** GitHub hostname */
   protected readonly GITHUB_HOSTNAME: string = 'github.com';
   /** Protocol prefix */
@@ -22,9 +24,11 @@ export class GitHubRemote {
   public constructor(
     owner: string,
     repo: string,
+    apiToken?: string
   ) {
     this.owner = owner;
     this.repo = repo;
+    this.apiToken = apiToken;
     this.url = `/${this.owner}/${this.repo}/`;
   }
 
@@ -36,6 +40,21 @@ export class GitHubRemote {
    */
   public getRemoteString(): string {
     return this.PROTOCOL_PREFIX + this.GITHUB_HOSTNAME + this.url;
+  }
+
+  /**
+   * Returns an HTTP-based git remote with embedded HTTP basic auth
+   *
+   * Using dummy username as it does not matter for cloning
+   *
+   * It MAY contain sensitive information (e.g. API tokens)
+   */
+  public getRemoteStringWithAuth(): string {
+    const authData =
+      this.apiToken
+        ? `dummyusername:${this.apiToken}@`
+        : '';
+    return this.PROTOCOL_PREFIX + authData + this.GITHUB_HOSTNAME + this.url;
   }
 }
 
@@ -53,20 +72,6 @@ export function getGitHubApiToken(): string {
     );
   }
   return githubApiToken;
-}
-
-/**
- * Returns the GitHub auth header
- *
- * @returns GitHub auth header
- */
-export function getGitHubAuthHeader(): Array<string> {
-  return [
-    'config',
-    '--global',
-    'http.extraheader',
-    'AUTHORIZATION: bearer ' + getGitHubApiToken()
-  ];
 }
 
 const _GitHubClientCache: Record<string, Octokit> = {};

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -52,7 +52,7 @@ export class GitHubRemote {
   public getRemoteStringWithAuth(): string {
     const authData =
       this.apiToken
-        ? `dummyusername:${this.apiToken}@`
+        ? `placeholderusername:${this.apiToken}@`
         : '';
     return this.PROTOCOL_PREFIX + authData + this.GITHUB_HOSTNAME + this.url;
   }


### PR DESCRIPTION
Currently we are using `https://username:token@github/owner/repo` to perform auth will talking to GitHub, it does not work well with GitHub Apps, hence deprecating it and bake the authentication token into authentication headers.