### PR TITLE
fix(docker): Add image template var and strict template validation

### DIFF
--- a/docs/src/content/docs/targets/docker.md
+++ b/docs/src/content/docs/targets/docker.md
@@ -18,10 +18,20 @@ Copies an existing source image tagged with the revision SHA to a new target tag
 |----------|-------------|
 | `image` | Docker image path (e.g., `ghcr.io/org/image`) |
 | `registry` | Override the registry (auto-detected from `image`) |
-| `format` | Format template. Default: `{{{source}}}:{{{revision}}}` for source |
+| `format` | Format template (see below). Default: `{{{source}}}:{{{revision}}}` for source, `{{{target}}}:{{{version}}}` for target |
 | `usernameVar` | Env var name for username |
 | `passwordVar` | Env var name for password |
 | `skipLogin` | Skip `docker login` for this registry |
+
+### Format Template Variables
+
+| Variable | Description |
+|----------|-------------|
+| `{{{image}}}` | The `image` value from the current block (source or target) |
+| `{{{source}}}` | The source image path |
+| `{{{target}}}` | The target image path |
+| `{{{revision}}}` | Git revision SHA (source format only) |
+| `{{{version}}}` | Release version (target format only) |
 
 ## Environment Variables
 
@@ -89,6 +99,25 @@ targets:
       usernameVar: PRIVATE_REGISTRY_USER
       passwordVar: PRIVATE_REGISTRY_PASS
     target: getsentry/craft
+```
+
+### Custom Format with "latest" Tag
+
+```yaml
+targets:
+  # Versioned tag
+  - name: docker
+    id: versioned
+    source: ghcr.io/getsentry/spotlight
+    target: ghcr.io/getsentry/spotlight
+
+  # Latest tag
+  - name: docker
+    id: latest
+    source: ghcr.io/getsentry/spotlight
+    target:
+      image: ghcr.io/getsentry/spotlight
+      format: "{{{image}}}:latest"
 ```
 
 ### Google Cloud Registries

--- a/src/targets/docker.ts
+++ b/src/targets/docker.ts
@@ -549,7 +549,9 @@ Please use ${registryHint}DOCKER_USERNAME and DOCKER_PASSWORD environment variab
     } else if (
       sourceRegistry &&
       !source.skipLogin &&
-      !gcrConfiguredRegistries.has(sourceRegistry)
+      !gcrConfiguredRegistries.has(sourceRegistry) &&
+      // Don't warn if source and target share the same registry - target login will cover it
+      sourceRegistry !== targetRegistry
     ) {
       // Source registry needs auth but we couldn't configure it
       // This is okay - source might be public or already authenticated
@@ -582,11 +584,13 @@ Please use ${registryHint}DOCKER_USERNAME and DOCKER_PASSWORD environment variab
     const { source, target } = this.dockerConfig;
 
     const sourceImage = renderTemplateSafe(source.format, {
+      image: source.image,
       source: source.image,
       target: target.image,
       revision: sourceRevision,
     });
     const targetImage = renderTemplateSafe(target.format, {
+      image: target.image,
       source: source.image,
       target: target.image,
       version,

--- a/src/utils/__tests__/strings.test.ts
+++ b/src/utils/__tests__/strings.test.ts
@@ -5,6 +5,7 @@ import {
   formatSize,
   formatJson,
 } from '../strings';
+import { ConfigurationError } from '../errors';
 
 describe('sanitizeObject', () => {
   test('processes empty object', () => {
@@ -69,8 +70,31 @@ describe('renderTemplateSafe', () => {
     );
   });
 
-  test('does not render globals', () => {
-    expect(renderTemplateSafe('{{ process }}', {})).toBe('');
+  test('throws error on unknown variable', () => {
+    expect(() => renderTemplateSafe('{{ unknown }}', { known: 'value' })).toThrow(
+      ConfigurationError
+    );
+    expect(() => renderTemplateSafe('{{ unknown }}', { known: 'value' })).toThrow(
+      /Unknown template variable\(s\): unknown/
+    );
+  });
+
+  test('throws error with available variables in message', () => {
+    expect(() =>
+      renderTemplateSafe('{{ missing }}', { foo: 1, bar: 2 })
+    ).toThrow(/Available variables: foo, bar/);
+  });
+
+  test('throws error for globals (prevents accidental access)', () => {
+    expect(() => renderTemplateSafe('{{ process }}', {})).toThrow(
+      ConfigurationError
+    );
+  });
+
+  test('throws error listing all unknown variables', () => {
+    expect(() =>
+      renderTemplateSafe('{{ a }} {{ b }} {{ c }}', { x: 1 })
+    ).toThrow(/Unknown template variable\(s\): a, b, c/);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two issues when publishing Docker images and adds a third improvement for better error handling:

### 1. Fix misleading "No credentials" debug message

When source and target registries are the same (e.g., both `ghcr.io`), the debug message "No credentials for source registry ghcr.io, assuming public" was shown even though credentials were available and login succeeded. Now we skip this message when the registries match since target login covers both.

### 2. Add `{{{image}}}` template variable support

Users can now use `{{{image}}}` in their format strings, which is more intuitive when defining formats inside source/target blocks:

```yaml
target:
  image: ghcr.io/getsentry/spotlight
  format: "{{{image}}}:latest"
```

### 3. Strict template variable validation

`renderTemplateSafe` now throws a `ConfigurationError` with a helpful message when an unknown template variable is used, instead of silently rendering an empty string:

```
ConfigurationError: Unknown template variable(s): typo. Available variables: image, source, target, version
```

This would have caught the original issue immediately rather than producing an invalid Docker reference like `:latest`.