### PR TITLE
fix(): GitHub username not found when pushing to registry

### DIFF
--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
-  getAuthUsername,
   getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
@@ -139,8 +138,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
     this.logger.trace('AWS regions: ', awsRegions);
 
     const remote = this.awsLambdaConfig.registryRemote;
-    const username = await getAuthUsername(this.github);
-    remote.setAuth(username, getGitHubApiToken());
+    remote.setAuth(getGitHubApiToken());
 
     await withTempDir(
       async directory => {

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
+  getAuthUsername,
+  getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
 } from '../utils/githubApi';
@@ -137,6 +139,8 @@ export class AwsLambdaLayerTarget extends BaseTarget {
     this.logger.trace('AWS regions: ', awsRegions);
 
     const remote = this.awsLambdaConfig.registryRemote;
+    const username = await getAuthUsername(this.github);
+    remote.setAuth(username, getGitHubApiToken());
 
     await withTempDir(
       async directory => {

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -8,6 +8,8 @@ import { GitHubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
+  getAuthUsername,
+  getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
 } from '../utils/githubApi';
@@ -217,9 +219,12 @@ export class GhPagesTarget extends BaseTarget {
       packageFiles[0]
     );
 
+    const username = await getAuthUsername(this.github);
     const remote = new GitHubRemote(
       githubOwner,
       githubRepo,
+      username,
+      getGitHubApiToken()
     );
 
     await withTempDir(

--- a/src/targets/ghPages.ts
+++ b/src/targets/ghPages.ts
@@ -8,7 +8,6 @@ import { GitHubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
-  getAuthUsername,
   getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
@@ -219,12 +218,9 @@ export class GhPagesTarget extends BaseTarget {
       packageFiles[0]
     );
 
-    const username = await getAuthUsername(this.github);
-
     const remote = new GitHubRemote(
       githubOwner,
       githubRepo,
-      username,
       getGitHubApiToken()
     );
 

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -6,7 +6,6 @@ import { GitHubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
-  getAuthUsername,
   getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
@@ -427,8 +426,7 @@ export class RegistryTarget extends BaseTarget {
 
   private async cloneRegistry(directory: string): Promise<SimpleGit> {
     const remote = this.remote;
-    const username = await getAuthUsername(this.github);
-    remote.setAuth(username, getGitHubApiToken());
+    remote.setAuth(getGitHubApiToken());
 
     const git = simpleGit(directory);
     this.logger.info(

--- a/src/targets/registry.ts
+++ b/src/targets/registry.ts
@@ -6,6 +6,8 @@ import { GitHubGlobalConfig, TargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import {
+  getAuthUsername,
+  getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
 } from '../utils/githubApi';
@@ -425,6 +427,8 @@ export class RegistryTarget extends BaseTarget {
 
   private async cloneRegistry(directory: string): Promise<SimpleGit> {
     const remote = this.remote;
+    const username = await getAuthUsername(this.github);
+    remote.setAuth(username, getGitHubApiToken());
 
     const git = simpleGit(directory);
     this.logger.info(

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -1,6 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
+  getAuthUsername,
   getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
@@ -106,9 +107,11 @@ export class UpmTarget extends BaseTarget {
       packageFile
     );
 
+    const username = await getAuthUsername(this.github);
     const remote = new GitHubRemote(
       this.config.releaseRepoOwner,
       this.config.releaseRepoName,
+      username,
       getGitHubApiToken()
     );
     const remoteAddr = remote.getRemoteString();

--- a/src/targets/upm.ts
+++ b/src/targets/upm.ts
@@ -1,7 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import simpleGit from 'simple-git';
 import {
-  getAuthUsername,
   getGitHubApiToken,
   getGitHubClient,
   GitHubRemote,
@@ -107,11 +106,9 @@ export class UpmTarget extends BaseTarget {
       packageFile
     );
 
-    const username = await getAuthUsername(this.github);
     const remote = new GitHubRemote(
       this.config.releaseRepoOwner,
       this.config.releaseRepoName,
-      username,
       getGitHubApiToken()
     );
     const remoteAddr = remote.getRemoteString();

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -26,13 +26,12 @@ export class GitHubRemote {
   public constructor(
     owner: string,
     repo: string,
-    username?: string,
     apiToken?: string
   ) {
     this.owner = owner;
     this.repo = repo;
-    if (username && apiToken) {
-      this.setAuth(username, apiToken);
+    if (apiToken) {
+      this.setAuth(apiToken);
     }
     this.url = `/${this.owner}/${this.repo}/`;
   }
@@ -43,8 +42,8 @@ export class GitHubRemote {
    * @param username GitHub username
    * @param apiToken GitHub API token
    */
-  public setAuth(username: string, apiToken: string): void {
-    this.username = username;
+  public setAuth(apiToken: string): void {
+    this.username = 'placeholderusername';
     this.apiToken = apiToken;
   }
 
@@ -121,23 +120,6 @@ export function getGitHubClient(token = ''): Octokit {
   }
 
   return _GitHubClientCache[githubApiToken];
-}
-
-/**
- * Gets the currently authenticated GitHub user from the client
- *
- * @param github GitHub client
- * @returns GitHub username
- */
-export async function getAuthUsername(github: Octokit): Promise<string> {
-  const userData = await github.users.getAuthenticated({});
-  const username = (userData.data || {}).login;
-  if (!username) {
-    // If no user is tied to the token, return a placeholder username
-    // The value should not matter as long as it's not empty
-    return 'placeholderusername';
-  }
-  return username;
 }
 
 /**

--- a/src/utils/githubApi.ts
+++ b/src/utils/githubApi.ts
@@ -133,7 +133,9 @@ export async function getAuthUsername(github: Octokit): Promise<string> {
   const userData = await github.users.getAuthenticated({});
   const username = (userData.data || {}).login;
   if (!username) {
-    throw new Error('Cannot reliably detect GitHub username, aborting');
+    // If no user is tied to the token, return a placeholder username
+    // The value should not matter as long as it's not empty
+    return 'placeholderusername';
   }
   return username;
 }


### PR DESCRIPTION
Restore `getAuthUsername` and pass `placeholderusername` if not found

Locally tested it with Simple-git and a GitHub App token.  Confirmed Anthony's theory that the `username` field in `https://username:token@github.com/owner/repo.git` does not matter for both clone and push, so returning `placeholderusername` when no user is tied to a token, which usually is the case when it's a GitHub App token.