### PR TITLE
fix: Avoid `global.json` when running all `dotnet` commands

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -18,10 +18,10 @@ const DEFAULT_NUGET_REGEX = /^.*\d\.\d.*\.nupkg$/;
 const SYMBOLS_NUGET_REGEX = /^.*\d\.\d.*\.snupkg$/;
 
 /**
- * Spawn options to run outside the repository folder to avoid global.json constraints
+ * Spawn options to run dotnet commands outside the repository folder to avoid global.json constraints
  * (we don't need specific dotnet/workload versions just to upload to nuget)
  */
-const SPAWN_OPTIONS = { cwd: '/' };
+const DOTNET_SPAWN_OPTIONS = { cwd: '/' };
 
 /** Nuget target configuration options */
 export interface NugetTargetOptions {
@@ -81,7 +81,7 @@ export class NugetTarget extends BaseTarget {
       '--source',
       this.nugetConfig.serverUrl,
     ];
-    return spawnProcess(NUGET_DOTNET_BIN, args, SPAWN_OPTIONS);
+    return spawnProcess(NUGET_DOTNET_BIN, args, DOTNET_SPAWN_OPTIONS);
   }
 
   /**
@@ -107,12 +107,12 @@ export class NugetTarget extends BaseTarget {
 
     // Emit the .NET version for informational purposes.
     this.logger.info('.NET Version:');
-    await spawnProcess(NUGET_DOTNET_BIN, ['--version'], SPAWN_OPTIONS);
+    await spawnProcess(NUGET_DOTNET_BIN, ['--version'], DOTNET_SPAWN_OPTIONS);
 
     // Also emit the nuget version, which is informative and works around a bug.
     // See https://github.com/NuGet/Home/issues/12159#issuecomment-1278360511
     this.logger.info('Nuget Version:');
-    await spawnProcess(NUGET_DOTNET_BIN, ['nuget', '--version'], SPAWN_OPTIONS);
+    await spawnProcess(NUGET_DOTNET_BIN, ['nuget', '--version'], DOTNET_SPAWN_OPTIONS);
 
     await Promise.all(
       packageFiles.map(async (file: RemoteArtifact) => {


### PR DESCRIPTION
### Summary

The [Sentry .NET SDK](https://github.com/getsentry/sentry-dotnet) uses a [global.json](https://learn.microsoft.com/dotnet/core/tools/global-json) file to pin a specific version of the .NET SDK and .NET Workloads to ensure reproducible builds.
When pushing the Sentry NuGet packages and Symbol packages, we can use any version of the .NET SDK,
as long as we ensure that the actual `dotnet build`, `dotnet test`, and creating the packages via `dotnet pack` run with the pinned version of the .NET SDK.

In a previous PR, see #601,
we applied `spawnOptions` to the invocation of `dotnet nuget push` via `spawnProcess`,
with which we set the Working Directory outside of the `sentry-dotnet` repository,
so that the `global.json` does not get picked up / enforced.

However,
we forgot to apply the same `spawnOptions` to the other invocations of `dotnet` commands.

This manifests in failure when invoking `dotnet --version`:
```TEXT
...
[info] [[target/nuget]] .NET Version:
Error:  Process "dotnet" errored with code 145
...
dotnet: 8.0.412 [/usr/share/dotnet/sdk]
dotnet: 9.0.303 [/usr/share/dotnet/sdk]
...
dotnet: Requested SDK version: 9.0.301
dotnet: global.json file: global.json
...
```

<details>
<summary>Publish using Craft</summary>

```TEXT
[info] [[target/nuget]] .NET Version:
Error:  Process "dotnet" errored with code 145

STDOUT: dotnet: 8.0.412 [/usr/share/dotnet/sdk]
dotnet: 9.0.303 [/usr/share/dotnet/sdk]
dotnet: 


STDERR:dotnet: The command could not be loaded, possibly because:
dotnet:   * You intended to execute a .NET application:
dotnet:       The application '--version' does not exist.
dotnet:   * You intended to execute a .NET SDK command:
dotnet:       A compatible .NET SDK was not found.
dotnet: 
dotnet: Requested SDK version: 9.0.301
dotnet: global.json file: /github/workspace/__repo__/global.json
dotnet: 
dotnet: Installed SDKs:
dotnet: 
dotnet: Install the [9.0.301] .NET SDK or update [/github/workspace/__repo__/global.json] to match an installed SDK.
dotnet: 
dotnet: Learn about SDK resolution:
dotnet: https://aka.ms/dotnet/sdk-not-found
dotnet: 

  
  STDOUT: dotnet: 8.0.412 [/usr/share/dotnet/sdk]
  dotnet: 9.0.303 [/usr/share/dotnet/sdk]
  dotnet:
  
  
  STDERR:dotnet: The command could not be loaded, possibly because:
  dotnet:   * You intended to execute a .NET application:
  dotnet:       The application '--version' does not exist.
  dotnet:   * You intended to execute a .NET SDK command:
  dotnet:       A compatible .NET SDK was not found.
  dotnet:
  dotnet: Requested SDK version: 9.0.301
  dotnet: global.json file: global.json
  dotnet:
  dotnet: Installed SDKs:
  dotnet:
  dotnet: Install the [9.0.301] .NET SDK or update [global.json] to match an installed SDK.
  dotnet:
  dotnet: Learn about SDK resolution:
  dotnet: https://aka.ms/dotnet/sdk-not-found
  dotnet:
  
  at Bqe (/usr/local/bin/craft:357:15452)
  at p (/usr/local/bin/craft:361:467)
  at ChildProcess.<anonymous> (/usr/local/bin/craft:361:761)
  at ChildProcess.emit (node:events:518:28)
  at ChildProcess.emit (node:domain:489:12)
  at ChildProcess._handle.onexit (node:internal/child_process:293:12)
```

</details>

### Changes
Applying the previously added `spawnOptions` to the invocations of all `dotnet` commands,
not just `dotnet nuget push`.

### See also
- getsentry/craft#598
- getsentry/craft#601
