### PR TITLE
fix(build): Add legacy artifact name for backward compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node: ['20','22']
+        node: ['20', '22']
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
@@ -81,6 +81,15 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: craft-binary
+          path: |
+            ${{ github.workspace }}/*.tgz
+            ${{ github.workspace }}/dist/craft
+      # Legacy artifact name for backward compatibility with older Craft versions
+      # that look for artifact.name === commit SHA. Can be removed after 2.21.0 is released.
+      - name: Upload Legacy Artifact (backward compat)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ github.sha }}
           path: |
             ${{ github.workspace }}/*.tgz
             ${{ github.workspace }}/dist/craft


### PR DESCRIPTION
## Summary

Fixes publishing failure when using the currently released Craft version.

The older Craft version uses legacy artifact lookup where `artifact.name === commit SHA`. Since we renamed artifacts to `craft-binary` and `craft-docs`, publishing fails because it can't find an artifact named with the commit SHA.

## Changes

- Upload an additional artifact with the commit SHA name for backward compatibility
- This allows the release to be published with the current Craft version

## Notes

This can be removed after 2.21.0 is released since the new version supports the named artifacts approach.

## Related

- Previous fix: #742