### PR TITLE
feat(aws-lambda): Add version templating for layer names

### DIFF
--- a/docs/src/content/docs/targets/aws-lambda-layer.md
+++ b/docs/src/content/docs/targets/aws-lambda-layer.md
@@ -9,11 +9,26 @@ Creates a new public Lambda layer in each available AWS region and updates the S
 
 | Option | Description |
 |--------|-------------|
-| `layerName` | Name of the Lambda layer |
+| `layerName` | Name of the Lambda layer. Supports template variables (see below) |
 | `compatibleRuntimes` | List of runtime configurations |
 | `license` | Layer license |
 | `linkPrereleases` | Update for preview releases. Default: `false` |
 | `includeNames` | Must filter to exactly one artifact |
+
+### Layer Name Templating
+
+The `layerName` option supports Mustache-style template variables for dynamic version interpolation:
+
+| Variable | Description | Example (for v10.2.3) |
+|----------|-------------|----------------------|
+| `{{{version}}}` | Full version string | `10.2.3` |
+| `{{{major}}}` | Major version number | `10` |
+| `{{{minor}}}` | Minor version number | `2` |
+| `{{{patch}}}` | Patch version number | `3` |
+
+This is useful when you want the layer name to reflect the SDK major version, making it easier for users to identify which version the layer supports.
+
+Example: `SentryNodeServerlessSDKv{{{major}}}` becomes `SentryNodeServerlessSDKv10` when publishing version `10.2.3`.
 
 ### Runtime Configuration
 
@@ -32,7 +47,9 @@ compatibleRuntimes:
 | `AWS_ACCESS_KEY` | AWS account access key |
 | `AWS_SECRET_ACCESS_KEY` | AWS account secret key |
 
-## Example
+## Examples
+
+### Basic Example
 
 ```yaml
 targets:
@@ -46,3 +63,22 @@ targets:
           - nodejs12.x
     license: MIT
 ```
+
+### With Version Templating
+
+Include the major version in the layer name so users can easily identify SDK compatibility:
+
+```yaml
+targets:
+  - name: aws-lambda-layer
+    includeNames: /^sentry-node-serverless-\d+(\.\d+)*\.zip$/
+    layerName: SentryNodeServerlessSDKv{{{major}}}
+    compatibleRuntimes:
+      - name: node
+        versions:
+          - nodejs18.x
+          - nodejs20.x
+    license: MIT
+```
+
+When publishing version `10.2.3`, the layer will be named `SentryNodeServerlessSDKv10`.

--- a/src/targets/__tests__/awsLambda.test.ts
+++ b/src/targets/__tests__/awsLambda.test.ts
@@ -119,6 +119,47 @@ describe('project config parameters', () => {
   });
 });
 
+describe('layer name templating', () => {
+  beforeAll(() => {
+    setAwsEnvironmentVariables();
+  });
+
+  test('layer name without template variables', () => {
+    const awsTarget = getAwsLambdaTarget();
+    awsTarget.config.layerName = 'SentryNodeServerlessSDK';
+    const resolved = awsTarget.resolveLayerName('10.2.3');
+    expect(resolved).toBe('SentryNodeServerlessSDK');
+  });
+
+  test('layer name with major version variable', () => {
+    const awsTarget = getAwsLambdaTarget();
+    awsTarget.config.layerName = 'SentryNodeServerlessSDKv{{{major}}}';
+    const resolved = awsTarget.resolveLayerName('10.2.3');
+    expect(resolved).toBe('SentryNodeServerlessSDKv10');
+  });
+
+  test('layer name with multiple version variables', () => {
+    const awsTarget = getAwsLambdaTarget();
+    awsTarget.config.layerName = 'SentrySDKv{{{major}}}-{{{minor}}}-{{{patch}}}';
+    const resolved = awsTarget.resolveLayerName('10.2.3');
+    expect(resolved).toBe('SentrySDKv10-2-3');
+  });
+
+  test('layer name with full version variable', () => {
+    const awsTarget = getAwsLambdaTarget();
+    awsTarget.config.layerName = 'SentrySDK-{{{version}}}';
+    const resolved = awsTarget.resolveLayerName('10.2.3');
+    expect(resolved).toBe('SentrySDK-10.2.3');
+  });
+
+  test('layer name with prerelease version', () => {
+    const awsTarget = getAwsLambdaTarget();
+    awsTarget.config.layerName = 'SentrySDKv{{{major}}}';
+    const resolved = awsTarget.resolveLayerName('10.2.3-alpha.1');
+    expect(resolved).toBe('SentrySDKv10');
+  });
+});
+
 describe('publish', () => {
   beforeAll(() => {
     setAwsEnvironmentVariables();


### PR DESCRIPTION
## Summary

Add support for Mustache-style template variables in the `layerName` config for AWS Lambda layers. This allows dynamic interpolation of version components at publish time, eliminating manual layer name updates when releasing new major versions.

## Template Variables

| Variable | Description | Example (for v10.2.3) |
|----------|-------------|----------------------|
| `{{{version}}}` | Full version string | `10.2.3` |
| `{{{major}}}` | Major version number | `10` |
| `{{{minor}}}` | Minor version number | `2` |
| `{{{patch}}}` | Patch version number | `3` |

## Example

```yaml
targets:
  - name: aws-lambda-layer
    layerName: SentryNodeServerlessSDKv{{{major}}}
    # ...
```

When publishing version `10.2.3`, the layer will be named `SentryNodeServerlessSDKv10`.

## Changes

- Added `resolveLayerName()` method to `AwsLambdaLayerTarget` for template interpolation
- Updated `publishRuntimes()` to use the resolved layer name
- Added unit tests for layer name templating
- Updated documentation with template variable reference and examples

Closes #646.