### PR TITLE
fix: set executable permissions on built craft binary

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,3 +1,4 @@
+import { chmod } from 'fs/promises';
 import esbuild from 'esbuild';
 import { sentryEsbuildPlugin } from '@sentry/esbuild-plugin';
 
@@ -36,3 +37,6 @@ await esbuild.build({
   outfile: 'dist/craft',
   plugins,
 });
+
+// Make the output file executable
+await chmod('dist/craft', 0o755);


### PR DESCRIPTION
The esbuild output doesn't have execute permissions by default. This adds a `chmod` call after the build to make `dist/craft` executable.

Fixes the CI failure:
```
./dist/craft: Permission denied
```