### PR TITLE
fix(action): Handle permission errors when updating publish issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -282,9 +282,13 @@ runs:
         ${CHANGELOG_SECTION}"
 
         if [[ -n "$existing_issue_number" ]]; then
-          # Update existing issue with fresh body (preserving checked target states)
-          gh issue edit "$existing_issue_number" -R "$PUBLISH_REPO" --body "$body"
-          echo "::notice::Updated existing publish request: ${existing_issue_url}"
+          # Try to update existing issue with fresh body (preserving checked target states)
+          # This may fail if the token doesn't have permission to update issues in the publish repo
+          if gh issue edit "$existing_issue_number" -R "$PUBLISH_REPO" --body "$body" 2>/dev/null; then
+            echo "::notice::Updated existing publish request: ${existing_issue_url}"
+          else
+            echo "::warning::Could not update existing issue (permission denied). Using existing issue as-is."
+          fi
           echo "issue_url=${existing_issue_url}" >> "$GITHUB_OUTPUT"
         else
           # Create new issue


### PR DESCRIPTION
## Summary

Fixes release workflow failure when the GitHub App token doesn't have permission to update issues in the publish repo.

## Problem

The release workflow failed with:
```
failed to update https://github.com/getsentry/publish/issues/7083: GraphQL: Resource not accessible by integration (updateIssue)
```

The `sentry-release-bot` GitHub App can create issues in `getsentry/publish` but cannot update them.

## Solution

Handle the permission error gracefully:
- Try to update the existing issue
- If it fails (permission denied), emit a warning and continue with the existing issue URL
- The workflow no longer fails due to this permission issue

## Related

- Failed run: https://github.com/getsentry/craft/actions/runs/21760927528/job/62784167482
- Feature that introduced this: #740