### PR TITLE
docs: Update base path for craft.sentry.dev domain

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: docs
         env:
           # Override base path for PR preview
-          DOCS_BASE_PATH: /craft/pr-preview/pr-${{ github.event.pull_request.number }}
+          DOCS_BASE_PATH: /pr-preview/pr-${{ github.event.pull_request.number }}
         run: |
           pnpm install --frozen-lockfile
           pnpm build
@@ -74,4 +74,5 @@ jobs:
           source-dir: docs/dist/
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+          pages-base-url: craft.sentry.dev
           action: auto

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,10 +2,10 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
 // Allow base path override via environment variable for PR previews
-const base = process.env.DOCS_BASE_PATH || '/craft';
+const base = process.env.DOCS_BASE_PATH || '/';
 
 export default defineConfig({
-  site: 'https://getsentry.github.io',
+  site: 'https://craft.sentry.dev',
   base: base,
   integrations: [
     starlight({


### PR DESCRIPTION
## Summary

The docs site has moved from \`getsentry.github.io/craft\` to \`craft.sentry.dev\`. This caused assets to fail loading as they were still being served from \`/craft/\`.

## Changes

- Change default base path from \`/craft\` to \`/\`
- Update site URL to \`https://craft.sentry.dev\`

PR previews continue to work via \`DOCS_BASE_PATH\` environment variable override in the workflow.