### PR TITLE
fix(nuget): move global.json aside during `dotnet setversion`

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -291,9 +291,9 @@ export class NugetTarget extends BaseTarget {
 
         this.logger.info(
           `Uploading file "${file.filename}" via "dotnet nuget"` +
-          (symbolFile
-            ? `, including symbol file "${symbolFile.filename}"`
-            : ''),
+            (symbolFile
+              ? `, including symbol file "${symbolFile.filename}"`
+              : ''),
         );
         return this.uploadAsset(path);
       }),

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -1,4 +1,10 @@
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync,
+} from 'fs';
 import { join } from 'path';
 
 import { TargetConfig, TypedTargetConfig } from '../schemas/project_config';
@@ -78,6 +84,19 @@ export class NugetTarget extends BaseTarget {
     }
 
     if (hasExecutable(NUGET_DOTNET_BIN)) {
+      // `dotnet-setversion` operates on files in cwd, so we must invoke it with
+      // cwd=rootDir. That means the dotnet host will read any global.json in
+      // rootDir and may refuse to launch if the pinned SDK isn't installed on
+      // this runner (consumer repos often pin SDK/workload versions with
+      // rollForward: disable for deterministic builds — see #614, #707, and
+      // getsentry/sentry-dotnet#5250). Move global.json aside for the duration
+      // of the call so the host can pick any installed SDK.
+      const globalJsonPath = join(rootDir, 'global.json');
+      const globalJsonBackup = `${globalJsonPath}.craft-bak`;
+      const globalJsonMoved = existsSync(globalJsonPath);
+      if (globalJsonMoved) {
+        renameSync(globalJsonPath, globalJsonBackup);
+      }
       try {
         const result = await spawnProcess(
           NUGET_DOTNET_BIN,
@@ -99,6 +118,10 @@ export class NugetTarget extends BaseTarget {
         logger.debug(
           'dotnet-setversion not available, falling back to manual edit',
         );
+      } finally {
+        if (globalJsonMoved) {
+          renameSync(globalJsonBackup, globalJsonPath);
+        }
       }
     }
 

--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -84,13 +84,9 @@ export class NugetTarget extends BaseTarget {
     }
 
     if (hasExecutable(NUGET_DOTNET_BIN)) {
-      // `dotnet-setversion` operates on files in cwd, so we must invoke it with
-      // cwd=rootDir. That means the dotnet host will read any global.json in
-      // rootDir and may refuse to launch if the pinned SDK isn't installed on
-      // this runner (consumer repos often pin SDK/workload versions with
-      // rollForward: disable for deterministic builds — see #614, #707, and
-      // getsentry/sentry-dotnet#5250). Move global.json aside for the duration
-      // of the call so the host can pick any installed SDK.
+      // `dotnet-setversion` operates in cwd and will pickup global.json,
+      // which breaks if the pinned SDK isn't installed on the craft runner.
+      // See: https://github.com/getsentry/craft/issues/819
       const globalJsonPath = join(rootDir, 'global.json');
       const globalJsonBackup = `${globalJsonPath}.craft-bak`;
       const globalJsonMoved = existsSync(globalJsonPath);
@@ -295,9 +291,9 @@ export class NugetTarget extends BaseTarget {
 
         this.logger.info(
           `Uploading file "${file.filename}" via "dotnet nuget"` +
-            (symbolFile
-              ? `, including symbol file "${symbolFile.filename}"`
-              : ''),
+          (symbolFile
+            ? `, including symbol file "${symbolFile.filename}"`
+            : ''),
         );
         return this.uploadAsset(path);
       }),


### PR DESCRIPTION
## Summary

Fixes #819. Refs getsentry/sentry-dotnet#5250.

The automatic version bumping added in #707 invokes `dotnet setversion` with `cwd: rootDir`, so the dotnet host reads any `global.json` in the consumer repo. The release runner won't always have that exact SDK installed — `dotnet` then refuses to launch and `craft prepare` aborts.

Other `dotnet` invocations in this target dodge this by spawning with `cwd: '/'` (see #601, #614). That isn't viable here because `dotnet-setversion` operates on files in cwd.

Instead, this PR temporarily renames `global.json` to `global.json.craft-bak` for the duration of the call and restores it in a `finally`. The XML-fallback path is unchanged and unaffected.

## Notes for reviewers

- An alternative workaround would be to skip `dotnet-setversion` altogether and rely on the xml based version update logic that is currently a fallback. Hard to say which workaround is better.
- No existing test file for `nuget.ts` (`src/targets/__tests__/` has no `nuget.test.ts`), so this PR doesn't add one. Happy to add one if you'd like — let me know the preferred shape.