### PR TITLE
fix(gh-pages): add CNAME file to preserve custom domain on deploy

### DIFF
--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+craft.sentry.dev


### PR DESCRIPTION
## Summary

- Adds `docs/public/CNAME` with `craft.sentry.dev` so the custom domain survives gh-pages deployments

## Problem

The gh-pages target runs `git rm -rf .` before extracting the new archive, which deletes any CNAME file previously on the branch. This causes `craft.sentry.dev` to stop resolving after each release.

## Fix

Astro copies everything from `public/` into the build output (`dist/`), which then gets zipped into `gh-pages.zip`. By placing the CNAME file in `docs/public/`, it's automatically included in every deployment archive. This is the same pattern used by [getsentry/cli](https://github.com/getsentry/cli/blob/master/docs/public/CNAME).

No changes to the gh-pages target code or `.craft.yml` are needed.