### PR TITLE
feat: Update publish issue body when re-running GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -206,7 +206,9 @@ runs:
 
         # Check if issue already exists by listing all open issues and filtering by exact title match.
         # We avoid GitHub search API to bypass indexing delays and query syntax edge cases.
-        existing_issue=$(gh -R "$PUBLISH_REPO" issue list --json title,url,number,body | jq -r --arg t "$title" '.[] | select(.title == $t)')
+        # gh issue list returns issues sorted by creation date (most recent first), so we take
+        # the first match to handle the theoretical case of duplicate titles.
+        existing_issue=$(gh -R "$PUBLISH_REPO" issue list --json title,url,number,body | jq -r --arg t "$title" '[.[] | select(.title == $t)] | first // empty')
         existing_issue_url=""
         existing_issue_number=""
         existing_body=""


### PR DESCRIPTION
## Summary

- Updates existing publish request issue instead of skipping when re-running the GitHub Action
- Preserves checked state of targets (already-published or user-skipped) when updating
- Refreshes all other content: requester, merge target, links, changelog, and target list

## Motivation

When running the release action multiple times for the same version (e.g., after fixing CI issues or updating changelog), the publish request issue would remain stale. Now the issue body reflects the latest state while preserving user decisions about which targets to skip.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Re-run with same targets | Skip, stale body | Update body, preserve checked states |
| Re-run with new targets | Skip, missing targets | Update body, new targets unchecked |
| Re-run with removed targets | Skip, invalid targets | Update body, removed targets gone |
| First run | Create issue | Create issue (unchanged) |

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>b48b970</u></sup><!-- /BUGBOT_STATUS -->