### PR TITLE
ci: fix Node 20 + app-id deprecation warnings, refresh Node matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node: ['20', '22']
+        node: ['22', '24']
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6
@@ -28,7 +28,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - uses: actions/cache@v5
@@ -57,7 +57,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - uses: actions/cache@v5
@@ -99,7 +99,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - name: Build Docs

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get pnpm version from Volta config
         id: pnpm-version
         run: echo "version=$(jq -r '.volta.pnpm' package.json)" >> $GITHUB_OUTPUT
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: ${{ steps.pnpm-version.outputs.version }}
       - uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && github.repository == 'getsentry/craft'
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          client-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Fixes deprecation warnings surfaced in [run 24743422957](https://github.com/getsentry/craft/actions/runs/24743422957):

- **4× `Node.js 20 actions are deprecated`** — `pnpm/action-setup@v4.3.0` runs on Node 20. Bumped to v4.4.0 which declares `using: node24` in its `action.yml`. Node 20 actions will be forced to Node 24 by 2026-06-02 and removed entirely by 2026-09-16.
- **2× `Input 'app-id' has been deprecated`** — `actions/create-github-app-token@v3` v3.1.0+ deprecates `app-id` in favour of `client-id`. The `SENTRY_RELEASE_BOT_CLIENT_ID` variable already holds a client ID, so only the input name changes.

Also drops Node 20 from the build matrix (EOL 2026-04-30) and adds Node 24 for forward-compat coverage.

## Changes

| File | Change |
|---|---|
| `.github/workflows/build.yml` | Matrix `['20','22']` → `['22','24']`; bump `pnpm/action-setup` pin (×3) to v4.4.0 |
| `.github/workflows/lint.yml` | Bump `pnpm/action-setup` pin to v4.4.0 |
| `.github/workflows/docs-preview.yml` | Bump `pnpm/action-setup` pin to v4.4.0 |
| `.github/workflows/release.yml` | `app-id:` → `client-id:` on `create-github-app-token@v3` |

## Notes

- `pnpm/action-setup` is third-party → SHA-pinned with trailing `# v4.4.0` comment, per the repo's pinning convention. SHA resolved via `git ls-remote … refs/tags/v4.4.0^{}`.
- `actions/create-github-app-token` is GitHub-owned → stays on the `@v3` major tag (not SHA-pinned). v3 major already resolves past v3.1.0 which supports `client-id`.
- No source/test changes — CI only.

## Verification

- `build.yml` will run 2 matrix jobs (Node 22, Node 24) on push/PR — no more Node 20 warning.
- `release.yml` `workflow_dispatch` should no longer emit the `app-id` deprecation warning.