### PR TITLE
fix(action): Use environment variables for complex inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,20 +77,9 @@ runs:
     - name: Set git user
       shell: bash
       env:
-        INPUT_GIT_USER_NAME: ${{ inputs.git_user_name }}
-        INPUT_GIT_USER_EMAIL: ${{ inputs.git_user_email }}
+        GIT_USER_NAME: ${{ inputs.git_user_name || github.actor }}
+        GIT_USER_EMAIL: ${{ inputs.git_user_email || format('{0}+{1}@users.noreply.github.com', github.actor_id, github.actor) }}
       run: |
-        # Use provided values or fall back to triggering actor
-        GIT_USER_NAME="${INPUT_GIT_USER_NAME}"
-        GIT_USER_EMAIL="${INPUT_GIT_USER_EMAIL}"
-
-        if [[ -z "$GIT_USER_NAME" ]]; then
-          GIT_USER_NAME="${GITHUB_ACTOR}"
-        fi
-        if [[ -z "$GIT_USER_EMAIL" ]]; then
-          GIT_USER_EMAIL="${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
-        fi
-
         echo "GIT_COMMITTER_NAME=${GIT_USER_NAME}" >> $GITHUB_ENV
         echo "GIT_AUTHOR_NAME=${GIT_USER_NAME}" >> $GITHUB_ENV
         echo "EMAIL=${GIT_USER_EMAIL}" >> $GITHUB_ENV
@@ -200,40 +189,20 @@ runs:
       env:
         CHANGELOG: ${{ steps.craft.outputs.changelog }}
         TARGETS: ${{ steps.craft-targets.outputs.targets }}
-        VERSION: ${{ steps.craft.outputs.version }}
-        BRANCH: ${{ steps.craft.outputs.branch }}
-        SHA: ${{ steps.craft.outputs.sha }}
-        PREVIOUS_TAG: ${{ steps.craft.outputs.previous_tag }}
-        INPUT_PATH: ${{ inputs.path }}
-        INPUT_MERGE_TARGET: ${{ inputs.merge_target }}
-        INPUT_PUBLISH_REPO: ${{ inputs.publish_repo }}
+        RESOLVED_VERSION: ${{ steps.craft.outputs.version }}
+        RELEASE_BRANCH: ${{ steps.craft.outputs.branch }}
+        RELEASE_SHA: ${{ steps.craft.outputs.sha }}
+        RELEASE_PREVIOUS_TAG: ${{ steps.craft.outputs.previous_tag || 'HEAD' }}
+        SUBDIRECTORY: ${{ inputs.path != '.' && format('/{0}', inputs.path) || '' }}
+        MERGE_TARGET: ${{ inputs.merge_target || '(default)' }}
+        PUBLISH_REPO: ${{ inputs.publish_repo || format('{0}/publish', github.repository_owner) }}
       run: |
-        if [[ "$INPUT_PATH" == "." ]]; then
-          subdirectory=''
-        else
-          subdirectory="/$INPUT_PATH"
-        fi
-
-        if [[ -n "$INPUT_MERGE_TARGET" ]]; then
-          merge_target="$INPUT_MERGE_TARGET"
-        else
-          merge_target='(default)'
-        fi
-
-        # Use resolved version from Craft output
-        RESOLVED_VERSION="$VERSION"
         if [[ -z "$RESOLVED_VERSION" ]]; then
           echo "::error::Craft did not output a version. This is unexpected."
           exit 1
         fi
 
-        title="publish: ${GITHUB_REPOSITORY}${subdirectory}@${RESOLVED_VERSION}"
-
-        # Determine publish repo
-        PUBLISH_REPO="$INPUT_PUBLISH_REPO"
-        if [[ -z "$PUBLISH_REPO" ]]; then
-          PUBLISH_REPO="${GITHUB_REPOSITORY_OWNER}/publish"
-        fi
+        title="publish: ${GITHUB_REPOSITORY}${SUBDIRECTORY}@${RESOLVED_VERSION}"
 
         # Check if issue already exists
         # GitHub only allows search with the "in" operator and this issue search can
@@ -244,16 +213,6 @@ runs:
           echo "::notice::Existing publish request: ${existing_issue_url}"
           echo "issue_url=${existing_issue_url}" >> "$GITHUB_OUTPUT"
           exit 0
-        fi
-
-        # Use Craft outputs for git info
-        RELEASE_BRANCH="$BRANCH"
-        RELEASE_SHA="$SHA"
-        RELEASE_PREVIOUS_TAG="$PREVIOUS_TAG"
-
-        # Fall back to HEAD if no previous tag
-        if [[ -z "$RELEASE_PREVIOUS_TAG" ]]; then
-          RELEASE_PREVIOUS_TAG="HEAD"
         fi
 
         # Build changelog section if available
@@ -273,7 +232,7 @@ runs:
 
         body="Requested by: @${GITHUB_ACTOR}
 
-        Merge target: ${merge_target}
+        Merge target: ${MERGE_TARGET}
 
         Quick links:
         - [View changes](https://github.com/${GITHUB_REPOSITORY}/compare/${RELEASE_PREVIOUS_TAG}...${RELEASE_BRANCH})


### PR DESCRIPTION
## Description

This PR refactors the 'Set git user' and 'Request publish' steps in `action.yml` to use environment variables for potentially complex data instead of direct string interpolation in bash scripts.

## Problem

Injecting content like `${{ steps.craft.outputs.changelog }}` directly into a bash script using single quotes fails if the content contains single quotes or other special characters (e.g., `syntax error near unexpected token '('`).

## Solution

Pass these values as environment variables, which is the recommended and safe way to handle complex string data in GitHub Actions.

## Changes

- Updated 'Set git user' to use `INPUT_GIT_USER_NAME` and `INPUT_GIT_USER_EMAIL` env vars.
- Updated 'Request publish' to use environment variables for `CHANGELOG`, `TARGETS`, `VERSION`, etc.