### PR TITLE
fix(targets): Add missing spawnProcess imports in pypi and crates

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "fix": "pnpm lint --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
     "docs:dev": "cd docs && pnpm dev",
     "docs:build": "cd docs && pnpm build"
   },

--- a/src/targets/__tests__/pypi.test.ts
+++ b/src/targets/__tests__/pypi.test.ts
@@ -3,13 +3,16 @@ import { PypiTarget } from '../pypi';
 import { NoneArtifactProvider } from '../../artifact_providers/none';
 import { RemoteArtifact } from '../../artifact_providers/base';
 
-vi.mock('../../utils/system', async (importOriginal) => {
+vi.mock('../../utils/system', async importOriginal => {
   const actual = await importOriginal<typeof import('../../utils/system')>();
   return {
     ...actual,
     checkExecutableIsPresent: vi.fn(),
+    spawnProcess: vi.fn(),
   };
 });
+
+import { spawnProcess } from '../../utils/system';
 
 describe('pypi', () => {
   const oldEnv = { ...process.env };
@@ -25,16 +28,18 @@ describe('pypi', () => {
 
   test('it uploads all artifacts in a single twine call', async () => {
     const target = new PypiTarget({ name: 'pypi' }, new NoneArtifactProvider());
-    target.getArtifactsForRevision = vi.fn().mockResolvedValueOnce([
-      { filename: 'pkg-1-py3-none-macos_11_0_arm64.whl' },
-      { filename: 'pkg-1-py3-none-manylinux_2_17_x86_64.whl' },
-      { filename: 'pkg-1.tar.gz' },
-    ]);
+    target.getArtifactsForRevision = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { filename: 'pkg-1-py3-none-macos_11_0_arm64.whl' },
+        { filename: 'pkg-1-py3-none-manylinux_2_17_x86_64.whl' },
+        { filename: 'pkg-1.tar.gz' },
+      ]);
     target.artifactProvider.downloadArtifact = vi.fn(
       async (
         artifact: RemoteArtifact,
-        _downloadDirectory?: string | undefined
-      ) => `downloaded/path/${artifact.filename}`
+        _downloadDirectory?: string | undefined,
+      ) => `downloaded/path/${artifact.filename}`,
     );
     const upload = vi.fn();
     target.uploadAssets = upload;
@@ -45,6 +50,19 @@ describe('pypi', () => {
       'downloaded/path/pkg-1-py3-none-macos_11_0_arm64.whl',
       'downloaded/path/pkg-1-py3-none-manylinux_2_17_x86_64.whl',
       'downloaded/path/pkg-1.tar.gz',
+    ]);
+  });
+
+  test('uploadAssets calls twine with correct arguments', async () => {
+    vi.mocked(spawnProcess).mockResolvedValueOnce(Buffer.from(''));
+
+    const target = new PypiTarget({ name: 'pypi' }, new NoneArtifactProvider());
+    await target.uploadAssets(['/path/to/pkg.whl', '/path/to/pkg.tar.gz']);
+
+    expect(spawnProcess).toHaveBeenCalledWith('twine', [
+      'upload',
+      '/path/to/pkg.whl',
+      '/path/to/pkg.tar.gz',
     ]);
   });
 });

--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -11,6 +11,7 @@ import {
   checkExecutableIsPresent,
   resolveExecutable,
   runWithExecutable,
+  spawnProcess,
 } from '../utils/system';
 import { BaseTarget } from './base';
 import { BaseArtifactProvider } from '../artifact_providers/base';

--- a/src/targets/pypi.ts
+++ b/src/targets/pypi.ts
@@ -7,7 +7,11 @@ import {
   RemoteArtifact,
 } from '../artifact_providers/base';
 import { ConfigurationError, reportError } from '../utils/errors';
-import { checkExecutableIsPresent, runWithExecutable } from '../utils/system';
+import {
+  checkExecutableIsPresent,
+  runWithExecutable,
+  spawnProcess,
+} from '../utils/system';
 import { BaseTarget } from './base';
 import { logger } from '../logger';
 


### PR DESCRIPTION
## Summary

Fixes runtime error `spawnProcess is not defined` when publishing to PyPI target.

## Problem

The `pypi.ts` and `crates.ts` targets used `spawnProcess` without importing it, causing runtime errors:

```
Error: spawnProcess is not defined
  at _PypiTarget.uploadAssets (/usr/local/bin/craft:128938:9)
```

This was not caught because:
- esbuild (used for builds) doesn't perform type checking
- Tests mocked the entire `uploadAssets` method instead of testing the real implementation

## Changes

- Add missing `spawnProcess` import to `pypi.ts` and `crates.ts`
- Add test that exercises the real `uploadAssets` implementation (mocks `spawnProcess` dependency instead of the method)
- Add `typecheck` script to `package.json` for local development

## Note

Full CI type checking was considered but deferred - the codebase has ~150 pre-existing type errors that would need to be fixed first. The `pnpm typecheck` script is available for developers to catch similar issues locally.