### PR TITLE
ref: Bump twine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get -qq update \
 
 COPY Gemfile Gemfile.lock ./
 
-RUN python3 -m venv /venv && pip install twine==5.0.0 pkginfo==1.10.0 --no-cache
+RUN python3 -m venv /venv && pip install twine==6.1.0 pkginfo==1.12.1.2 --no-cache
 
 RUN : \
   && . /etc/os-release \


### PR DESCRIPTION
Our CI workflows for getsentry/streams and getsentry/arroyo most
recently started to write wheel metadata that is not compatible with
this version of twine.

We could pin wheel in arroyo and streams, but most likely other
workflows are also broken.
