### PR TITLE
fix(changelog): Tailor preview output to versioning policy

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -154,6 +154,7 @@ jobs:
           CHANGELOG=$(echo "$RESULT" | jq -r '.changelog // ""')
           BUMP_TYPE=$(echo "$RESULT" | jq -r '.bumpType // "none"')
           PR_SKIPPED=$(echo "$RESULT" | jq -r '.prSkipped // false')
+          VERSIONING_POLICY=$(echo "$RESULT" | jq -r '.versioningPolicy // "auto"')
 
           if [[ "$PR_SKIPPED" == "true" ]]; then
             CHANGELOG="_This PR will not appear in the changelog._"
@@ -161,31 +162,30 @@ jobs:
             CHANGELOG="_No changelog entries will be generated from this PR._"
           fi
 
-          case "$BUMP_TYPE" in
-            major) BUMP_BADGE="🔴 **Major** (breaking changes)" ;;
-            minor) BUMP_BADGE="🟡 **Minor** (new features)" ;;
-            patch) BUMP_BADGE="🟢 **Patch** (bug fixes)" ;;
-            *) BUMP_BADGE="⚪ **None** (no version bump detected)" ;;
-          esac
+          # CalVer projects don't use semver bumps — skip the impact badge
+          if [[ "$VERSIONING_POLICY" == "calver" ]]; then
+            BUMP_BADGE=""
+            BUMP_SHORT="CalVer"
+            SECTION_HEADING="Changelog Preview"
+            STATUS_CONTEXT="Changelog Preview"
+          else
+            case "$BUMP_TYPE" in
+              major) BUMP_BADGE="🔴 **Major** (breaking changes)" ;;
+              minor) BUMP_BADGE="🟡 **Minor** (new features)" ;;
+              patch) BUMP_BADGE="🟢 **Patch** (bug fixes)" ;;
+              *) BUMP_BADGE="⚪ **None** (no version bump detected)" ;;
+            esac
 
-          case "$BUMP_TYPE" in
-            major) 
-              BUMP_SHORT="Major"
-              BUMP_EMOJI="🔴"
-              ;;
-            minor) 
-              BUMP_SHORT="Minor"
-              BUMP_EMOJI="🟡"
-              ;;
-            patch) 
-              BUMP_SHORT="Patch"
-              BUMP_EMOJI="🟢"
-              ;;
-            *) 
-              BUMP_SHORT="None"
-              BUMP_EMOJI="⚪"
-              ;;
-          esac
+            case "$BUMP_TYPE" in
+              major) BUMP_SHORT="Major" ;;
+              minor) BUMP_SHORT="Minor" ;;
+              patch) BUMP_SHORT="Patch" ;;
+              *) BUMP_SHORT="None" ;;
+            esac
+
+            SECTION_HEADING="Semver Impact of This PR"
+            STATUS_CONTEXT="Changelog Preview / Semver Impact"
+          fi
 
           # Determine mode: use status check mode when comment is false OR when running internally (no input)
           USE_COMMENT_MODE="${{ inputs.comment }}"
@@ -204,7 +204,7 @@ jobs:
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
               -f state="success" \
-              -f context="Changelog Preview / Semver Impact" \
+              -f context="$STATUS_CONTEXT" \
               -f description="$BUMP_SHORT" \
               -f target_url="$TARGET_URL"
             
