### PR TITLE
security(commit-repo): replace execSync tar with node-tar

### DIFF
--- a/src/targets/__tests__/commitOnGitRepository.test.ts
+++ b/src/targets/__tests__/commitOnGitRepository.test.ts
@@ -1,8 +1,19 @@
 import { vi } from 'vitest';
 import { pushArchiveToGitRepository } from '../commitOnGitRepository';
-import childProcess from 'child_process';
 
-const execSyncSpy = vi.spyOn(childProcess, 'execSync');
+const { tarExtractMock } = vi.hoisted(() => ({
+  tarExtractMock: vi.fn<(...args: any[]) => Promise<void>>(() =>
+    Promise.resolve(),
+  ),
+}));
+
+vi.mock('tar', async importOriginal => {
+  const actual = await importOriginal<typeof import('tar')>();
+  return {
+    ...actual,
+    x: tarExtractMock,
+  };
+});
 
 const mockClone = vi.fn();
 const mockCheckout = vi.fn();
@@ -20,11 +31,17 @@ vi.mock('simple-git', () => ({
   }),
 }));
 
-test('Basic commit-on-git-repository functionality', async () => {
-  execSyncSpy.mockImplementationOnce(() => {
-    return Buffer.from('noop');
-  });
+beforeEach(() => {
+  tarExtractMock.mockReset();
+  tarExtractMock.mockImplementation(() => Promise.resolve(undefined));
+  mockClone.mockReset();
+  mockCheckout.mockReset();
+  mockRaw.mockReset();
+  mockCommit.mockReset();
+  mockAddTag.mockReset();
+});
 
+test('Basic commit-on-git-repository functionality', async () => {
   await pushArchiveToGitRepository({
     archivePath: '/tmp/my-archive.tgz',
     branch: 'main',
@@ -40,10 +57,12 @@ test('Basic commit-on-git-repository functionality', async () => {
   );
   expect(mockCheckout).toHaveBeenCalledWith('main');
   expect(mockRaw).toHaveBeenCalledWith('rm', '-r', '.');
-  expect(execSyncSpy).toHaveBeenCalledWith(
-    'tar -zxvf /tmp/my-archive.tgz --strip-components 1',
-    expect.objectContaining({ cwd: expect.any(String) }),
-  );
+  expect(tarExtractMock).toHaveBeenCalledWith({
+    file: '/tmp/my-archive.tgz',
+    cwd: expect.any(String),
+    gzip: true,
+    strip: 1,
+  });
   expect(mockRaw).toHaveBeenCalledWith('add', '--all');
   expect(mockCommit).toHaveBeenCalledWith('release: 1.2.3');
   expect(mockAddTag).toHaveBeenCalledWith('1.2.3');
@@ -59,6 +78,49 @@ test('Basic commit-on-git-repository functionality', async () => {
   );
 });
 
+test('No strip-components when not configured', async () => {
+  await pushArchiveToGitRepository({
+    archivePath: '/tmp/my-archive.tgz',
+    branch: 'main',
+    createTag: false,
+    repositoryUrl: 'https://github.com/getsentry/sentry-deno',
+    stripComponents: undefined,
+    version: '1.2.3',
+  });
+
+  expect(tarExtractMock).toHaveBeenCalledWith({
+    file: '/tmp/my-archive.tgz',
+    cwd: expect.any(String),
+    gzip: true,
+    strip: 0,
+  });
+});
+
+test('Shell-metacharacter archivePath does not reach a shell', async () => {
+  // Regression guard: the previous `execSync(`tar -zxvf ${archivePath}`)`
+  // pattern would interpret `;` / `$()` / backticks in the path if an
+  // artifact provider ever returned such a value. `tar.x({ file })`
+  // passes the path as a parameter with no shell involvement, so even
+  // adversarial input is treated as a literal filename.
+  const adversarial = '/tmp/evil;touch /tmp/CRAFT_INJECTION.tgz';
+
+  await pushArchiveToGitRepository({
+    archivePath: adversarial,
+    branch: 'main',
+    createTag: false,
+    repositoryUrl: 'https://github.com/getsentry/sentry-deno',
+    stripComponents: 0,
+    version: '1.2.3',
+  });
+
+  expect(tarExtractMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      file: adversarial,
+    }),
+  );
+  // No subprocess spawn occurred; tar.x received the literal string.
+});
+
 describe('With authentication', () => {
   let oldToken: string | undefined;
 
@@ -71,10 +133,6 @@ describe('With authentication', () => {
   });
 
   test('adds GitHub pat to repository url', async () => {
-    execSyncSpy.mockImplementationOnce(() => {
-      return Buffer.from('noop');
-    });
-
     process.env['GITHUB_API_TOKEN'] = 'test-token';
 
     await pushArchiveToGitRepository({

--- a/src/targets/commitOnGitRepository.ts
+++ b/src/targets/commitOnGitRepository.ts
@@ -4,7 +4,7 @@ import { ConfigurationError, reportError } from '../utils/errors';
 import { withTempDir } from '../utils/files';
 import { cloneRepo } from '../utils/git';
 import { BaseTarget } from './base';
-import childProcess from 'child_process';
+import * as tar from 'tar';
 import type { Consola } from 'consola';
 import { URL } from 'url';
 
@@ -164,12 +164,20 @@ export async function pushArchiveToGitRepository({
         logger?.info(`Defined --strip-components depth as ${stripComponents}`);
       }
       logger?.info(`Unpack tarball archive at "${archivePath}"...`);
-      const stripComponentsArg =
-        stripComponents && stripComponents > 0
-          ? ` --strip-components ${stripComponents}`
-          : '';
-      childProcess.execSync(`tar -zxvf ${archivePath}${stripComponentsArg}`, {
+      // Use the `tar` npm package (already a dependency) instead of
+      // shelling out to the `tar` binary. The previous implementation
+      // interpolated `archivePath` into a shell command string; while
+      // `archivePath` is currently craft-constructed and not
+      // attacker-controllable, the pattern is fragile against future
+      // refactors (e.g. an artifact provider that returns a path
+      // containing `;` or `$()` would become a command-injection
+      // vector). `tar.x` takes a file path as a parameter, with no
+      // shell parsing at any layer.
+      await tar.x({
+        file: archivePath,
         cwd: directory,
+        gzip: true,
+        strip: stripComponents && stripComponents > 0 ? stripComponents : 0,
       });
 
       logger?.info(`Staging files...`);


### PR DESCRIPTION
## Summary

Replaces the shell-interpolated `execSync` tar invocation in `pushArchiveToGitRepository()` with the `tar` npm package (already a dep). Closes a latent shell-injection hazard and makes the unpack step robust against adversarial artifact paths.

## The hazard

`src/targets/commitOnGitRepository.ts` used to unpack the downloaded tarball with:

```ts
childProcess.execSync(`tar -zxvf ${archivePath}${stripComponentsArg}`, {
  cwd: directory,
});
```

`archivePath` comes from `this.artifactProvider.downloadArtifact(...)` so today it's Craft-constructed and not directly attacker-controllable. But the pattern is fragile: any future artifact provider that returns a path containing `;`, `$()`, backticks, spaces, or `|` becomes a silent arbitrary-command-execution vector during release. `stripComponents` is zod-validated as a number so that vector is blocked, but the archive path is not so constrained.

## The fix

Use `tar.x({ file, cwd, gzip, strip })` from the `tar` npm package. It takes the path as a function parameter with no shell parsing at any layer, so even a path like `/tmp/evil;touch /tmp/pwned.tgz` is treated as a literal filename.

`tar` 7.x is already a dep (`package.json`); `src/utils/system.ts` already uses `tar.extract` elsewhere.

## Tests

`src/targets/__tests__/commitOnGitRepository.test.ts`:

- Existing "basic functionality" test updated to assert on the `tar.x` mock instead of the old `execSync` spy.
- New test "No strip-components when not configured" covers the `strip: 0` path.
- New regression test **"Shell-metacharacter archivePath does not reach a shell"** plants a path like `/tmp/evil;touch /tmp/CRAFT_INJECTION.tgz` and asserts `tar.x` received it literally. This would have been a shell injection under the old code.

All 4 tests pass; lint / build clean.
