### PR TITLE
feat(github): Emit resolved version to GITHUB_OUTPUTS on prepare

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,5 @@
 minVersion: '2.14.0'
-changelogPolicy: auto
+changelog: auto
 preReleaseCommand: >-
   node -p "
     const {execSync} = require('child_process');

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -34,7 +34,11 @@ import {
   isBumpType,
   type BumpType,
 } from '../utils/autoVersion';
-import { isDryRun, promptConfirmation } from '../utils/helpers';
+import {
+  isDryRun,
+  promptConfirmation,
+  setGitHubActionsOutput,
+} from '../utils/helpers';
 import { formatJson } from '../utils/strings';
 import { spawnProcess } from '../utils/system';
 import { isValidVersion } from '../utils/version';
@@ -548,6 +552,9 @@ export async function prepareMain(argv: PrepareOptions): Promise<any> {
     newVersion = calculateNextVersion(currentVersion, bumpType);
     logger.info(`Version bump: ${currentVersion} -> ${newVersion} (${bumpType} bump)`);
   }
+
+  // Emit resolved version for GitHub Actions
+  setGitHubActionsOutput('version', newVersion);
 
   logger.info(`Releasing version ${newVersion} from ${rev}`);
   if (!argv.rev && rev !== defaultBranch) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { appendFileSync } from 'fs';
+
 import prompts from 'prompts';
 import { logger, LogLevel, setLevel } from '../logger';
 
@@ -58,4 +60,15 @@ export async function promptConfirmation(): Promise<void> {
 
 export function hasInput(): boolean {
   return !GLOBAL_FLAGS['no-input'];
+}
+
+/**
+ * Sets a GitHub Actions output variable.
+ * No-op when not running in GitHub Actions.
+ */
+export function setGitHubActionsOutput(name: string, value: string): void {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${name}=${value}\n`);
+  }
 }


### PR DESCRIPTION
This allows us to use automatic and/or semantic versioning easily in action-prepare-release as we can then consume the resolved version directly from GitHub Actions.