@@ -216,7 +216,7 @@ jobs:
 
           [→ View PR #${PR_NUMBER}](${PR_URL})
 
-          ## Semver Impact of This PR
+          ## ${SECTION_HEADING}
 
           ${BUMP_BADGE}
 
@@ -243,7 +243,7 @@ jobs:
             COMMENT_FILE=$(mktemp)
             cat > "$COMMENT_FILE" << CRAFT_CHANGELOG_COMMENT_END
           <!-- craft-changelog-preview -->
-          ## Semver Impact of This PR
+          ## ${SECTION_HEADING}
 
           ${BUMP_BADGE}
 

--- a/src/commands/__tests__/changelog-versioning-policy.test.ts
+++ b/src/commands/__tests__/changelog-versioning-policy.test.ts
@@ -1,0 +1,136 @@
+import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
+
+import type { ChangelogResult } from '../../utils/changelog';
+
+// Mock all heavy dependencies
+vi.mock('../../logger');
+
+vi.mock('../../config', () => ({
+  findConfigFile: vi.fn(),
+  getVersioningPolicy: vi.fn(),
+}));
+
+vi.mock('../../utils/git', () => ({
+  getGitClient: vi.fn().mockResolvedValue({}),
+  getLatestTag: vi.fn().mockResolvedValue('1.0.0'),
+}));
+
+const mockResult: ChangelogResult = {
+  changelog: '### Bug Fixes\n- fix something',
+  bumpType: 'patch',
+  totalCommits: 3,
+  matchedCommitsWithSemver: 2,
+};
+
+vi.mock('../../utils/changelog', () => ({
+  generateChangesetFromGit: vi.fn().mockResolvedValue(mockResult),
+  generateChangelogWithHighlight: vi.fn().mockResolvedValue(mockResult),
+}));
+
+describe('changelog command versioningPolicy in JSON output', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  function parseJsonOutput(): Record<string, unknown> {
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    return JSON.parse(consoleSpy.mock.calls[0][0] as string);
+  }
+
+  it('includes versioningPolicy "calver" when config has calver policy', async () => {
+    const { findConfigFile, getVersioningPolicy } =
+      await import('../../config');
+    const { changelogMain } = await import('../changelog');
+
+    vi.mocked(findConfigFile).mockReturnValue('/repo/.craft.yml');
+    vi.mocked(getVersioningPolicy).mockReturnValue(
+      'calver' as ReturnType<typeof getVersioningPolicy>,
+    );
+
+    await changelogMain({ format: 'json' });
+
+    const output = parseJsonOutput();
+    expect(output.versioningPolicy).toBe('calver');
+    expect(output.bumpType).toBe('patch');
+    expect(output.changelog).toContain('Bug Fixes');
+  });
+
+  it('includes versioningPolicy "auto" when config has auto policy', async () => {
+    const { findConfigFile, getVersioningPolicy } =
+      await import('../../config');
+    const { changelogMain } = await import('../changelog');
+
+    vi.mocked(findConfigFile).mockReturnValue('/repo/.craft.yml');
+    vi.mocked(getVersioningPolicy).mockReturnValue(
+      'auto' as ReturnType<typeof getVersioningPolicy>,
+    );
+
+    await changelogMain({ format: 'json' });
+
+    const output = parseJsonOutput();
+    expect(output.versioningPolicy).toBe('auto');
+  });
+
+  it('includes versioningPolicy "manual" when config has manual policy', async () => {
+    const { findConfigFile, getVersioningPolicy } =
+      await import('../../config');
+    const { changelogMain } = await import('../changelog');
+
+    vi.mocked(findConfigFile).mockReturnValue('/repo/.craft.yml');
+    vi.mocked(getVersioningPolicy).mockReturnValue(
+      'manual' as ReturnType<typeof getVersioningPolicy>,
+    );
+
+    await changelogMain({ format: 'json' });
+
+    const output = parseJsonOutput();
+    expect(output.versioningPolicy).toBe('manual');
+  });
+
+  it('defaults to "auto" when no config file exists', async () => {
+    const { findConfigFile, getVersioningPolicy } =
+      await import('../../config');
+    const { changelogMain } = await import('../changelog');
+
+    vi.mocked(findConfigFile).mockReturnValue(undefined);
+
+    await changelogMain({ format: 'json' });
+
+    const output = parseJsonOutput();
+    expect(output.versioningPolicy).toBe('auto');
+    expect(getVersioningPolicy).not.toHaveBeenCalled();
+  });
+
+  it('defaults to "auto" when getVersioningPolicy throws', async () => {
+    const { findConfigFile, getVersioningPolicy } =
+      await import('../../config');
+    const { changelogMain } = await import('../changelog');
+
+    vi.mocked(findConfigFile).mockReturnValue('/repo/.craft.yml');
+    vi.mocked(getVersioningPolicy).mockImplementation(() => {
+      throw new Error('Config parse error');
+    });
+
+    await changelogMain({ format: 'json' });
+
+    const output = parseJsonOutput();
+    expect(output.versioningPolicy).toBe('auto');
+  });
+
+  it('does not include versioningPolicy in text output', async () => {
+    const { changelogMain } = await import('../changelog');
+
+    await changelogMain({ format: 'text' });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const textOutput = consoleSpy.mock.calls[0][0] as string;
+    expect(textOutput).not.toContain('versioningPolicy');
+  });
+});


### PR DESCRIPTION
## Summary

- Detect the versioning policy from `.craft.yml` and include it in the `craft changelog --format json` output as a new `versioningPolicy` field (`"auto"`, `"manual"`, or `"calver"`)
- The `changelog-preview` workflow reads this field and adjusts its display: CalVer projects get a neutral "Changelog Preview" heading with no semver impact badge; auto/manual projects are unchanged
- Graceful fallback to `"auto"` when no config file exists or config can't be read

## Changes

### `src/commands/changelog.ts`
Added versioning policy detection to the JSON output path. Uses `findConfigFile()` to check for `.craft.yml` existence first (avoids throwing), then `getVersioningPolicy()` to read the policy. Falls back to `"auto"` on any error.

### `.github/workflows/changelog-preview.yml`
Extracts `VERSIONING_POLICY` from craft's JSON output. When `calver`:
- `BUMP_BADGE` → empty (no badge shown)
- `BUMP_SHORT` → `"CalVer"` (status check description)
- `SECTION_HEADING` → `"Changelog Preview"` (not "Semver Impact of This PR")
- `STATUS_CONTEXT` → `"Changelog Preview"` (not "Changelog Preview / Semver Impact")

Both status-check mode and comment mode use the same variables.

### `src/commands/__tests__/changelog-versioning-policy.test.ts` (new)
6 tests covering: calver/auto/manual in JSON output, fallback when no config, fallback when config throws, text output exclusion.