### PR TITLE
fix(action): Resolve install sub-action path for external repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,8 +83,16 @@ runs:
         echo "GIT_AUTHOR_NAME=${GIT_USER_NAME}" >> $GITHUB_ENV
         echo "EMAIL=${GIT_USER_EMAIL}" >> $GITHUB_ENV
 
-    - name: Install Craft
+    # For dogfooding (Craft releasing itself) - local path works because
+    # the checkout is in the Craft repo, so ./install resolves correctly
+    - name: Install Craft (local)
+      if: github.repository == 'getsentry/craft'
       uses: ./install
+
+    # For external repos - use fully-qualified reference with action ref
+    - name: Install Craft
+      if: github.repository != 'getsentry/craft'
+      uses: getsentry/craft/install@${{ github.action_ref }}
 
     - name: Craft Prepare
       id: craft


### PR DESCRIPTION
## Problem

When external repositories (like `sentry-capacitor`) use `getsentry/craft@v2`, the composite action fails at the "Install Craft" step:

```
Can't find 'action.yml' under '/home/runner/work/sentry-capacitor/sentry-capacitor/install'
```

GitHub Actions incorrectly resolves the relative `./install` path against the calling repository's checkout directory instead of the Craft action's directory.

## Solution

Use two conditional steps that handle both scenarios:

- **Dogfooding** (`github.repository == 'getsentry/craft'`): Uses `./install` which works because the checkout is in the Craft repo
- **External repos**: Uses `getsentry/craft/install@${{ github.action_ref }}` to fetch the sub-action from the Craft repository at the same ref (e.g., `v2`)

This also works correctly when external repos use the reusable workflow, since it internally uses `getsentry/craft@v2`.