### PR TITLE
feat(maven): add new config to process klib distributions differently from root and apple

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Options:
   -h, --help     Show help                                             [boolean]
 ```
 
-
 ### Version naming conventions
 
 Craft currently supports [semantic versioning (semver)](https://semver.org)-like versions for the `NEW-VERSION` argument passed to its `prepare` and `publish` commands. This means, releases made with craft need to follow a general pattern as follows:
@@ -145,7 +144,6 @@ Examples:
 ```
 
 #### Special Case: Python Post Releases
-
 
 Python has the concept of post releases, which craft handles implicitly. A post release is indicated by a `-\d+` suffix to the semver version, for example: `1.0.0-1`.
 Given that we only consider certain identifiers as [pre-releases](#preview-releases-prerelease), post releases are considered stable releases.
@@ -578,8 +576,8 @@ contains any one of [pre-release identifiers](#preview-releases-prerelease).
 
 **Environment**
 
-| Name           | Description                                                        |
-| -------------- | ------------------------------------------------------------------ |
+| Name           | Description                                                          |
+| -------------- | -------------------------------------------------------------------- |
 | `GITHUB_TOKEN` | Personal GitHub API token (see <https://github.com/settings/tokens>) |
 
 **Configuration**
@@ -621,10 +619,10 @@ The `npm` utility must be installed on the system.
 
 **Configuration**
 
-| Option             | Description                                                                                                                     |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `access`           | **optional**. Visibility for scoped packages: `restricted` (default) or `public`                                                |
-| `checkPackageName` | **optional**. If defined, check this package on the registry to get the current latest version to compare for the `latest` tag. The package(s) to be published will only be tagged with `latest` if the new version is greater than the checked package's version|
+| Option             | Description                                                                                                                                                                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `access`           | **optional**. Visibility for scoped packages: `restricted` (default) or `public`                                                                                                                                                                                  |
+| `checkPackageName` | **optional**. If defined, check this package on the registry to get the current latest version to compare for the `latest` tag. The package(s) to be published will only be tagged with `latest` if the new version is greater than the checked package's version |
 
 **Example**
 
@@ -669,8 +667,8 @@ like [getsentry/pypi]
 
 **Environment**
 
-| Name           | Description                                                        |
-| -------------- | ------------------------------------------------------------------ |
+| Name           | Description                                                          |
+| -------------- | -------------------------------------------------------------------- |
 | `GITHUB_TOKEN` | Personal GitHub API token (see <https://github.com/settings/tokens>) |
 
 **Configuration**
@@ -1164,6 +1162,7 @@ targets:
     kmp:
       rootDistDirRegex: /sentry-kotlin-multiplatform-[0-9]+.*$/
       appleDistDirRegex: /sentry-kotlin-multiplatform-(macos|ios|tvos|watchos).*/
+      klibDistDirRegex: /sentry-kotlin-multiplatform-(js|wasm-js).*/
 ```
 
 ### Symbol Collector (`symbol-collector`)
@@ -1208,10 +1207,10 @@ For this target to work correctly, either `dart` must be installed on the system
 
 **Configuration**
 
-| Option        | Description                                                                                                                                                                                     |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dartCliPath`    | **optional** Path to the Dart CLI. It must be executable by the calling process. Defaults to `dart`.                                                                                            |
-| `packages`       | **optional** List of directories to be released, relative to the root. Useful when a single repository contains multiple packages. When skipped, root directory is assumed as the only package. |
+| Option           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dartCliPath`    | **optional** Path to the Dart CLI. It must be executable by the calling process. Defaults to `dart`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `packages`       | **optional** List of directories to be released, relative to the root. Useful when a single repository contains multiple packages. When skipped, root directory is assumed as the only package.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `skipValidation` | **optional** Publishes the package without going through validation steps, such as analyzer & dependency checks. <br /> This is useful in particular situations when package maintainers know why the validation fails and wish to side step the issue. For example, there may be analyzer issues due to not following the current (latest) dart SDK recommendation because the package needs to maintain the package compatibility with an old SDK version. <br /> This option should be used with caution and only after testing and verifying the reported issue shouldn't affect the package. It is advisable to do an alpha pre-release to further reduce the chance of a potential negative impact. |
 
 **Example**
@@ -1293,17 +1292,17 @@ The extracted directory is then published as a module.
 
 The `pwsh` executable [must be installed](https://github.com/powershell/powershell#get-powershell) on the system.
 
-| Name                 | Description                                          | Default   |
-| -------------------- | ---------------------------------------------------- | --------- |
-| `POWERSHELL_API_KEY` | **required** PowerShell Gallery API key              |           |
-| `POWERSHELL_BIN`     | **optional** Path to PowerShell binary               | `pwsh`    |
+| Name                 | Description                             | Default |
+| -------------------- | --------------------------------------- | ------- |
+| `POWERSHELL_API_KEY` | **required** PowerShell Gallery API key |         |
+| `POWERSHELL_BIN`     | **optional** Path to PowerShell binary  | `pwsh`  |
 
 #### Configuration
 
-| Option               | Description                                          | Default   |
-| -------------------- | ---------------------------------------------------- | --------- |
-| `module`             | **required** Module name.                            |           |
-| `repository`         | **optional** Repository to publish the package to.   | PSGallery |
+| Option       | Description                                        | Default   |
+| ------------ | -------------------------------------------------- | --------- |
+| `module`     | **required** Module name.                          |           |
+| `repository` | **optional** Repository to publish the package to. | PSGallery |
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,7 @@ targets:
     kmp:
       rootDistDirRegex: /sentry-kotlin-multiplatform-[0-9]+.*$/
       appleDistDirRegex: /sentry-kotlin-multiplatform-(macos|ios|tvos|watchos).*/
+      klibDistDirRegex: /sentry-kotlin-multiplatform-(js|wasm-js).*/
 ```
 
 ### Symbol Collector (`symbol-collector`)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Options:
   -h, --help     Show help                                             [boolean]
 ```
 
+
 ### Version naming conventions
 
 Craft currently supports [semantic versioning (semver)](https://semver.org)-like versions for the `NEW-VERSION` argument passed to its `prepare` and `publish` commands. This means, releases made with craft need to follow a general pattern as follows:
@@ -144,6 +145,7 @@ Examples:
 ```
 
 #### Special Case: Python Post Releases
+
 
 Python has the concept of post releases, which craft handles implicitly. A post release is indicated by a `-\d+` suffix to the semver version, for example: `1.0.0-1`.
 Given that we only consider certain identifiers as [pre-releases](#preview-releases-prerelease), post releases are considered stable releases.
@@ -576,8 +578,8 @@ contains any one of [pre-release identifiers](#preview-releases-prerelease).
 
 **Environment**
 
-| Name           | Description                                                          |
-| -------------- | -------------------------------------------------------------------- |
+| Name           | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
 | `GITHUB_TOKEN` | Personal GitHub API token (see <https://github.com/settings/tokens>) |
 
 **Configuration**
@@ -619,10 +621,10 @@ The `npm` utility must be installed on the system.
 
 **Configuration**
 
-| Option             | Description                                                                                                                                                                                                                                                       |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `access`           | **optional**. Visibility for scoped packages: `restricted` (default) or `public`                                                                                                                                                                                  |
-| `checkPackageName` | **optional**. If defined, check this package on the registry to get the current latest version to compare for the `latest` tag. The package(s) to be published will only be tagged with `latest` if the new version is greater than the checked package's version |
+| Option             | Description                                                                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `access`           | **optional**. Visibility for scoped packages: `restricted` (default) or `public`                                                |
+| `checkPackageName` | **optional**. If defined, check this package on the registry to get the current latest version to compare for the `latest` tag. The package(s) to be published will only be tagged with `latest` if the new version is greater than the checked package's version|
 
 **Example**
 
@@ -667,8 +669,8 @@ like [getsentry/pypi]
 
 **Environment**
 
-| Name           | Description                                                          |
-| -------------- | -------------------------------------------------------------------- |
+| Name           | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
 | `GITHUB_TOKEN` | Personal GitHub API token (see <https://github.com/settings/tokens>) |
 
 **Configuration**
@@ -1162,7 +1164,6 @@ targets:
     kmp:
       rootDistDirRegex: /sentry-kotlin-multiplatform-[0-9]+.*$/
       appleDistDirRegex: /sentry-kotlin-multiplatform-(macos|ios|tvos|watchos).*/
-      klibDistDirRegex: /sentry-kotlin-multiplatform-(js|wasm-js).*/
 ```
 
 ### Symbol Collector (`symbol-collector`)
@@ -1207,10 +1208,10 @@ For this target to work correctly, either `dart` must be installed on the system
 
 **Configuration**
 
-| Option           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dartCliPath`    | **optional** Path to the Dart CLI. It must be executable by the calling process. Defaults to `dart`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `packages`       | **optional** List of directories to be released, relative to the root. Useful when a single repository contains multiple packages. When skipped, root directory is assumed as the only package.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Option        | Description                                                                                                                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dartCliPath`    | **optional** Path to the Dart CLI. It must be executable by the calling process. Defaults to `dart`.                                                                                            |
+| `packages`       | **optional** List of directories to be released, relative to the root. Useful when a single repository contains multiple packages. When skipped, root directory is assumed as the only package. |
 | `skipValidation` | **optional** Publishes the package without going through validation steps, such as analyzer & dependency checks. <br /> This is useful in particular situations when package maintainers know why the validation fails and wish to side step the issue. For example, there may be analyzer issues due to not following the current (latest) dart SDK recommendation because the package needs to maintain the package compatibility with an old SDK version. <br /> This option should be used with caution and only after testing and verifying the reported issue shouldn't affect the package. It is advisable to do an alpha pre-release to further reduce the chance of a potential negative impact. |
 
 **Example**
@@ -1292,17 +1293,17 @@ The extracted directory is then published as a module.
 
 The `pwsh` executable [must be installed](https://github.com/powershell/powershell#get-powershell) on the system.
 
-| Name                 | Description                             | Default |
-| -------------------- | --------------------------------------- | ------- |
-| `POWERSHELL_API_KEY` | **required** PowerShell Gallery API key |         |
-| `POWERSHELL_BIN`     | **optional** Path to PowerShell binary  | `pwsh`  |
+| Name                 | Description                                          | Default   |
+| -------------------- | ---------------------------------------------------- | --------- |
+| `POWERSHELL_API_KEY` | **required** PowerShell Gallery API key              |           |
+| `POWERSHELL_BIN`     | **optional** Path to PowerShell binary               | `pwsh`    |
 
 #### Configuration
 
-| Option       | Description                                        | Default   |
-| ------------ | -------------------------------------------------- | --------- |
-| `module`     | **required** Module name.                          |           |
-| `repository` | **optional** Repository to publish the package to. | PSGallery |
+| Option               | Description                                          | Default   |
+| -------------------- | ---------------------------------------------------- | --------- |
+| `module`             | **required** Module name.                            |           |
+| `repository`         | **optional** Repository to publish the package to.   | PSGallery |
 
 #### Example
 

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -613,9 +613,9 @@ describe('upload', () => {
     const cmdArgs = callArgs[1] as string[];
     expect(cmdArgs).toHaveLength(11);
     expect(cmdArgs[0]).toBe('gpg:sign-and-deploy-file');
-    expect(cmdArgs[1]).toMatch(new RegExp(`-Dfile=${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0`));
+    expect(cmdArgs[1]).toMatch(new RegExp(`-Dfile=${klibDistDir}/${klibDistDirName}`));
     expect(cmdArgs[2]).toBe(
-      `-Dfiles=${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0-javadoc.jar,${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0-sources.jar,${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0.klib,${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0.module`
+      `-Dfiles=${klibDistDir}/${klibDistDirName}-javadoc.jar,${klibDistDir}/${klibDistDirName}-sources.jar,${klibDistDir}/${klibDistDirName}.klib,${klibDistDir}/${klibDistDirName}.module`
     );
     expect(cmdArgs[3]).toBe(`-Dclassifiers=javadoc,sources,,`);
     expect(cmdArgs[4]).toBe(`-Dtypes=jar,jar,klib,module`);

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -297,7 +297,7 @@ describe('publish', () => {
 describe('transform KMP artifacts', () => {
   const tmpDirName = 'tmpDir';
 
-  test('transform klib-only target side artifacts', async () => {
+  test('transform klib distDir target side artifacts', async () => {
     (withTempDir as jest.MockedFunction<typeof withTempDir>).mockImplementation(
       async cb => {
         return await cb(tmpDirName);

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -614,14 +614,11 @@ describe('upload', () => {
     expect(cmdArgs).toHaveLength(11);
     expect(cmdArgs[0]).toBe('gpg:sign-and-deploy-file');
     expect(cmdArgs[1]).toMatch(new RegExp(`-Dfile=${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0`));
-
     expect(cmdArgs[2]).toBe(
       `-Dfiles=${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0-javadoc.jar,${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0-sources.jar,${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0.klib,${klibDistDir}/sentry-klib-distDir-linuxx64-1.0.0.module`
     );
-
     expect(cmdArgs[3]).toBe(`-Dclassifiers=javadoc,sources,,`);
     expect(cmdArgs[4]).toBe(`-Dtypes=jar,jar,klib,module`);
-
     expect(cmdArgs[5]).toMatch(
       new RegExp(`-DpomFile=${klibDistDir}/pom-default\\.xml`)
     );

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -542,8 +542,6 @@ describe('upload', () => {
   });
 
   test('should skip upload for artifacts without any POM/BOM', async () => {
-    // simple mock to always use the same temporary directory,
-    // instead of creating a new one
     (withTempDir as jest.MockedFunction<typeof withTempDir>).mockImplementation(
       async cb => {
         return await cb(tmpDirName);
@@ -571,8 +569,6 @@ describe('upload', () => {
     const klibDistDirName = 'sentry-klib-distDir-linuxx64-1.0.0'; // matches klib regex
     const klibDistDir = `${tmpDirName}/${klibDistDirName}`;
 
-    // simple mock to always use the same temporary directory,
-    // instead of creating a new one
     (withTempDir as jest.MockedFunction<typeof withTempDir>).mockImplementation(
       async cb => {
         return await cb(tmpDirName);

--- a/src/targets/__tests__/maven.test.ts
+++ b/src/targets/__tests__/maven.test.ts
@@ -74,7 +74,7 @@ function getFullTargetConfig(): any {
       fileReplacerStr: 'replacer',
     },
     kmp: {
-      rootDistDirRegex: '/^(?!.*klib).*distDir/',  // matches distDir but not klib-distDir
+      rootDistDirRegex: '/root-distDir/',
       appleDistDirRegex: '/apple-distDir/',
       klibDistDirRegex: '/klib-distDir/',
   },

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -64,6 +64,7 @@ type KotlinMultiplatformFields = {
     | {
         appleDistDirRegex: RegExp;
         rootDistDirRegex: RegExp;
+        klibDistDirRegex: RegExp;
       };
 };
 
@@ -170,10 +171,17 @@ export class MavenTarget extends BaseTarget {
       );
     }
 
+    if (!this.config.kmp.klibDistDirRegex) {
+      throw new ConfigurationError(
+        'Required klib configuration for Kotlin Multiplatform is incorrect. See the documentation for more details.'
+      );
+    }
+
     return {
       kmp: {
         appleDistDirRegex: stringToRegexp(this.config.kmp.appleDistDirRegex),
         rootDistDirRegex: stringToRegexp(this.config.kmp.rootDistDirRegex),
+        klibDistDirRegex: stringToRegexp(this.config.kmp.klibDistDirRegex),
       },
     };
   }
@@ -376,13 +384,16 @@ export class MavenTarget extends BaseTarget {
       const isAppleDistDir = this.mavenConfig.kmp.appleDistDirRegex.test(
         moduleName
       );
+      const isKlibOnly = this.mavenConfig.kmp.klibDistDirRegex.test(
+        moduleName
+      );
       const files = await this.getFilesForKmpMavenPomDist(distDir);
       const { targetFile, pomFile } = files;
       const {
         sideArtifacts,
         classifiers,
         types,
-      } = this.transformKmpSideArtifacts(isRootDistDir, isAppleDistDir, files);
+      } = this.transformKmpSideArtifacts(isRootDistDir, isAppleDistDir, isKlibOnly, files);
 
       await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
         'gpg:sign-and-deploy-file',
@@ -418,6 +429,7 @@ export class MavenTarget extends BaseTarget {
  *
  * @param isRootDistDir boolean indicating whether the distDir is the root distDir
  * @param isAppleDistDir boolean indicating whether the distDir is the Apple distDir
+ * @param isKlibOnly boolean indicating whether the distDir is the klib-only distDir
  * @param files an object containing the input files, as described above
  * @returns a Record with three fields:
  *    - sideArtifacts: a comma-separated string listing the paths to all generated "side artifacts"
@@ -427,6 +439,7 @@ export class MavenTarget extends BaseTarget {
   public transformKmpSideArtifacts(
     isRootDistDir: boolean,
     isAppleDistDir: boolean,
+    isKlibOnly: boolean,
     files: Record<string, string | string[]>
   ): Record<string, string | string[]> {
     const {
@@ -447,25 +460,38 @@ export class MavenTarget extends BaseTarget {
       types += ',jar,json';
       classifiers += ',all,kotlin-tooling-metadata';
     } else if (isAppleDistDir) {
-      if (klibFiles) {
-        sideArtifacts += `,${klibFiles}`;
-
-        // In order to upload cinterop klib files we need to extract the classifier from the file name.
-        // e.g: "sentry-kotlin-multiplatform-iosarm64-0.0.1-cinterop-Sentry.klib",
-        // the classifier is "cinterop-Sentry".
-        for (let i = 0; i < klibFiles.length; i++) {
-          const input = klibFiles[i];
-          const start = input.indexOf('cinterop');
-          const end = input.indexOf('.klib', start);
-          const classifier = input.substring(start, end);
-
-          types += ',klib';
-          classifiers += `,${classifier}`;
-        }
+      if (!Array.isArray(klibFiles)) {
+        throw new ConfigurationError(
+          'klib files in apple distributions must be an array'
+        );
       }
+      sideArtifacts += `,${klibFiles}`;
+
+      // In order to upload cinterop klib files we need to extract the classifier from the file name.
+      // e.g: "sentry-kotlin-multiplatform-iosarm64-0.0.1-cinterop-Sentry.klib",
+      // the classifier is "cinterop-Sentry".
+      for (let i = 0; i < klibFiles.length; i++) {
+        const input = klibFiles[i];
+        const start = input.indexOf('cinterop');
+        const end = input.indexOf('.klib', start);
+        const classifier = input.substring(start, end);
+
+        types += ',klib';
+        classifiers += `,${classifier}`;
+      }
+
       sideArtifacts += `,${metadataFile}`;
       types += ',jar';
       classifiers += ',metadata';
+    } else if (isKlibOnly) {
+      if (!Array.isArray(klibFiles) || klibFiles.length !== 1) {
+        throw new ConfigurationError(
+          'klib files in klib-only distributions must be an array with exactly one element'
+        );
+      }
+      sideArtifacts += `,${klibFiles}`;
+      types += ',klib';
+      classifiers += ',';
     }
 
     // .module files should be available in every KMP artifact
@@ -596,12 +622,12 @@ export class MavenTarget extends BaseTarget {
 
     const moduleName = parse(distDir).base;
     if (this.mavenConfig.kmp !== false) {
-      const isRootDistDir = this.mavenConfig.kmp.rootDistDirRegex.test(
-        moduleName
-      );
-      const isAppleDistDir = this.mavenConfig.kmp.appleDistDirRegex.test(
-        moduleName
-      );
+      const { klibDistDirRegex, appleDistDirRegex, rootDistDirRegex } = this.mavenConfig.kmp;
+
+      const isRootDistDir = rootDistDirRegex.test(moduleName);
+      const isAppleDistDir = appleDistDirRegex.test(moduleName);
+      const isKlibOnly = klibDistDirRegex.test(moduleName);
+
       if (isRootDistDir) {
         files['allFile'] = join(distDir, `${moduleName}-all.jar`);
         files['kotlinToolingMetadataFile'] = join(
@@ -615,6 +641,35 @@ export class MavenTarget extends BaseTarget {
           .map(file => join(distDir, file));
 
         files['klibFiles'] = cinteropFiles;
+      } else if (isKlibOnly) {
+        const dirEntries = await fsPromises.readdir(distDir);
+        const expectedFiles = [
+          `${moduleName}-javadoc.jar`,
+          `${moduleName}.klib`,
+          `${moduleName}-sources.jar`,
+          `${moduleName}.module`,
+          POM_DEFAULT_FILENAME,
+        ];
+
+        const missingFiles = expectedFiles.filter(f => !dirEntries.includes(f));
+        if (missingFiles.length > 0) {
+          throw new ConfigurationError(
+            `Missing expected file: ${missingFiles.join(', ')} in ${distDir}`
+          );
+        }
+
+        const extraFiles = dirEntries.filter(f => !expectedFiles.includes(f));
+        if (extraFiles.length > 0) {
+          throw new ConfigurationError(
+            `Unexpected extra files in ${distDir}: ${extraFiles.join(', ')}`
+          );
+        }
+
+        this.logger.info(
+          `Found klib artifacts for ${moduleName}: [${expectedFiles.join(', ')}]`
+        );
+
+        files['klibFile'] = join(distDir, `${moduleName}.klib`);
       }
     }
     return files;
@@ -649,13 +704,17 @@ export class MavenTarget extends BaseTarget {
       }
     }
     if (this.mavenConfig.kmp !== false) {
-      const isAppleDistDir = this.mavenConfig.kmp.appleDistDirRegex.test(
-        moduleName
-      );
-      if (isAppleDistDir) {
+      const { klibDistDirRegex, appleDistDirRegex } = this.mavenConfig.kmp;
+
+      if (klibDistDirRegex.test(moduleName)) {
+        return `${moduleName}.klib`;
+      }
+
+      if (appleDistDirRegex.test(moduleName)) {
         return `${moduleName}.klib`;
       }
     }
+
     return `${moduleName}.jar`;
   }
 

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -669,7 +669,7 @@ export class MavenTarget extends BaseTarget {
           `Found klib artifacts for ${moduleName}: [${expectedFiles.join(', ')}]`
         );
 
-        files['klibFile'] = join(distDir, `${moduleName}.klib`);
+        files['klibFiles'] = [join(distDir, `${moduleName}.klib`)];
       }
     }
     return files;

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -642,33 +642,6 @@ export class MavenTarget extends BaseTarget {
 
         files['klibFiles'] = cinteropFiles;
       } else if (isKlibDistDir) {
-        const dirEntries = await fsPromises.readdir(distDir);
-        const expectedFiles = [
-          `${moduleName}-javadoc.jar`,
-          `${moduleName}.klib`,
-          `${moduleName}-sources.jar`,
-          `${moduleName}.module`,
-          POM_DEFAULT_FILENAME,
-        ];
-
-        const missingFiles = expectedFiles.filter(f => !dirEntries.includes(f));
-        if (missingFiles.length > 0) {
-          throw new ConfigurationError(
-            `Missing expected file: ${missingFiles.join(', ')} in ${distDir}`
-          );
-        }
-
-        const extraFiles = dirEntries.filter(f => !expectedFiles.includes(f));
-        if (extraFiles.length > 0) {
-          throw new ConfigurationError(
-            `Unexpected extra files in ${distDir}: ${extraFiles.join(', ')}`
-          );
-        }
-
-        this.logger.info(
-          `Found klib artifacts for ${moduleName}: [${expectedFiles.join(', ')}]`
-        );
-
         files['klibFiles'] = [join(distDir, `${moduleName}.klib`)];
       }
     }

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -384,7 +384,7 @@ export class MavenTarget extends BaseTarget {
       const isAppleDistDir = this.mavenConfig.kmp.appleDistDirRegex.test(
         moduleName
       );
-      const isKlibOnly = this.mavenConfig.kmp.klibDistDirRegex.test(
+      const isKlibDistDir = this.mavenConfig.kmp.klibDistDirRegex.test(
         moduleName
       );
       const files = await this.getFilesForKmpMavenPomDist(distDir);
@@ -393,7 +393,7 @@ export class MavenTarget extends BaseTarget {
         sideArtifacts,
         classifiers,
         types,
-      } = this.transformKmpSideArtifacts(isRootDistDir, isAppleDistDir, isKlibOnly, files);
+      } = this.transformKmpSideArtifacts(isRootDistDir, isAppleDistDir, isKlibDistDir, files);
 
       await retrySpawnProcess(this.mavenConfig.mavenCliPath, [
         'gpg:sign-and-deploy-file',
@@ -429,7 +429,7 @@ export class MavenTarget extends BaseTarget {
  *
  * @param isRootDistDir boolean indicating whether the distDir is the root distDir
  * @param isAppleDistDir boolean indicating whether the distDir is the Apple distDir
- * @param isKlibOnly boolean indicating whether the distDir is the klib-only distDir
+ * @param isKlibDistDir boolean indicating whether the distDir is the klib-only distDir
  * @param files an object containing the input files, as described above
  * @returns a Record with three fields:
  *    - sideArtifacts: a comma-separated string listing the paths to all generated "side artifacts"
@@ -439,7 +439,7 @@ export class MavenTarget extends BaseTarget {
   public transformKmpSideArtifacts(
     isRootDistDir: boolean,
     isAppleDistDir: boolean,
-    isKlibOnly: boolean,
+    isKlibDistDir: boolean,
     files: Record<string, string | string[]>
   ): Record<string, string | string[]> {
     const {
@@ -483,7 +483,7 @@ export class MavenTarget extends BaseTarget {
       sideArtifacts += `,${metadataFile}`;
       types += ',jar';
       classifiers += ',metadata';
-    } else if (isKlibOnly) {
+    } else if (isKlibDistDir) {
       if (!Array.isArray(klibFiles) || klibFiles.length !== 1) {
         throw new ConfigurationError(
           'klib files in klib-only distributions must be an array with exactly one element'
@@ -626,7 +626,7 @@ export class MavenTarget extends BaseTarget {
 
       const isRootDistDir = rootDistDirRegex.test(moduleName);
       const isAppleDistDir = appleDistDirRegex.test(moduleName);
-      const isKlibOnly = klibDistDirRegex.test(moduleName);
+      const isKlibDistDir = klibDistDirRegex.test(moduleName);
 
       if (isRootDistDir) {
         files['allFile'] = join(distDir, `${moduleName}-all.jar`);
@@ -641,7 +641,7 @@ export class MavenTarget extends BaseTarget {
           .map(file => join(distDir, file));
 
         files['klibFiles'] = cinteropFiles;
-      } else if (isKlibOnly) {
+      } else if (isKlibDistDir) {
         const dirEntries = await fsPromises.readdir(distDir);
         const expectedFiles = [
           `${moduleName}-javadoc.jar`,

--- a/src/targets/maven.ts
+++ b/src/targets/maven.ts
@@ -679,11 +679,7 @@ export class MavenTarget extends BaseTarget {
     if (this.mavenConfig.kmp !== false) {
       const { klibDistDirRegex, appleDistDirRegex } = this.mavenConfig.kmp;
 
-      if (klibDistDirRegex.test(moduleName)) {
-        return `${moduleName}.klib`;
-      }
-
-      if (appleDistDirRegex.test(moduleName)) {
+      if (klibDistDirRegex.test(moduleName) || appleDistDirRegex.test(moduleName)) {
         return `${moduleName}.klib`;
       }
     }


### PR DESCRIPTION
For KMP we are going to publish new targets: `js`, `wasm-js`, `linux`, `mingw` and all the artifacts to publish are currently not compatible with the KMP implementation in craft -> they would be processed incorrectly with the current implementation

All these distributions have the same structure so we can add a new config that targets these. They all contain 5 files: 1 -source.jar, 1 -javadoc.jar, 1 .klib, 1 .module and 1 pom file.