### PR TITLE
ci: Use correct artifact name for dogfooding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
       if: github.repository == 'getsentry/craft'
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
       with:
-        name: ${{ github.sha }}
+        name: craft-binary
         path: /tmp/craft-artifact
 
     - name: Install Craft from artifact or release


### PR DESCRIPTION
## Summary

Fixes release workflow failure caused by artifact name mismatch.

The `download-artifact` step in `action.yml` was looking for an artifact named with the commit SHA (`${{ github.sha }}`), but `build.yml` uploads the artifact as `craft-binary`.

## Changes

- Updated `action.yml` to download artifact by name `craft-binary` instead of `${{ github.sha }}`

## Related

- Failed run: https://github.com/getsentry/craft/actions/runs/21755074971