### PR TITLE
feat: Add noMerge config option with auto-detection for GitHub Actions

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -17,10 +17,7 @@ describe('validateConfiguration', () => {
   test('parses configuration with targets', () => {
     const data = {
       github: { owner: 'getsentry', repo: 'craft' },
-      targets: [
-        { name: 'npm' },
-        { name: 'github', tagPrefix: 'v' },
-      ],
+      targets: [{ name: 'npm' }, { name: 'github', tagPrefix: 'v' }],
     };
 
     expect(validateConfiguration(data)).toEqual(data);
@@ -61,18 +58,21 @@ describe('validateConfiguration', () => {
   });
 
   test('fails with invalid github config', () => {
-    expect(() => validateConfiguration({ github: { owner: 'getsentry' } }))
-      .toThrow(/repo.*Required/);
+    expect(() =>
+      validateConfiguration({ github: { owner: 'getsentry' } }),
+    ).toThrow(/repo.*Required/);
   });
 
   test('fails with invalid minVersion format', () => {
-    expect(() => validateConfiguration({ minVersion: 'invalid' }))
-      .toThrow(/minVersion/);
+    expect(() => validateConfiguration({ minVersion: 'invalid' })).toThrow(
+      /minVersion/,
+    );
   });
 
   test('fails with invalid changelog policy', () => {
-    expect(() => validateConfiguration({ changelog: { policy: 'invalid' } }))
-      .toThrow(/changelog/);
+    expect(() =>
+      validateConfiguration({ changelog: { policy: 'invalid' } }),
+    ).toThrow(/changelog/);
   });
 });
 
@@ -94,5 +94,27 @@ describe('CraftProjectConfigSchema', () => {
 
     const result = CraftProjectConfigSchema.safeParse(data);
     expect(result.success).toBe(false);
+  });
+});
+
+describe('noMerge config', () => {
+  test('parses configuration with noMerge: true', () => {
+    const data = { noMerge: true };
+    expect(validateConfiguration(data)).toEqual(data);
+  });
+
+  test('parses configuration with noMerge: false', () => {
+    const data = { noMerge: false };
+    expect(validateConfiguration(data)).toEqual(data);
+  });
+
+  test('noMerge defaults to undefined when not specified', () => {
+    const data = { github: { owner: 'getsentry', repo: 'craft' } };
+    const result = validateConfiguration(data);
+    expect(result.noMerge).toBeUndefined();
+  });
+
+  test('fails with invalid noMerge type', () => {
+    expect(() => validateConfiguration({ noMerge: 'yes' })).toThrow(/noMerge/);
   });
 });

--- a/src/schemas/project_config.ts
+++ b/src/schemas/project_config.ts
@@ -85,17 +85,17 @@ export type BaseArtifactProvider = z.infer<typeof BaseArtifactProviderSchema>;
 /**
  * Artifact pattern(s) for a single workflow - can be a single string or array of strings
  */
-export const ArtifactPatternsSchema = z.union([z.string(), z.array(z.string())]);
+export const ArtifactPatternsSchema = z.union([
+  z.string(),
+  z.array(z.string()),
+]);
 
 /**
  * Artifacts config for GitHub artifact provider.
  * Accepts string, array of strings, or object mapping workflow names to artifact patterns.
  */
 export const GitHubArtifactsConfigSchema = z
-  .union([
-    ArtifactPatternsSchema,
-    z.record(z.string(), ArtifactPatternsSchema),
-  ])
+  .union([ArtifactPatternsSchema, z.record(z.string(), ArtifactPatternsSchema)])
   .optional();
 
 export type GitHubArtifactsConfig = z.infer<typeof GitHubArtifactsConfigSchema>;
