### PR TITLE
fix(action): Expand changelog by default in publish issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -219,7 +219,7 @@ runs:
           CHANGELOG_SECTION="
         ---
 
-        <details>
+        <details open>
         <summary>📋 Changelog</summary>
 
         ${CHANGELOG}


### PR DESCRIPTION
## Summary

- Make the changelog section expanded by default in publish issues by adding the `open` attribute to the `<details>` tag

## Motivation

Feedback indicated that reviewers almost always click to expand the changelog before approving a release. Having it expanded by default improves the workflow since the changelog content is immediately visible alongside the repo name and who triggered the release.

Users can still manually collapse the section if desired.