### PR TITLE
chore: Update CocoaPods from 1.14.2 to 1.16.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,4 @@
 # Pin CocoaPods Version to avoid that bugs in CocoaPods like
 # https://github.com/CocoaPods/CocoaPods/issues/12081 break our release
 # workflow.
-# 1.16.2 has a bug that breaks the release workflow. Publishing with craft then
-# fails with:
-# - ERROR | [iOS] unknown: Encountered an unknown error (Unable to locate the
-#   executable `rsync`) during validation.
-# This could be related to https://github.com/CocoaPods/CocoaPods/issues/12674.
-# Therefore, we stick to 1.14.2.
-gem "cocoapods", "= 1.14.2"
+gem "cocoapods", "= 1.16.2"


### PR DESCRIPTION
We added the missing rsync dependency via GH-575. We can update CocoaPods now.

It's complicated to test if the fix actually works when releasing the Cocoa SDK. In the worst case, we have to rollback to 1.14.2 and publish another release.

Fixes GH-573