### PR TITLE
fix: Clean up docs preview folders when PRs are closed

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -2,6 +2,7 @@ name: Docs Preview
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - 'docs/**'
       - '.github/workflows/docs-preview.yml'
@@ -33,7 +34,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           # Try to fetch the gh-pages branch
           if git fetch origin gh-pages:gh-pages 2>/dev/null; then
             # Branch exists remotely, check if .nojekyll is present


### PR DESCRIPTION
Add the `closed` event type to the docs-preview workflow trigger so that `pr-preview-action` can automatically clean up PR preview folders from the `gh-pages` branch when PRs are merged or closed.

Previously, the workflow only triggered on `opened`, `synchronize`, and `reopened` events (the defaults), so cleanup never ran.