### PR TITLE
fix(changelog): Unscoped entries should be grouped under "other" 

### DIFF
--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -914,15 +914,25 @@ async function generateChangesetFromGitImpl(
       return scopeA.localeCompare(scopeB);
     });
 
+    // Check if any scope has multiple entries (would get a header)
+    const hasScopeHeaders = [...category.scopeGroups.entries()].some(
+      ([s, entries]) => s !== null && entries.length > 1
+    );
+
     for (const [scope, prs] of sortedScopes) {
       // Add scope header if:
       // - scope grouping is enabled AND
       // - scope exists (not null) AND
       // - there's more than one entry in this scope (single entry headers aren't useful)
+      // OR
+      // - scope is null (scopeless) AND there are other scope headers (to visually separate)
       if (scopeGroupingEnabled && scope !== null && prs.length > 1) {
         changelogSections.push(
           markdownHeader(SCOPE_HEADER_LEVEL, formatScopeTitle(scope))
         );
+      } else if (scopeGroupingEnabled && scope === null && hasScopeHeaders) {
+        // Add "Other" header for scopeless commits when there are other scope headers
+        changelogSections.push(markdownHeader(SCOPE_HEADER_LEVEL, 'Other'));
       }
 
       const prEntries = prs.map(pr =>


### PR DESCRIPTION
Add an "Other" sub-header for scopeless commits in the changelog to improve visual separation.

Previously, scopeless commits (e.g., `feat:`) would appear directly after the last scoped group (e.g., `feat(usage overview):`), making them visually appear to belong to that group. This change introduces an `#### Other` header for these commits when other scoped groups are present and have their own headers, ensuring clear distinction.

Fixes #658 