### PR TITLE
 fix(docker): Support regional Artifact Registry endpoints in isGoogleCloudRegistry

### DIFF
--- a/src/targets/__tests__/docker.test.ts
+++ b/src/targets/__tests__/docker.test.ts
@@ -239,10 +239,19 @@ describe('isGoogleCloudRegistry', () => {
     expect(isGoogleCloudRegistry('asia.gcr.io')).toBe(true);
   });
 
-  it('returns true for Artifact Registry (pkg.dev)', () => {
+  it('returns true for Artifact Registry multi-region (pkg.dev)', () => {
     expect(isGoogleCloudRegistry('us-docker.pkg.dev')).toBe(true);
     expect(isGoogleCloudRegistry('europe-docker.pkg.dev')).toBe(true);
     expect(isGoogleCloudRegistry('asia-docker.pkg.dev')).toBe(true);
+  });
+
+  it('returns true for Artifact Registry regional endpoints (pkg.dev)', () => {
+    expect(isGoogleCloudRegistry('us-west1-docker.pkg.dev')).toBe(true);
+    expect(isGoogleCloudRegistry('us-central1-docker.pkg.dev')).toBe(true);
+    expect(isGoogleCloudRegistry('us-east4-docker.pkg.dev')).toBe(true);
+    expect(isGoogleCloudRegistry('europe-west1-docker.pkg.dev')).toBe(true);
+    expect(isGoogleCloudRegistry('asia-east1-docker.pkg.dev')).toBe(true);
+    expect(isGoogleCloudRegistry('australia-southeast1-docker.pkg.dev')).toBe(true);
   });
 
   it('returns false for non-Google registries', () => {

--- a/src/targets/docker.ts
+++ b/src/targets/docker.ts
@@ -28,7 +28,7 @@ const GCR_REGISTRY_PATTERNS = [
   /^gcr\.io$/,
   /^[a-z]+-gcr\.io$/, // us-gcr.io, eu-gcr.io, asia-gcr.io, etc.
   /^[a-z]+\.gcr\.io$/, // us.gcr.io, eu.gcr.io, asia.gcr.io, etc.
-  /^[a-z]+-docker\.pkg\.dev$/, // us-docker.pkg.dev, europe-docker.pkg.dev, etc.
+  /^[a-z][a-z0-9-]*-docker\.pkg\.dev$/, // us-docker.pkg.dev, us-west1-docker.pkg.dev, europe-west1-docker.pkg.dev, etc.
 ];
 
 /**


### PR DESCRIPTION
The regex pattern for matching Google Artifact Registry hosts only allowed
lowercase letters in the region name (e.g., `us-docker.pkg.dev`). This caused
valid regional endpoints like `us-west1-docker.pkg.dev` to be rejected,
incorrectly requiring explicit DOCKER_*_USERNAME/PASSWORD credentials instead
of using gcloud authentication.

Updated the pattern from `/^[a-z]+-docker\.pkg\.dev$/` to
`/^[a-z][a-z0-9-]*-docker\.pkg\.dev$/` to support regional endpoints.