### PR TITLE
security(ci): pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - uses: actions/cache@v5
@@ -57,7 +57,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - uses: actions/cache@v5
@@ -99,7 +99,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - name: Build Docs

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
 
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Deploy Preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         with:
           source-dir: docs/dist/
           preview-branch: gh-pages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Pins every third-party GitHub Action used in Craft's own CI to a full commit SHA, with the semver retained as a trailing comment for human reviewers. Protects against tag-hijacking (compromised maintainer account, malicious force-push to a tag, or an intentional-turned-hostile maintainer) without losing the readability of "what version am I on?" at a glance.

## Changes

Two third-party actions touched, 6 usages total across 3 workflow files:

| Action | Old | New |
|---|---|---|
| `pnpm/action-setup` | `@v4` | `@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0` |
| `rossjrw/pr-preview-action` | `@v1` | `@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1` |

Files: `.github/workflows/build.yml`, `.github/workflows/docs-preview.yml`, `.github/workflows/lint.yml`.

## Scope — what's not pinned and why

- **`actions/*`** (`checkout`, `setup-node`, `cache`, `upload-artifact`, `create-github-app-token`): GitHub-owned, trust root, out of scope for this pass.
- **`getsentry/*`** (`craft@v2`, local reusable workflows, local `./` action): same-org, separate trust boundary, out of scope.
- **`getsentry/action-enforce-license-compliance`**: already SHA-pinned to `4fae092d42cc91cdfa447eb5b0987cbecfdb07c6` — no change needed.

## Verification

- `python3 -c "import yaml; ..."` parses all 7 workflow files cleanly.
- `grep` post-change shows only SHA-pinned references for both third-party actions.
- SHAs resolved via `git ls-remote <repo> 'v4^{}' 'v1^{}'` (authoritative deref of annotated tag objects to the commits). Both match the current tip of the respective `v<N>` floating tags.

Tag-pointer drift from here on is visible in the diff when anyone bumps these references in a future PR.
