### PR TITLE
feat: recognize `security:` commit prefix for changelog and versioning

### DIFF
--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -237,6 +237,10 @@ changelog:
       commit_patterns:
         - "^(?<type>\\w+(?:\\((?<scope>[^)]+)\\))?!:\\s*)"
       semver: major
+    - title: Security 🔒
+      commit_patterns:
+        - "^(?<type>security(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"
+      semver: patch
     - title: New Features ✨
       commit_patterns:
         - "^(?<type>feat(?:\\((?<scope>[^)]+)\\))?!?:\\s*)"

--- a/src/utils/__tests__/changelog-extract.test.ts
+++ b/src/utils/__tests__/changelog-extract.test.ts
@@ -24,6 +24,8 @@ describe('extractScope', () => {
     ['docs(readme): update docs', 'readme'],
     ['chore(deps): update dependencies', 'deps'],
     ['feat(my-long_scope): mixed separators', 'my-long-scope'],
+    ['security(auth): patch login', 'auth'],
+    ['security(auth)!: rotate keys', 'auth'],
   ])('extracts scope from "%s" as "%s"', (title, expected) => {
     expect(extractScope(title)).toBe(expected);
   });

--- a/src/utils/__tests__/changelog-generate.test.ts
+++ b/src/utils/__tests__/changelog-generate.test.ts
@@ -607,6 +607,136 @@ changelog:
       const result = await generateChangesetFromGit(dummyGit, '1.0.0', 10);
       expect(result.changelog).toMatchSnapshot();
     });
+
+    it('categorizes security commits under Security section with patch bump', async () => {
+      setup(
+        [
+          {
+            hash: 'abc123',
+            title: 'security: patch XSS in renderer',
+            body: '',
+            pr: {
+              local: '1',
+              remote: { number: '1', author: { login: 'alice' } },
+            },
+          },
+          {
+            hash: 'def456',
+            title: 'security(auth): fix login bypass',
+            body: '',
+            pr: {
+              local: '2',
+              remote: { number: '2', author: { login: 'bob' } },
+            },
+          },
+        ],
+        null,
+      );
+      const result = await generateChangesetFromGit(dummyGit, '1.0.0', 10);
+      expect(result.changelog).toContain('### Security 🔒');
+      expect(result.changelog).toContain('Patch XSS in renderer');
+      expect(result.changelog).toContain('Fix login bypass');
+      expect(result.bumpType).toBe('patch');
+    });
+
+    it('renders Security section above New Features and Bug Fixes', async () => {
+      setup(
+        [
+          {
+            hash: 'aaa111',
+            title: 'feat: new widget',
+            body: '',
+            pr: {
+              local: '1',
+              remote: { number: '1', author: { login: 'alice' } },
+            },
+          },
+          {
+            hash: 'bbb222',
+            title: 'security: patch XSS',
+            body: '',
+            pr: {
+              local: '2',
+              remote: { number: '2', author: { login: 'bob' } },
+            },
+          },
+          {
+            hash: 'ccc333',
+            title: 'fix: off-by-one',
+            body: '',
+            pr: {
+              local: '3',
+              remote: { number: '3', author: { login: 'charlie' } },
+            },
+          },
+        ],
+        null,
+      );
+      const result = await generateChangesetFromGit(dummyGit, '1.0.0', 10);
+      const securityIdx = result.changelog.indexOf('### Security 🔒');
+      const featuresIdx = result.changelog.indexOf('### New Features ✨');
+      const fixesIdx = result.changelog.indexOf('### Bug Fixes 🐛');
+      expect(securityIdx).toBeGreaterThanOrEqual(0);
+      expect(featuresIdx).toBeGreaterThanOrEqual(0);
+      expect(fixesIdx).toBeGreaterThanOrEqual(0);
+      expect(securityIdx).toBeLessThan(featuresIdx);
+      expect(featuresIdx).toBeLessThan(fixesIdx);
+      // A feat: commit dominates aggregation: security is patch, feat is minor.
+      // If Security were accidentally tagged as minor, this would still be minor
+      // so we test that separately below.
+      expect(result.bumpType).toBe('minor');
+    });
+
+    it('security alone does not escalate above patch when mixed with docs', async () => {
+      // Guards against accidentally setting semver: 'minor' on the Security category.
+      // docs: is patch, security: is patch -> aggregate must be patch.
+      setup(
+        [
+          {
+            hash: 'aaa111',
+            title: 'security: patch XSS',
+            body: '',
+            pr: {
+              local: '1',
+              remote: { number: '1', author: { login: 'alice' } },
+            },
+          },
+          {
+            hash: 'bbb222',
+            title: 'docs: update readme',
+            body: '',
+            pr: {
+              local: '2',
+              remote: { number: '2', author: { login: 'bob' } },
+            },
+          },
+        ],
+        null,
+      );
+      const result = await generateChangesetFromGit(dummyGit, '1.0.0', 10);
+      expect(result.bumpType).toBe('patch');
+    });
+
+    it('escalates breaking security commits to major via Breaking Changes', async () => {
+      setup(
+        [
+          {
+            hash: 'abc123',
+            title: 'security!: rotate signing keys',
+            body: '',
+            pr: {
+              local: '1',
+              remote: { number: '1', author: { login: 'alice' } },
+            },
+          },
+        ],
+        null,
+      );
+      const result = await generateChangesetFromGit(dummyGit, '1.0.0', 10);
+      expect(result.changelog).toContain('### Breaking Changes 🛠');
+      expect(result.changelog).not.toContain('### Security 🔒');
+      expect(result.bumpType).toBe('major');
+    });
   });
 
   // ============================================================================

