### PR TITLE
Fixed argument order

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -78,13 +78,13 @@ export class NugetTarget extends BaseTarget {
       path,
       '--api-key',
       '${NUGET_API_TOKEN}',
-      '--source',
       // Warning: `--skip-duplicate` means we will NOT error when a version
       //          already exists. This is unlike any other target in Craft but
       //          became needed here as NuGet repo is quite flaky and we need to
       //          publish many packages at once without another way to resume a
       //          broken release.
       '--skip-duplicate',
+      '--source',
       this.nugetConfig.serverUrl,
     ];
     return spawnProcess(NUGET_DOTNET_BIN, args, DOTNET_SPAWN_OPTIONS);


### PR DESCRIPTION
Looks like this was broken for a while and later versions of the tooling are finally enforcing the correct order.

Fixes problem observed [here](https://github.com/getsentry/publish/actions/runs/18883988158/job/53894435429):
```
Error:  Process "dotnet" errored with code 1

STDOUT: dotnet: error: The specified source '--skip-duplicate' is invalid. Provide a valid source.
```