### PR TITLE
fix(aws): make reading/writing of aws manifest consistent with other packages

### DIFF
--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -316,13 +316,12 @@ export class AwsLambdaLayerTarget extends BaseTarget {
 
         if (!fs.existsSync(baseFilepath)) {
           this.logger.warn(`The ${runtime.name} base file is missing.`);
-          fs.writeFileSync(newVersionFilepath, JSON.stringify(runtimeData));
+          const manifestString = JSON.stringify(runtimeData, undefined, 2) + '\n';
+          fs.writeFileSync(newVersionFilepath, manifestString);
         } else {
-          const baseData = JSON.parse(fs.readFileSync(baseFilepath).toString());
-          fs.writeFileSync(
-            newVersionFilepath,
-            JSON.stringify({ ...baseData, ...runtimeData })
-          );
+          const baseData = JSON.parse(fs.readFileSync(baseFilepath, { encoding: 'utf-8' }).toString());
+          const manifestString = JSON.stringify({ ...baseData, ...runtimeData }, undefined, 2) + '\n';
+          fs.writeFileSync(newVersionFilepath, manifestString);
         }
 
         this.createVersionSymlinks(runtimeBaseDir, version, newVersionFilepath);


### PR DESCRIPTION
see the corresponding implementation here for all other packages:
https://github.com/getsentry/craft/blob/f4949f4b275e495e949bfd88e50125f284680446/src/utils/registry.ts#L41-L43
https://github.com/getsentry/craft/blob/f4949f4b275e495e949bfd88e50125f284680446/src/utils/registry.ts#L62

mainly the newline at the end was missing which was causing the aws endpoint failures I think.