--- a/src/utils/__tests__/changelog-utils.test.ts
+++ b/src/utils/__tests__/changelog-utils.test.ts
@@ -134,6 +134,45 @@ describe('getBumpTypeForPR', () => {
     expect(getBumpTypeForPR(prInfo)).toBe('patch');
   });
 
+  it('returns patch for security commits', () => {
+    const prInfo = { ...basePRInfo, title: 'security: patch XSS' };
+    expect(getBumpTypeForPR(prInfo)).toBe('patch');
+  });
+
+  it('returns patch for scoped security commits', () => {
+    const prInfo = { ...basePRInfo, title: 'security(auth): patch login' };
+    expect(getBumpTypeForPR(prInfo)).toBe('patch');
+  });
+
+  it('returns major for breaking security commits', () => {
+    const prInfo = { ...basePRInfo, title: 'security!: rotate keys' };
+    expect(getBumpTypeForPR(prInfo)).toBe('major');
+  });
+
+  it('returns major for scoped breaking security commits', () => {
+    const prInfo = { ...basePRInfo, title: 'security(auth)!: rotate keys' };
+    expect(getBumpTypeForPR(prInfo)).toBe('major');
+  });
+
+  it('matches security prefix case-insensitively', () => {
+    // commit_patterns are compiled with /i in normalizeReleaseConfig.
+    const prInfo = { ...basePRInfo, title: 'Security(Auth): Fix bypass' };
+    expect(getBumpTypeForPR(prInfo)).toBe('patch');
+  });
+
+  it('does not match security-lookalike prefixes', () => {
+    // Guard against accidentally widening the pattern (e.g. to `security\w*:`).
+    expect(
+      getBumpTypeForPR({ ...basePRInfo, title: 'securityfix: foo' }),
+    ).toBeNull();
+    expect(
+      getBumpTypeForPR({ ...basePRInfo, title: 'securityaudit: foo' }),
+    ).toBeNull();
+    expect(
+      getBumpTypeForPR({ ...basePRInfo, title: 'secure: foo' }),
+    ).toBeNull();
+  });
+
   it('returns null for unrecognized commit types', () => {
     const prInfo = { ...basePRInfo, title: 'random commit' };
     expect(getBumpTypeForPR(prInfo)).toBeNull();
@@ -257,6 +296,19 @@ describe('stripTitle', () => {
       );
       expect(stripTitle('doc(readme): update docs', pattern, false)).toBe(
         'Update docs',
+      );
+    });
+
+    it('works with security type', () => {
+      const pattern = /^(?<type>security(?:\((?<scope>[^)]+)\))?!?:\s*)/;
+      expect(stripTitle('security: patch xss', pattern, false)).toBe(
+        'Patch xss',
+      );
+      expect(stripTitle('security(auth): patch login', pattern, false)).toBe(
+        'Patch login',
+      );
+      expect(stripTitle('security(auth): patch login', pattern, true)).toBe(
+        '(auth) Patch login',
       );
     });
 

