### PR TITLE
fix(npm): Disable scripts during publish

### DIFF
--- a/src/targets/hex.ts
+++ b/src/targets/hex.ts
@@ -17,6 +17,12 @@ const MIX_BIN = process.env.MIX_BIN || DEFAULT_MIX_BIN;
 /**
  * Target responsible for publishing releases to Hex, the Elixir/Erlang package manager.
  * https://hex.pm
+ *
+ * NOTE: This target runs `mix deps.get` and `mix hex.publish` which compile the project
+ * as part of normal Elixir/Mix tooling behavior. Unlike npm's lifecycle scripts, these
+ * are not arbitrary user-defined scripts but standard build tooling operations required
+ * for publishing. There is no `--ignore-scripts` equivalent as Elixir does not have the
+ * concept of user-defined publish lifecycle hooks.
  */
 export class HexTarget extends BaseTarget {
   /** Target name */

--- a/src/targets/npm.ts
+++ b/src/targets/npm.ts
@@ -173,7 +173,10 @@ export class NpmTarget extends BaseTarget {
     path: string,
     options: NpmPublishOptions
   ): Promise<any> {
-    const args = ['publish'];
+    // NOTE: --ignore-scripts prevents execution of lifecycle scripts (prepublish,
+    // prepublishOnly, prepack, postpack, publish, postpublish) which could run
+    // arbitrary code during the publish process.
+    const args = ['publish', '--ignore-scripts'];
     let bin: string;
 
     if (this.npmConfig.useYarn) {

--- a/src/targets/pubDev.ts
+++ b/src/targets/pubDev.ts
@@ -36,6 +36,12 @@ export type PubDevTargetConfig = PubDevTargetOptions &
 
 /**
  * Target responsible for uploading files to pub.dev.
+ *
+ * NOTE: This target runs `dart pub publish` which performs analysis and validation
+ * as part of normal Dart tooling behavior. Unlike npm's lifecycle scripts, these
+ * are not arbitrary user-defined scripts but standard build tooling operations required
+ * for publishing. There is no `--ignore-scripts` equivalent as Dart does not have the
+ * concept of user-defined publish lifecycle hooks.
  */
 export class PubDevTarget extends BaseTarget {
   /** Target name */


### PR DESCRIPTION
This patch disables user-defined npm scripts during publish which pose a security risk. It also adds some notes on other targets where they run code during publish (but not user-defined code).
