### PR TITLE
fix(nuget): use unique suffix for global.json backup

### DIFF
--- a/src/targets/nuget.ts
+++ b/src/targets/nuget.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
 } from 'fs';
 import { join } from 'path';
+import { randomUUID } from 'crypto';
 
 import { TargetConfig, TypedTargetConfig } from '../schemas/project_config';
 import { ConfigurationError, reportError } from '../utils/errors';
@@ -88,7 +89,7 @@ export class NugetTarget extends BaseTarget {
       // which breaks if the pinned SDK isn't installed on the craft runner.
       // See: https://github.com/getsentry/craft/issues/819
       const globalJsonPath = join(rootDir, 'global.json');
-      const globalJsonBackup = `${globalJsonPath}.craft-bak`;
+      const globalJsonBackup = `${globalJsonPath}.craft-bak-${randomUUID()}`;
       const globalJsonMoved = existsSync(globalJsonPath);
       if (globalJsonMoved) {
         renameSync(globalJsonPath, globalJsonBackup);


### PR DESCRIPTION
## Summary

Follow-up to #820, addressing [BYK's review note](https://github.com/getsentry/craft/pull/820#discussion_r3287646962).

The backup path was hardcoded to `global.json.craft-bak`. If two craft invocations ever ran against the same working directory, the second would clobber the first's backup. Probability is very low in normal use (craft typically runs in a release-specific checkout), but a unique suffix costs nothing.

Uses `crypto.randomUUID()` to make the backup name unique per invocation.