### PR TITLE
fix(changelog-preview): Replace deleted install sub-action with inline install

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -52,11 +52,52 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install Craft using the shared install action
+      # Install Craft from release
+      # Note: Dogfooding (using build artifact from this PR) is not feasible here because:
+      # 1. The build workflow runs separately and artifacts are scoped to that workflow run
+      # 2. Cross-workflow artifact fetching would require additional complexity
+      # 3. The changelog preview is less critical than the main release action
+      # For now, we always use the released version for changelog previews.
       - name: Install Craft
-        uses: getsentry/craft/install@master
-        with:
-          craft-version: ${{ inputs.craft-version || 'latest' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          CRAFT_VERSION="${{ inputs.craft-version || 'latest' }}"
+          
+          if [[ "$CRAFT_VERSION" == "latest" || -z "$CRAFT_VERSION" ]]; then
+            echo "Downloading latest Craft release..."
+            CRAFT_URL=$(curl -fsSL "https://api.github.com/repos/getsentry/craft/releases/latest" \
+              | jq -r '.assets[] | select(.name == "craft") | .browser_download_url')
+          else
+            CRAFT_URL="https://github.com/getsentry/craft/releases/download/${CRAFT_VERSION}/craft"
+            echo "Downloading Craft ${CRAFT_VERSION}..."
+            
+            # Fallback to latest if specified version doesn't exist
+            if ! curl -sfI "$CRAFT_URL" >/dev/null 2>&1; then
+              echo "Release not found for version '${CRAFT_VERSION}', falling back to latest..."
+              CRAFT_URL=$(curl -fsSL "https://api.github.com/repos/getsentry/craft/releases/latest" \
+                | jq -r '.assets[] | select(.name == "craft") | .browser_download_url')
+            fi
+          fi
+          
+          # Verify we have a valid URL
+          if [[ -z "$CRAFT_URL" ]]; then
+            echo "::error::Failed to determine Craft download URL"
+            exit 1
+          fi
+          
+          echo "Installing Craft from: ${CRAFT_URL}"
+          sudo curl -fsSL -o /usr/local/bin/craft "$CRAFT_URL"
+          sudo chmod +x /usr/local/bin/craft
+          
+          # Verify installation
+          if [[ ! -s /usr/local/bin/craft ]]; then
+            echo "::error::Downloaded Craft binary is empty or missing"
+            exit 1
+          fi
+          
+          craft --version
 
       - name: Generate Changelog Preview
         shell: bash


### PR DESCRIPTION
## Problem

PR #705 removed the `install/` sub-action, but the `changelog-preview.yml` workflow was still referencing it:

```yaml
uses: getsentry/craft/install@master
```

This broke the changelog preview workflow for all PRs.

## Solution

Replace the deleted sub-action reference with inline install logic that downloads Craft from release:

- Respects `craft-version` input (defaults to latest)
- Falls back to latest if specified version doesn't exist
- Adds robust error handling with `set -euo pipefail`
- Verifies download succeeded and binary is valid
- Runs `craft --version` to confirm installation

## Why No Dogfooding?

Unlike the main release action, this workflow **does not dogfood** (use build artifacts from PRs) because:

1. **Different workflow runs**: The build workflow runs separately, and artifacts are scoped to that workflow run
2. **Complexity**: Cross-workflow artifact fetching would require additional dependencies and logic
3. **Timing issues**: Build workflow might still be running when changelog-preview starts
4. **Lower criticality**: Changelog preview is less critical than the main release action

For changelog previews, we always use the released version of Craft.