### PR TITLE
feat(aws-lambda): Add description including SDK version to layer metadata

### DIFF
--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -251,7 +251,8 @@ export class AwsLambdaLayerTarget extends BaseTarget {
           this.config.layerName,
           this.config.license,
           artifactBuffer,
-          awsRegions
+          awsRegions,
+          version
         );
 
         let publishedLayers = [];
@@ -316,11 +317,16 @@ export class AwsLambdaLayerTarget extends BaseTarget {
 
         if (!fs.existsSync(baseFilepath)) {
           this.logger.warn(`The ${runtime.name} base file is missing.`);
-          const manifestString = JSON.stringify(runtimeData, undefined, 2) + '\n';
+          const manifestString =
+            JSON.stringify(runtimeData, undefined, 2) + '\n';
           fs.writeFileSync(newVersionFilepath, manifestString);
         } else {
-          const baseData = JSON.parse(fs.readFileSync(baseFilepath, { encoding: 'utf-8' }).toString());
-          const manifestString = JSON.stringify({ ...baseData, ...runtimeData }, undefined, 2) + '\n';
+          const baseData = JSON.parse(
+            fs.readFileSync(baseFilepath, { encoding: 'utf-8' }).toString()
+          );
+          const manifestString =
+            JSON.stringify({ ...baseData, ...runtimeData }, undefined, 2) +
+            '\n';
           fs.writeFileSync(newVersionFilepath, manifestString);
         }
 

--- a/src/utils/__tests__/awsLambdaLayerManager.test.ts
+++ b/src/utils/__tests__/awsLambdaLayerManager.test.ts
@@ -14,7 +14,8 @@ function getTestAwsLambdaLayerManager(): awsManager.AwsLambdaLayerManager {
     'test layer name',
     'test license',
     Buffer.alloc(0),
-    AWS_TEST_REGIONS
+    AWS_TEST_REGIONS,
+    '0.0.0'
   );
 }
 

--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -45,19 +45,23 @@ export class AwsLambdaLayerManager {
   private artifactBuffer: Buffer;
   /** Controls if published layers are logged. */
   public verboseInfo = true;
+  /** Version of the SDK. */
+  private sdkVersion: string;
 
   public constructor(
     runtime: CompatibleRuntime,
     layerName: string,
     license: string,
     artifactBuffer: Buffer,
-    awsRegions: string[]
+    awsRegions: string[],
+    sdkVersion: string
   ) {
     this.runtime = runtime;
     this.layerName = layerName;
     this.license = license;
     this.artifactBuffer = artifactBuffer;
     this.awsRegions = awsRegions;
+    this.sdkVersion = sdkVersion;
   }
 
   /**
@@ -75,6 +79,7 @@ export class AwsLambdaLayerManager {
       LayerName: this.layerName,
       CompatibleRuntimes: this.runtime.versions,
       LicenseInfo: this.license,
+      Description: `Sentry AWS Serverless SDK v${this.sdkVersion}`,
     });
     await lambda.addLayerVersionPermission({
       LayerName: this.layerName,
@@ -156,7 +161,8 @@ export async function getRegionsFromAws(): Promise<string[]> {
     );
   }
   const data = await response.text();
-  return new XMLParser().parse(data)
+  return new XMLParser()
+    .parse(data)
     .DescribeRegionsResponse.regionInfo.item.map(
       (region: Region) => region.regionName
     )


### PR DESCRIPTION
This allows users to easily identify which SDK version they use by looking at the description of the layer.
Also boosts confidence that you have input the correct ARN when adding the layer.