### PR TITLE
feat: Install most recent Erlang from RabbitMQ packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim as builder
+FROM node:22-bookworm-slim AS builder
 
 WORKDIR /usr/local/lib
 
@@ -27,20 +27,20 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get -qq update \
   && apt-get install -y --no-install-recommends \
-    apt-transport-https \
-    build-essential \
-    curl \
-    default-jdk-headless \
-    dirmngr \
-    gnupg \
-    git \
-    jq \
-    python3-packaging \
-    python3-venv \
-    rsync \
-    ruby-full \
-    unzip \
-    maven \
+  apt-transport-https \
+  build-essential \
+  curl \
+  default-jdk-headless \
+  dirmngr \
+  gnupg \
+  git \
+  jq \
+  python3-packaging \
+  python3-venv \
+  rsync \
+  ruby-full \
+  unzip \
+  maven \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -58,16 +58,21 @@ RUN : \
   # Note we use the Erlang Solutions-provided binaries as the ones in Debian were too old
   # This may have changed and we may want to revert back to official Debian packages
   # See https://www.erlang-solutions.com/downloads/#
-  && curl -fsSL https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc | apt-key add - \
-  && echo "deb https://binaries2.erlang-solutions.com/debian bullseye-elixir-1.15 contrib" >> /etc/apt/sources.list \
+  ## Team RabbitMQ's main signing key
+  && curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor | tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null \
+  ## Community mirror of Cloudsmith: modern Erlang repository
+  && curl -1sLf https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key | gpg --dearmor | tee /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg > /dev/null \
+  ## Add apt repositories maintained by Team RabbitMQ
+  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/debian bookworm main" >> /etc/apt/sources.list.d/erlang.list \
+  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/debian bookworm main" >> /etc/apt/sources.list.d/erlang.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
-    dotnet-sdk-9.0 \
-    dotnet-sdk-8.0 \
-    docker-ce-cli \
-    docker-buildx-plugin \
-    erlang \
-    elixir \
+  dotnet-sdk-9.0 \
+  dotnet-sdk-8.0 \
+  docker-ce-cli \
+  docker-buildx-plugin \
+  erlang \
+  elixir \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --  --profile minimal -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,9 @@ RUN : \
   && rm /tmp/packages-microsoft-prod.deb \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
   && echo "deb [arch=amd64] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" >> /etc/apt/sources.list \
-  # Note we use the Erlang Solutions-provided binaries as the ones in Debian were too old
-  # This may have changed and we may want to revert back to official Debian packages
-  # See https://www.erlang-solutions.com/downloads/#
+  # We are using RabbitMQ's Erlang repository to get the latest Erlang version
+  # https://www.rabbitmq.com/docs/install-debian
+  # https://github.com/rabbitmq/erlang-debian-package
   ## Team RabbitMQ's main signing key
   && curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor | tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null \
   ## Community mirror of Cloudsmith: modern Erlang repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,20 +27,20 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get -qq update \
   && apt-get install -y --no-install-recommends \
-  apt-transport-https \
-  build-essential \
-  curl \
-  default-jdk-headless \
-  dirmngr \
-  gnupg \
-  git \
-  jq \
-  python3-packaging \
-  python3-venv \
-  rsync \
-  ruby-full \
-  unzip \
-  maven \
+    apt-transport-https \
+    build-essential \
+    curl \
+    default-jdk-headless \
+    dirmngr \
+    gnupg \
+    git \
+    jq \
+    python3-packaging \
+    python3-venv \
+    rsync \
+    ruby-full \
+    unzip \
+    maven \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -67,12 +67,12 @@ RUN : \
   && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/debian bookworm main" >> /etc/apt/sources.list.d/erlang.list \
   && apt-get update -qq \
   && apt-get install -y --no-install-recommends \
-  dotnet-sdk-9.0 \
-  dotnet-sdk-8.0 \
-  docker-ce-cli \
-  docker-buildx-plugin \
-  erlang \
-  elixir \
+    dotnet-sdk-9.0 \
+    dotnet-sdk-8.0 \
+    docker-ce-cli \
+    docker-buildx-plugin \
+    erlang \
+    elixir \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --  --profile minimal -y \


### PR DESCRIPTION
This should fix the Elixir release issues: https://github.com/getsentry/publish/actions/runs/13697376301/job/38302799587#step:12:94
