### PR TITLE
fix(github): Use pull_request_target for changelog preview on fork PRs

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -6,18 +6,22 @@ on:
   # USAGE REQUIREMENTS:
   # When calling this workflow from another repository, you must:
   #
-  # 1. Grant required permissions:
+  # 1. Use pull_request_target (NOT pull_request):
+  #    - This is required to post comments on PRs from forks
+  #    - pull_request event has read-only GITHUB_TOKEN for fork PRs
+  #
+  # 2. Grant required permissions:
   #    - contents: read        (to checkout repo and read git history)
   #    - pull-requests: write  (to post/update PR comments in comment mode)
   #    - statuses: write       (to create commit statuses in status check mode)
   #
-  # 2. Inherit secrets:
+  # 3. Inherit secrets:
   #    - secrets: inherit      (ensures caller's GITHUB_TOKEN is used)
   #
   # Example caller workflow (comment mode):
   #
   #   on:
-  #     pull_request:
+  #     pull_request_target:
   #       types: [opened, synchronize, reopened, edited, labeled, unlabeled]
   #
   #   permissions:
@@ -42,6 +46,12 @@ on:
   #         comment: false
   #       secrets: inherit
   #
+  # SECURITY NOTE:
+  # This workflow is safe to use with pull_request_target because:
+  # - The Craft binary is downloaded from releases, NOT from the PR
+  # - Only git metadata (commits, tags) and .craft.yml config are read
+  # - No code from the PR is ever executed
+  #
   workflow_call:
     inputs:
       working-directory:
@@ -59,9 +69,8 @@ on:
         type: boolean
         default: true
 
-  # Also run on PRs in this repository (for dogfooding)
-  # Includes 'edited' and 'labeled' to update when PR title/description/labels change
-  pull_request:
+  # Also run on PRs in this repository (dogfooding)
+  pull_request_target:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 permissions:
@@ -73,16 +82,21 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
+      # For pull_request_target, we must explicitly specify the ref to get the PR commits.
+      # Try the merge ref first; fall back to head ref if PR has merge conflicts.
       - uses: actions/checkout@v4
+        id: checkout-merge
+        continue-on-error: true
         with:
           fetch-depth: 0
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      # Install Craft from release
-      # Note: Dogfooding (using build artifact from this PR) is not feasible here because:
-      # 1. The build workflow runs separately and artifacts are scoped to that workflow run
-      # 2. Cross-workflow artifact fetching would require additional complexity
-      # 3. The changelog preview is less critical than the main release action
-      # For now, we always use the released version for changelog previews.
+      - uses: actions/checkout@v4
+        if: steps.checkout-merge.outcome == 'failure'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Install Craft
         shell: bash
         run: |
@@ -134,11 +148,9 @@ jobs:
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          # Generate changelog with current PR injected and highlighted (JSON format)
           echo "Running craft changelog --pr $PR_NUMBER --format json..."
           RESULT=$(craft changelog --pr "$PR_NUMBER" --format json 2>/dev/null || echo '{"changelog":"","bumpType":null}')
 
-          # Extract fields from JSON
           CHANGELOG=$(echo "$RESULT" | jq -r '.changelog // ""')
           BUMP_TYPE=$(echo "$RESULT" | jq -r '.bumpType // "none"')
           PR_SKIPPED=$(echo "$RESULT" | jq -r '.prSkipped // false')
@@ -149,7 +161,6 @@ jobs:
             CHANGELOG="_No changelog entries will be generated from this PR._"
           fi
 
-          # Format bump type for display
           case "$BUMP_TYPE" in
             major) BUMP_BADGE="🔴 **Major** (breaking changes)" ;;
             minor) BUMP_BADGE="🟡 **Minor** (new features)" ;;
@@ -157,7 +168,6 @@ jobs:
             *) BUMP_BADGE="⚪ **None** (no version bump detected)" ;;
           esac
 
-          # Create descriptions for status check (no emoji support in Commit Status API)
           case "$BUMP_TYPE" in
             major) 
               BUMP_SHORT="Major"
@@ -230,7 +240,6 @@ jobs:
             # Comment mode (original behavior)
             echo "Using comment mode..."
             
-            # Build comment body using a temp file (safer than heredoc)
             COMMENT_FILE=$(mktemp)
             cat > "$COMMENT_FILE" << CRAFT_CHANGELOG_COMMENT_END
           <!-- craft-changelog-preview -->
@@ -255,7 +264,6 @@ jobs:
           <sub>🤖 This preview updates automatically when you update the PR.</sub>
           CRAFT_CHANGELOG_COMMENT_END
 
-            # Find existing comment with our marker
             COMMENT_ID=$(gh api \
               "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
               --jq '.[] | select(.body | contains("<!-- craft-changelog-preview -->")) | .id' \

--- a/docs/src/content/docs/github-actions.md
+++ b/docs/src/content/docs/github-actions.md
@@ -127,8 +127,8 @@ Call the reusable workflow from your repository:
 ```yaml
 name: Changelog Preview
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited, labeled]
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -139,6 +139,12 @@ jobs:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
     secrets: inherit
 ```
+
+:::caution[Use `pull_request_target`, not `pull_request`]
+The workflow requires `pull_request_target` to post comments on PRs from forks. The standard `pull_request` event provides a read-only `GITHUB_TOKEN` for fork PRs, which would cause the workflow to fail with a 403 error.
+
+This is safe because the workflow only reads git metadata and config - no code from the PR is executed.
+:::
 
 ### Inputs
 
@@ -225,6 +231,10 @@ Craft itself uses status check mode to avoid notification noise. You can see it 
 ### Pinning a Specific Version
 
 ```yaml
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
 permissions:
   contents: read
   pull-requests: write
@@ -358,8 +368,8 @@ You can use both the changelog preview and release workflows together for a comp
 # .github/workflows/changelog-preview.yml
 name: Changelog Preview
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited, labeled]
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Fixes changelog-preview workflow failing with HTTP 403 on PRs from forks.

**Problem:** The `pull_request` event provides a read-only `GITHUB_TOKEN` for fork PRs (security measure), preventing the workflow from posting comments.

**Solution:** Switch to `pull_request_target` which runs in the base repository context with write permissions.

## Changes

- Changed event trigger from `pull_request` to `pull_request_target`
- Added explicit `ref` to checkout step (required because `pull_request_target` defaults to base branch)
- Updated documentation to recommend callers use `pull_request_target`
- Added security note explaining why this approach is safe

## Security

This is safe because:
- Craft binary is downloaded from releases, not from the PR
- Only git metadata and `.craft.yml` config are read
- No code from the PR is ever executed