### PR TITLE
chore(maven): Update base url to support publishing to central portal

### DIFF
--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -21,7 +21,7 @@ const BOM_FILE_KEY_REGEXP = new RegExp('<packaging>pom</packaging>');
 
 // TODO: Make it configurable to allow for sentry-clj releases?
 export const NEXUS_API_BASE_URL =
-  'https://oss.sonatype.org/service/local/staging';
+  'https://ossrh-staging-api.central.sonatype.com/service/local/staging';
 const NEXUS_RETRY_DELAY = 10 * 1000; // 10s
 const NEXUS_RETRY_DEADLINE = 60 * 60 * 1000; // 60min
 


### PR DESCRIPTION
This is a [temporary measure](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api) until we start supporting publishing to the central repo in #606.