### PR TITLE
fix(docker): Add GITHUB_API_TOKEN and x-access-token fallbacks for ghcr.io

### DIFF
--- a/src/targets/docker.ts
+++ b/src/targets/docker.ts
@@ -331,15 +331,18 @@ export class DockerTarget extends BaseTarget {
           // GHCR defaults: use GitHub Actions built-in env vars
           // GITHUB_ACTOR and GITHUB_TOKEN are available by default in GitHub Actions
           // See: https://docs.github.com/en/actions/reference/workflows-and-actions/variables
-          username = username ?? process.env.GITHUB_ACTOR;
-          password = password ?? process.env.GITHUB_TOKEN;
+          // GITHUB_API_TOKEN is used by getsentry/publish workflow with release bot token
+          // x-access-token works with GitHub App installation tokens and PATs
+          username = username || process.env.GITHUB_ACTOR || 'x-access-token';
+          password = password || process.env.GITHUB_TOKEN || process.env.GITHUB_API_TOKEN;
         }
       }
 
       // 3. Fallback to defaults (only for target registry, not for source)
+      // Use || to treat empty strings as "not set" (consistent with ghcr.io logic above)
       if (useDefaultFallback) {
-        username = username ?? process.env.DOCKER_USERNAME;
-        password = password ?? process.env.DOCKER_PASSWORD;
+        username = username || process.env.DOCKER_USERNAME;
+        password = password || process.env.DOCKER_PASSWORD;
       }
     }
 


### PR DESCRIPTION
## Summary

Add fallback credential support for ghcr.io authentication to work with GitHub App tokens used in the getsentry/publish workflow.

## Changes

- Add `GITHUB_API_TOKEN` as a fallback password when `GITHUB_TOKEN` is not set
- Add `x-access-token` as a fallback username when `GITHUB_ACTOR` is empty or not set
- Use `||` instead of `??` to also handle empty string values

## Fallback Chain for ghcr.io

1. `DOCKER_GHCR_IO_USERNAME` / `DOCKER_GHCR_IO_PASSWORD`
2. `GITHUB_ACTOR` / `GITHUB_TOKEN`
3. `x-access-token` / `GITHUB_API_TOKEN` (new)
4. `DOCKER_USERNAME` / `DOCKER_PASSWORD` (existing universal fallback)

## Related

- Companion change in getsentry/publish: https://github.com/getsentry/publish/commit/d83d81d