### PR TITLE
feat(pypi): use `--skip-existing` flag when uploading to pypi

### DIFF
--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -66,7 +66,7 @@ export class PypiTarget extends BaseTarget {
 
   async uploadAssets(paths: string[]): Promise<any> {
     // TODO: Sign the package with "--sign"
-    return spawnProcess(TWINE_BIN, ['upload', ...paths]);
+    return spawnProcess(TWINE_BIN, ['upload', '--skip-existing', ...paths]);
   }
 
   /**


### PR DESCRIPTION
When a publish action partially succeeds for Pypi, it becomes very cumbersome to fix the issue. 
Re-running the action fails because some files already exist, so we would have to either upload the missing files manually or create a new version which then hopefully succeeds uploading all files.

To enable smooth retries for publish, we can add the `--skip-existing` flag, which will just continue to upload all files that are not present.

For context, the latest publish action for symbolic succeeded at uploading the `whl` files but failed to upload the source archive and there is no easy way to just retry. 

Initial publish: https://github.com/getsentry/publish/actions/runs/14335484402/job/40181341681
Retried publish: https://github.com/getsentry/publish/actions/runs/14356458244/job/40246910505

Twine docs: https://twine.readthedocs.io/en/stable/#twine-upload

