### PR TITLE
fix(prepare): Pass --no-git-checks flag to publish step

### DIFF
--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -356,9 +356,15 @@ function checkGitStatus(repoStatus: StatusResult, rev: string) {
  * This function will never return: it terminates the process with the
  * corresponding error code after publishing is done.
  *
+ * @param remote The git remote to use when pushing
  * @param newVersion Version to publish
+ * @param noGitChecks If true, skip git status checks
  */
-async function execPublish(remote: string, newVersion: string): Promise<never> {
+async function execPublish(
+  remote: string,
+  newVersion: string,
+  noGitChecks: boolean
+): Promise<never> {
   logger.info('Running the "publish" command...');
   const publishOptions: PublishOptions = {
     remote,
@@ -367,6 +373,7 @@ async function execPublish(remote: string, newVersion: string): Promise<never> {
     keepDownloads: false,
     noMerge: false,
     noStatusCheck: false,
+    noGitChecks,
   };
   logger.info(
     `Sleeping for ${SLEEP_BEFORE_PUBLISH_SECONDS} seconds before publishing...`
@@ -750,7 +757,7 @@ export async function prepareMain(argv: PrepareOptions): Promise<any> {
 
   if (argv.publish) {
     logger.success(`Release branch "${branchName}" has been pushed.`);
-    await execPublish(argv.remote, newVersion);
+    await execPublish(argv.remote, newVersion, argv.noGitChecks);
   } else {
     logger.success(
       'Done. Do not forget to run "craft publish" to publish the artifacts:',


### PR DESCRIPTION
## Summary

When running `craft prepare --publish --no-git-checks`, the `noGitChecks` flag was not being passed to the publish step, causing git checks to run even when explicitly disabled by the user.

## Problem

The `execPublish()` function constructs a `PublishOptions` object but omits the required `noGitChecks` property. This causes:

1. User runs: `craft prepare --publish --no-git-checks 1.0.0`
2. The prepare step correctly skips git checks
3. The publish step runs git checks anyway (because `noGitChecks` is `undefined`)

## Fix

Updated `execPublish()` to:
- Accept a `noGitChecks` parameter
- Include it in the `PublishOptions` object passed to the publish handler

This ensures the user's intent to skip git checks is respected throughout the entire prepare+publish flow.

Follow up to https://github.com/getsentry/craft/pull/683/files/a1ebfffc1a0cbc40e7d96b04771672e2d6418e22#diff-adc8934db1a646fd72f3cdda4ede76ecfc3628ec0f8dd1f37403d0121183e94a