### PR TITLE
fix(security): bump devalue override to ^5.8.1 (CVE-2026-42570)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   "pnpm": {
     "overrides": {
       "h3": "^1.15.6",
-      "devalue": "^5.6.4",
+      "devalue": "^5.8.1",
       "rollup": "^4.59.0",
       "svgo": "^4.0.1",
       "smol-toml": "^1.6.1",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   h3: ^1.15.6
-  devalue: ^5.6.4
+  devalue: ^5.8.1
   rollup: ^4.59.0
   svgo: ^4.0.1
   smol-toml: ^1.6.1
@@ -971,8 +971,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  devalue@5.7.1:
-    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -2699,7 +2699,7 @@ snapshots:
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      devalue: 5.7.1
+      devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
       es-module-lexer: 2.0.0
@@ -2884,7 +2884,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  devalue@5.7.1: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Bumps the `devalue` pnpm override in `docs/package.json` from `^5.6.4` to `^5.8.1`
- Fixes Dependabot alert #158 — DoS via sparse array deserialization in `devalue.parse` (CVE-2026-42570, CVSS 7.5 high)

## Details

`devalue` is a transitive dependency of `astro` in the docs workspace. The existing override floor (`^5.6.4`) allowed resolution to `5.7.1`, which is within the vulnerable range (`>= 5.6.3, <= 5.8.0`). Raising the override to `^5.8.1` forces resolution to the patched version.

Docs-only change — no impact on the Craft CLI binary.