### PR TITLE
fix: Avoid global.json when running `dotnet push`

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -66,7 +66,7 @@ export class NugetTarget extends BaseTarget {
    * @returns A promise that resolves when the upload has completed
    */
   public async uploadAsset(path: string): Promise<any> {
-    return spawnProcess(NUGET_DOTNET_BIN, [
+    const args = [
       'nuget',
       'push',
       path,
@@ -74,7 +74,11 @@ export class NugetTarget extends BaseTarget {
       '${NUGET_API_TOKEN}',
       '--source',
       this.nugetConfig.serverUrl,
-    ]);
+    ];
+    // Run this outside the repository folder to avoid global.json constraints
+    // (we don't need specific dotnet/workload versions to upload to nuget)
+    const spawnOptions = { cwd: '/tmp/' };
+    return spawnProcess(NUGET_DOTNET_BIN, args, spawnOptions);
   }
 
   /**

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -75,9 +75,9 @@ export class NugetTarget extends BaseTarget {
       '--source',
       this.nugetConfig.serverUrl,
     ];
-    // Run this outside the repository folder to avoid global.json constraints
-    // (we don't need specific dotnet/workload versions to upload to nuget)
-    const spawnOptions = { cwd: '/tmp/' };
+    // Run outside the repository folder to avoid global.json constraints
+    // (we don't need specific dotnet/workload versions just to upload to nuget)
+    const spawnOptions = { cwd: '/' };
     return spawnProcess(NUGET_DOTNET_BIN, args, spawnOptions);
   }
 


### PR DESCRIPTION
Resolves #598:
- https://github.com/getsentry/craft/issues/598

Pinning the version of of the .NET SDK used to build the sentry-dotnet repo prevents us from making relases, since that version of .NET is not installed on the machine that publishes NuGet packages.

We can run `dotnet push` using any version of .NET so this PR simply runs that command from outside the repository working directory.