--- a/src/utils/changelog.ts
+++ b/src/utils/changelog.ts
@@ -878,6 +878,13 @@ export const DEFAULT_RELEASE_CONFIG: ReleaseConfig = {
         semver: 'major',
       },
       {
+        title: 'Security 🔒',
+        commit_patterns: [
+          '^(?<type>security(?:\\((?<scope>[^)]+)\\))?!?:\\s*)',
+        ],
+        semver: 'patch',
+      },
+      {
         title: 'New Features ✨',
         commit_patterns: ['^(?<type>feat(?:\\((?<scope>[^)]+)\\))?!?:\\s*)'],
         semver: 'minor',


### PR DESCRIPTION
## Summary

Adds a dedicated **Security 🔒** category to the default release config, positioned between **Breaking Changes** and **New Features**. Commits prefixed `security:` (with optional scope and/or breaking marker `!`) are now recognized for both changelog grouping and auto-versioning.

| Commit | Category | Semver bump |
| --- | --- | --- |
| `security: patch XSS` | Security 🔒 | patch |
| `security(auth): fix login bypass` | Security 🔒 (grouped under `auth` when multiple) | patch |
| `security!: rotate signing keys` | Breaking Changes 🛠 | major |
| `security(auth)!: rotate keys` | Breaking Changes 🛠 | major |

## Why a dedicated section vs. folding into Bug Fixes

1. Security fixes are the kind of entry downstream consumers scan changelogs for — giving them their own heading makes them discoverable.
2. Conventional Commits and downstream tooling (Keep a Changelog, release-please) already treat `security` as a first-class type.
3. Empty sections are not rendered, so the cost is zero when no security commits are present.

## Design choices

- **Ordering**: Security sits **above** `feat:`/`fix:` so a `security:` commit is never swallowed by a broader catch-all, but **below** Breaking Changes so `security!:` still escalates to `major` (consistent with every other type).
- **Pattern parity**: `^(?<type>security(?:\((?<scope>[^)]+)\))?!?:\s*)` mirrors the existing `feat:`/`fix:` patterns exactly — scope extraction, title stripping and case-insensitive matching all work without further wiring.
- **Semver**: `patch`, matching how `fix:` is treated. `security!:` escalates to `major` via Breaking Changes.

## Changes

- `src/utils/changelog.ts` — one new category inserted in `DEFAULT_RELEASE_CONFIG`.
- `docs/src/content/docs/configuration.md` — Default Configuration YAML snippet updated to include the Security entry so users copy-pasting it as a customization starting point get parity with the real default.
- New tests (unit + e2e):
  - `getBumpTypeForPR` for plain, scoped, breaking, scoped-breaking, case-insensitive, and lookalike-rejection cases.
  - `stripTitle` for the `security` type (plain + scoped).
  - `extractScope` for `security(auth):` and `security(auth)!:`.
  - End-to-end `generateChangesetFromGit` cases covering: Security section rendering, ordering (Security above New Features above Bug Fixes), mixed-with-`docs:` aggregation stays `patch`, and `security!:` escalating to Breaking Changes / `major`.

## Verification

- `pnpm test` — all new tests pass; 972 total pass. The 7 failures are the pre-existing environment-dependent `EDITOR unset` failures in `src/__tests__/prepare-dry-run.e2e.test.ts` (documented in AGENTS.md), unrelated to this change.
- `pnpm lint` — clean (only pre-existing warnings in `src/utils/git.ts`).
- `pnpm build` — clean.

## Non-goals

- No change to existing category order or the `BUMP_TYPES` priority map.
- No new user-facing config surface; users who want to override the section can already do so via `.github/release.yml` (the standard `readReleaseConfig` mechanism).