### PR TITLE
fix(actions): use repository check instead of event_name for dogfooding conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ on:
 jobs:
   # Build job only for Craft's own releases (dogfooding)
   build:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.repository == 'getsentry/craft'
     name: Build
     uses: ./.github/workflows/build.yml
     permissions:
@@ -114,7 +114,7 @@ jobs:
 
       # For Craft's own releases: use local action (dogfooding)
       - name: Prepare release (dogfooding)
-        if: github.event_name == 'workflow_dispatch'
+        if: github.repository == 'getsentry/craft'
         id: craft-local
         uses: ./
         env:
@@ -125,7 +125,7 @@ jobs:
 
       # For external repos: use published action
       - name: Prepare release
-        if: github.event_name == 'workflow_call'
+        if: github.repository != 'getsentry/craft'
         id: craft-action
         uses: getsentry/craft@v2
         env:


### PR DESCRIPTION
## Summary

When external repos call the reusable release workflow via `workflow_call`, the `github.event_name` still reflects the original trigger (e.g., `workflow_dispatch` from the caller). This caused the build job and dogfooding steps to incorrectly run for external repos.

This fix changes the conditions to check `github.repository == 'getsentry/craft'` instead of `github.event_name`, properly distinguishing Craft's own releases from external callers.

## Changes

- Build job: `github.event_name == 'workflow_dispatch'` → `github.repository == 'getsentry/craft'`
- Dogfooding step: `github.event_name == 'workflow_dispatch'` → `github.repository == 'getsentry/craft'`  
- External step: `github.event_name == 'workflow_call'` → `github.repository != 'getsentry/craft'`