@@ -161,11 +161,19 @@ export const CraftProjectConfigSchema = z.object({
   releaseBranchPrefix: z.string().optional(),
   changelog: ChangelogConfigSchema.optional(),
   changelogPolicy: z.enum(['auto', 'simple', 'none']).optional(),
-  minVersion: z.string().regex(/^\d+\.\d+\.\d+.*$/).optional(),
+  minVersion: z
+    .string()
+    .regex(/^\d+\.\d+\.\d+.*$/)
+    .optional(),
   requireNames: z.array(z.string()).optional(),
   statusProvider: BaseStatusProviderSchema.optional(),
   artifactProvider: BaseArtifactProviderSchema.optional(),
   versioning: VersioningConfigSchema.optional(),
+  /**
+   * Do not merge the release branch after publishing.
+   * Defaults to true for compiled GitHub Actions (Node.js actions with dist/ folder).
+   */
+  noMerge: z.boolean().optional(),
 });
 
 export type CraftProjectConfig = z.infer<typeof CraftProjectConfigSchema>;

--- a/src/utils/__tests__/detection.test.ts
+++ b/src/utils/__tests__/detection.test.ts
@@ -1,0 +1,185 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+
+import { isCompiledGitHubAction } from '../detection';
+
+describe('isCompiledGitHubAction', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(
+      os.tmpdir(),
+      `craft-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('returns false when no action.yml exists', () => {
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('returns false for composite action', () => {
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Action'
+runs:
+  using: 'composite'
+  steps:
+    - run: echo "Hello"
+      shell: bash
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('returns false for docker action', () => {
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Docker Action'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('returns true for node20 action with dist/index.js', () => {
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Node Action'
+runs:
+  using: 'node20'
+  main: 'dist/index.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(true);
+  });
+
+  test('returns true for node16 action with ./dist/index.js', () => {
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Node Action'
+runs:
+  using: 'node16'
+  main: './dist/index.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(true);
+  });
+
+  test('returns true for node12 action with dist/main.js', () => {
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Node Action'
+runs:
+  using: 'node12'
+  main: 'dist/main.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(true);
+  });
+
+  test('returns false for node action without dist/ in main path', () => {
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Node Action'
+runs:
+  using: 'node20'
+  main: 'src/index.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('returns false for node action with nested dist/ path (not root-level)', () => {
+    // This should NOT be detected as a compiled action because dist/ is not at the root
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Node Action'
+runs:
+  using: 'node20'
+  main: 'lib/dist/index.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('returns false for node action with no main field', () => {
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'My Node Action'
+runs:
+  using: 'node20'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('works with action.yaml (alternative extension)', () => {
+    writeFileSync(
+      join(tempDir, 'action.yaml'),
+      `name: 'My Node Action'
+runs:
+  using: 'node20'
+  main: 'dist/index.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(true);
+  });
+
+  test('returns false for malformed YAML', () => {
+    writeFileSync(join(tempDir, 'action.yml'), 'this is not: valid: yaml: {{');
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('returns false for empty action.yml', () => {
+    writeFileSync(join(tempDir, 'action.yml'), '');
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('prefers action.yml over action.yaml', () => {
+    // action.yml is NOT a compiled action
+    writeFileSync(
+      join(tempDir, 'action.yml'),
+      `name: 'Composite'
+runs:
+  using: 'composite'
+  steps:
+    - run: echo "Hello"
+      shell: bash
+`,
+    );
+    // action.yaml IS a compiled action - but action.yml takes precedence
+    writeFileSync(
+      join(tempDir, 'action.yaml'),
+      `name: 'Node'
+runs:
+  using: 'node20'
+  main: 'dist/index.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+
+  test('empty action.yml still takes precedence over valid action.yaml', () => {
+    // Empty action.yml should still be preferred (and result in false)
+    writeFileSync(join(tempDir, 'action.yml'), '');
+    // action.yaml IS a compiled action - but empty action.yml takes precedence
+    writeFileSync(
+      join(tempDir, 'action.yaml'),
+      `name: 'Node'
+runs:
+  using: 'node20'
+  main: 'dist/index.js'
+`,
+    );
+    expect(isCompiledGitHubAction(tempDir)).toBe(false);
+  });
+});

--- a/src/utils/detection.ts
+++ b/src/utils/detection.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { load } from 'js-yaml';
+
+/**
+ * GitHub Action manifest structure (partial, only what we need)
+ */
+interface ActionManifest {
+  runs?: {
+    using?: string;
+    main?: string;
+  };
+}
+
+/**
+ * Read a file as text from the project directory
+ */
+function readTextFile(
+  rootDir: string,
+  ...pathSegments: string[]
+): string | null {
+  const filePath = path.join(rootDir, ...pathSegments);
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  try {
+    return readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect if a project is a compiled GitHub Action.
+ *
+ * A compiled GitHub Action is identified by:
+ * 1. Has `action.yml` or `action.yaml` at the root
+ * 2. The `runs.using` field starts with `node` (e.g., `node20`, `node16`, `node12`)
+ * 3. The `runs.main` field references a path in `dist/` (e.g., `dist/index.js`)
+ *
+ * These actions typically have their `dist/` folder gitignored on main/master
+ * but need it in release branches for the action to work. Merging the release
+ * branch back would overwrite the clean main branch with compiled artifacts.
+ *
+ * @param rootDir The root directory of the project
+ * @returns true if the project is a compiled GitHub Action
+ */
+export function isCompiledGitHubAction(rootDir: string): boolean {
+  // Check for action.yml or action.yaml (action.yml takes precedence)
+  // Use ?? instead of || so empty files are still respected as "existing"
+  const actionContent =
+    readTextFile(rootDir, 'action.yml') ?? readTextFile(rootDir, 'action.yaml');
+
+  if (!actionContent) {
+    return false;
+  }
+
+  try {
+    const manifest = load(actionContent) as ActionManifest;
+
+    // Check if it's a Node.js action
+    const using = manifest?.runs?.using;
+    if (!using || !using.startsWith('node')) {
+      return false;
+    }
+
+    // Check if main references dist/
+    const main = manifest?.runs?.main;
+    if (!main) {
+      return false;
+    }
+
+    // Check if main path starts with 'dist/' (after removing optional './' prefix)
+    // Common patterns: 'dist/index.js', './dist/index.js', 'dist/main.js'
+    // We only check for root-level dist/ since that's the standard for compiled actions
+    const normalizedMain = main.replace(/^\.\//, '');
+    return normalizedMain.startsWith('dist/');
+  } catch {
+    // If we can't parse the YAML, assume it's not a compiled action
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Add `noMerge` as a config option in `.craft.yml` that mirrors the `--no-merge` CLI flag. When enabled, the release branch is not merged back into main/master after publishing.

**Key features:**
- New `noMerge: true/false` option in `.craft.yml`
- Auto-detects compiled GitHub Actions (Node.js actions with `dist/` folder) and defaults to `noMerge: true`
- Clear logging indicates why merging was skipped (CLI, config, or auto-detected)
- Warns if `--merge-target` is specified but ignored due to noMerge

## Why?

Compiled GitHub Actions (built with `@vercel/ncc` or `esbuild`) need the `dist/` folder in release branches but typically gitignore it on main. Merging the release branch back would overwrite the clean main with compiled artifacts.

## Example

```yaml
# .craft.yml
minVersion: '2.21.0'
noMerge: true  # Optional - auto-detected for compiled GitHub Actions
targets:
  - name: github
```

## Changes

- `src/schemas/project_config.ts` - Added `noMerge` to config schema
- `src/utils/detection.ts` - New file with `isCompiledGitHubAction()` detection
- `src/config.ts` - Added `getNoMergeConfig()` accessor function
- `src/commands/publish.ts` - Modified merge logic to respect config
- Added tests for config parsing and detection

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>8f2ab72</u></sup><!-- /BUGBOT_STATUS -->