### PR TITLE
meta: Rename changelog category to "Internal Changes"

### DIFF
--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -140,7 +140,7 @@ changelog:
       commit_patterns:
         - "^(?<type>docs?(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
       semver: patch
-    - title: Build / dependencies / internal 🔧
+    - title: Internal Changes 🔧
       commit_patterns:
         - "^(?<type>(?:build|refactor|meta|chore|ci|ref|perf)(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
       semver: patch

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -818,7 +818,7 @@ export const DEFAULT_RELEASE_CONFIG: ReleaseConfig = {
         semver: 'patch',
       },
       {
-        title: 'Build / dependencies / internal 🔧',
+        title: 'Internal Changes 🔧',
         commit_patterns: [
           '^(?<type>(?:build|refactor|meta|chore|ci|ref|perf)(?:\\((?<scope>[^)]+)\\))?!?:\\s*)',
         ],


### PR DESCRIPTION
## Summary

- Renamed the default changelog category from "Build / dependencies / internal 🔧" to "Internal Changes 🔧"
- Updated both source code (`src/utils/changelog.ts`) and documentation (`docs/src/content/docs/configuration.md`)
- Kept the 🔧 emoji for consistency

This makes the category name clearer and more concise while maintaining its purpose of grouping build, refactor, chore, CI, and performance commits.