### PR TITLE
fix(changelog): escape leading underscores in titles

### DIFF
--- a/src/utils/__tests__/changelog.test.ts
+++ b/src/utils/__tests__/changelog.test.ts
@@ -572,6 +572,19 @@ describe('generateChangesetFromGit', () => {
       ].join('\n'),
     ],
     [
+      'should escape leading underscores in changelog entries',
+      [
+        {
+          hash: 'abcdef1234567890',
+          title: 'Serialized _meta (#123)',
+          body: '',
+          pr: { local: '123' },
+        },
+      ],
+      {},
+      '### Various fixes & improvements\n\n- Serialized \\_meta (#123)',
+    ],
+    [
       'should omit milestone body if it is empty or null',
       [
         {

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -52,6 +52,10 @@ function markdownHeader(level: number, text: string): string {
   return `${prefix} ${escapeMarkdownPound(text)}`;
 }
 
+function escapeLeadingUnderscores(text: string): string {
+  return text.replace(/(^| )_/, '$1\\_');
+}
+
 /**
  * Extracts a specific changeset from a markdown document
  *
@@ -235,7 +239,7 @@ type MilestoneWithPRs = Partial<Milestone> & {
 // avoid collisions.
 const SHORT_SHA_LENGTH = 8;
 function formatCommit(commit: Commit): string {
-  let text = `- ${commit.title}`;
+  let text = `- ${escapeLeadingUnderscores(commit.title)}`;
   if (!commit.hasPRinTitle) {
     const link = commit.pr
       ? `#${commit.pr}`


### PR DESCRIPTION
Releases to [sentry-kafka-schemas](https://github.com/getsentry/sentry-kafka-schemas) are currently failing because the changelog generated by craft [fails its code formatting check](https://github.com/getsentry/sentry-kafka-schemas/actions/runs/18320171269/job/52171014771), as `prettier --write .` reformats the generated changelog:

```diff
-- fix(spans): Add _meta field to ingest spans (#445) by @mjq
+- fix(spans): Add \_meta field to ingest spans (#445) by @mjq
``` 

The most robust thing to do feels like running the changelog update through prettier inside craft, but this is a stopgap to avoid taking on that dependency.