### PR TITLE
fix: bump shell-quote 1.7.3 → ^1.8.4 (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ora": "5.4.0",
     "prettier": "^3.4.2",
     "prompts": "2.4.1",
-    "shell-quote": "1.7.3",
+    "shell-quote": "^1.8.4",
     "simple-git": "^3.33.0",
     "source-map-support": "^0.5.20",
     "split": "1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
       shell-quote:
-        specifier: 1.7.3
-        version: 1.7.3
+        specifier: ^1.8.4
+        version: 1.8.4
       simple-git:
         specifier: ^3.33.0
         version: 3.36.0
@@ -2685,8 +2685,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.7.3:
-    resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -5911,7 +5912,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.7.3: {}
+  shell-quote@1.8.4: {}
 
   siginfo@2.0.0: {}
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, readFileSync } from 'fs';
 
 import { safeFs } from '../utils/dryRun';
 import { dirname, join } from 'path';
-import shellQuote from 'shell-quote';
+import * as shellQuote from 'shell-quote';
 import stringLength from 'string-length';
 
 import {


### PR DESCRIPTION
## Summary

Resolves the **2 open critical Dependabot alerts** (#165 and #166) for `shell-quote`.

| Alert | Manifest | GHSA | Severity |
|-------|----------|------|----------|
| #165 | `package.json` | GHSA-w7jw-789q-3m8p | Critical |
| #166 | `pnpm-lock.yaml` | (same) | Critical |

`shell-quote < 1.8.4` does not escape newlines in object `.op` values within `quote()`. Craft only uses `parse()` on developer-controlled config strings (`.craft.yml` pre/post-release commands), so it was **not actually exploitable** — but the bump clears the alerts.

## Changes

- **`package.json`**: `shell-quote` `1.7.3` → `^1.8.4`
- **`pnpm-lock.yaml`**: regenerated (resolves `1.8.4`)
- **`src/commands/publish.ts`**: normalized `import shellQuote from 'shell-quote'` → `import * as shellQuote from 'shell-quote'` to match `prepare.ts` (correct form for a CJS module with no default export)

No breaking changes to `parse()` or the `ParseEntry` type between 1.7.3 and 1.8.4.

## Verification

- `pnpm build` ✅
- `pnpm test` ✅ (972 passed; the 7 `prepare-dry-run.e2e` failures are a pre-existing env issue — `EDITOR` unset in headless CI — unrelated to this change)
- `pnpm lint` ✅ (0 errors)