### PR TITLE
fix(security): override @tootallnate/once to ^2.0.1 (CVE-2026-3449)

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
       "rollup": "^4.59.0",
       "flatted": "^3.4.2",
       "picomatch@<3": "^2.3.2",
-      "uuid": "^14.0.0"
+      "uuid": "^14.0.0",
+      "@tootallnate/once": "^2.0.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   flatted: ^3.4.2
   picomatch@<3: ^2.3.2
   uuid: ^14.0.0
+  '@tootallnate/once': ^2.0.1
 
 importers:
 
@@ -1658,8 +1659,8 @@ packages:
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
   '@types/async@3.2.25':
@@ -4939,7 +4940,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@2.0.1': {}
 
   '@types/async@3.2.25': {}
 
@@ -5853,7 +5854,7 @@ snapshots:
 
   http-proxy-agent@5.0.0:
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 2.0.1
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#160](https://github.com/getsentry/craft/security/dependabot/160) (CVE-2026-3449, GHSA-vpq2-c234-7xj6).

## Problem

`@tootallnate/once@2.0.0` is vulnerable to Incorrect Control Flow Scoping — Promises hang indefinitely when `AbortSignal` is used (control-flow leak). Severity: **Low** (CVSS 3.3).

Dependency chain:
```
@google-cloud/storage@7.18.0
  → teeny-request@9.0.0
    → http-proxy-agent@5.0.0
      → @tootallnate/once@2.0.0  ← vulnerable
```

Upgrading `@google-cloud/storage` alone doesn't fix this — the latest `7.19.0` still uses `teeny-request@^9.0.0` which pulls the same vulnerable chain.

## Fix

Add a `pnpm.overrides` entry for `@tootallnate/once` to force `^2.0.1` (the patched version). This follows the same pattern already used for 8 other transitive dependency overrides in the project. The patched version satisfies the parent's declared range (`"2"` = `>=2.0.0 <3.0.0`), so there is no compatibility risk.