### PR TITLE
fix: resolve 10 Dependabot security alerts

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -12,316 +12,72 @@
 
 - **Craft npm target auth: temp .npmrc via npm_config_userconfig bypasses all default config**: Craft's npm target creates a temporary \`.npmrc\` file containing \`//registry.npmjs.org/:\_authToken=${NPM_TOKEN}\` and sets the \`npm_config_userconfig\` env var to point to it. This completely overrides npm's default config file lookup chain — the user's home \`.npmrc\` and project \`.npmrc\` are both bypassed. This is why OIDC (which relies on \`setup-node\` creating a properly configured project \`.npmrc\`) requires a separate code path that skips the temp file entirely. The pattern is used in both \`publishPackage()\` and \`getLatestVersion()\`. The \`npm_config_userconfig\` approach (instead of \`--userconfig\` CLI flag) was chosen for yarn compatibility.
 
-<!-- lore:019d4479-fd88-7a7d-96b1-2a6b668dfc45 -->
-
-- **Craft post-publish merge is non-blocking housekeeping**: After all publish targets complete, \`handleReleaseBranch()\` in \`src/commands/publish.ts\` merges the release branch back into the default branch and deletes it. This is a housekeeping step — failures are caught, reported to Sentry via \`captureException\`, and logged as warnings without failing the command. The merge uses \`--no-ff\` with the default (ort) strategy first, then retries with \`-s resolve\` if conflicts occur (handles criss-cross ambiguities in files like CHANGELOG.md). An \`isAuthError()\` helper distinguishes authentication failures (expired tokens) from merge conflicts to provide targeted diagnostics.
-
-<!-- lore:019db09e-ac9b-765d-a091-bb6bb512b987 -->
-
-- **Craft release commands forward sanitized env, not full process.env**: Craft release commands forward sanitized env, not full process.env: Pre/postReleaseCommand invocations must NOT forward \`...process.env\` to subprocesses — this allows attacker-controlled \`.craft.env\` or config to inject \`LD_PRELOAD\`/\`LD_LIBRARY_PATH\` for RCE via CI. Use the allowlist helper in \`src/utils/releaseCommandEnv.ts\` which returns only {PATH, HOME, USER, GIT_COMMITTER_NAME, GIT_AUTHOR_NAME, EMAIL, GITHUB_TOKEN, CRAFT\_\*} plus per-command additions (CRAFT_NEW_VERSION/OLD_VERSION for prepare, CRAFT_RELEASED_VERSION for publish). Also strips dynamic-linker env (\`LD_PRELOAD\`, \`LD_LIBRARY_PATH\`, \`LD_AUDIT\`, \`DYLD\_\*\`) via \`sanitizeSpawnEnv()\` in \`src/utils/dynamicLinkerEnv.ts\` as defence-in-depth.
-
-<!-- lore:019db141-686a-718a-8a22-eff2f6f60b1b -->
-
-- **Craft spawnProcess strips dynamic-linker env from subprocess env**: PR #800: \`spawnProcess\` in \`src/utils/system.ts\` now sanitizes \`LD_PRELOAD\`/\`LD_LIBRARY_PATH\`/\`LD_AUDIT\`/\`DYLD\_\*\` from the child's env before every spawn — defence-in-depth layer on top of startup-time \`sanitizeDynamicLinkerEnv()\` (which only protects \`process.env\` of Craft itself, not subprocess inheritance if something re-injects mid-run). Helper \`sanitizeSpawnEnv(env)\` lives in new standalone \`src/utils/dynamicLinkerEnv.ts\` (no other imports) to avoid circular dep. Same \`CRAFT_ALLOW_DYNAMIC_LINKER_ENV=1\` opt-out as startup path. \`env.ts\` re-exports constants for backward compat. Complements \[\[019db09e-ac9b-765d-a091-bb6bb512b987]].
-
-<!-- lore:019db1ee-c08f-7a26-b68a-dea0d9370615 -->
-
-- **Craft static bumpVersion pattern across targets**: Craft auto version bumping is opt-in per target class via a static \`bumpVersion(rootDir, newVersion): Promise\<boolean>\` method. \`src/utils/versionBump.ts\` discovers which target classes have it via \`hasBumpVersion()\`, calls each unique class once in config order (not per-target-instance), and records bumpable vs skipped. Returning \`false\` means no-op (e.g., no package.json found); throwing fails the whole release with context. Targets implementing it today: npm, pypi, crates, gem, pubDev, hex, nuget. \`github\` target intentionally has none. Tests live in \`src/\_\_tests\_\_/versionBump.test.ts\` with a hoisted \`mockSpawnProcess\` + \`mockHasExecutable\` pattern that also stubs \`runWithExecutable\` to re-invoke the mocks (since real \`runWithExecutable\` internally calls unmocked \`hasExecutable\`).
-
-<!-- lore:019db0c1-fb9b-7f8a-bde6-050fc204afc7 -->
-
-- **Craft target \*\_BIN env vars allow redirecting binary execution**: Craft target \*\_BIN env vars allow redirecting binary execution: Targets honor \`\*\_BIN\` env var overrides (\`DOCKER_BIN\`, \`NPM_BIN\`, etc.) to locate tool binaries. A malicious \`preReleaseCommand\` could \`export NPM_BIN=/tmp/evil-npm\` before exiting, affecting subsequent targets. Hardening: resolve each \`\*\_BIN\` once at startup via \`resolveExecutable\`, warn if outside standard PATH, reject relative paths.
-
 <!-- lore:019c9be1-33d8-7edb-8e74-95d7369f4abb -->
 
 - **Craft tsconfig.build.json is now self-contained — no @sentry/typescript base**: The \`@sentry/typescript\` package was removed as a dev dependency. It only provided a base \`tsconfig.json\` with strict TS settings, but dragged in deprecated \`tslint\` and vulnerable \`minimatch@3.1.2\`. All useful compiler options from its tsconfig are now inlined directly in \`tsconfig.build.json\`. Key settings carried forward: \`declaration\`, \`declarationMap\`, \`downlevelIteration\`, \`inlineSources\`, \`noFallthroughCasesInSwitch\`, \`noImplicitAny\`, \`noImplicitReturns\`, \`noUnusedLocals\`, \`noUnusedParameters\`, \`pretty\`, \`sourceMap\`, \`strict\`. The chain is: \`tsconfig.json\` extends \`tsconfig.build.json\` (no further extends).
 
-<!-- lore:019dd52d-410d-7561-b017-a5210b48081f -->
+<!-- lore:019ef3df-18ab-75a5-8917-effd8fb9c183 -->
 
-- **getsentry/action-prepare-release is the legacy predecessor of getsentry/craft action**: getsentry/action-prepare-release is the legacy predecessor of getsentry/craft action: Two GitHub Actions wrap \`craft prepare\`: (1) legacy \`getsentry/action-prepare-release\` — minimal, just killswitch + prepare; (2) modern \`getsentry/craft\` (action.yml at repo root) — installs Craft binary, runs prepare, reads targets, creates/updates publish issue on \`getsentry/publish\` with checkboxes preserved across re-runs. Publish issue title: \`publish: \<owner>/\<repo>\[/\<subpath>]@\<version>\`. As of Apr 2026, ~70 getsentry repos use new action, ~52 still use legacy, migration ongoing. New repos should use \`getsentry/craft@v2\`.
-
-<!-- lore:019daf66-fed2-7f4f-be92-0db09b675d66 -->
-
-- **getsentry/publish poller: active-polling via self-dispatch, cron as fallback**: GitHub Actions \`\*/5\` cron drifts to 30-40 min under load, stalling releases with fast CI. \`ci-poller.yml\` uses self-dispatch: when pending issues remain, it \`gh workflow run\`s itself (cap 60 attempts ~30min). Concurrency group \`ci-status-poller\` with \`cancel-in-progress: false\` queues runs — GHA startup gives ~30-60s between checks. Chain starts via \`waiting-for-ci\` job in \`publish.yml\` when \`accepted\` label is added. Cron is safety net (also skipped when \`CI_POLLER_HAS_PENDING == 'false'\`). Zero idle cost — no chain running unless human action occurred. Self-dispatch step must guard on \`steps.token.outcome == 'success'\` and \`steps.remaining.outcome == 'success'\` to avoid dispatching with empty token.
-
-<!-- lore:019d7bfb-6e1b-7ac1-b55c-09ff4b50d4a1 -->
-
-- **Publish repo event-driven CI gate replaces polling in craft publish**: The \`getsentry/publish\` repo uses a label-based state machine instead of having \`craft publish\` poll CI status for up to 60 minutes. Labels: \`ci-pending\` (set at issue creation), \`ci-ready\` (set by poller or dispatch when CI passes). The \`publish.yml\` job requires \`accepted && !ci-pending\`. A \`ci-poller.yml\` cron (every 5 min) checks CI via GitHub API and swaps labels when ready. A \`ci-ready.yml\` handles \`repository_dispatch\` for repos that signal directly. This eliminates wasted runner time from idle polling and preserves the GitHub App token's 1-hour lifetime for the actual publish step.
-
-<!-- lore:019db6da-30d7-7c0d-8ac0-a7eedc088741 -->
-
-- **publish.yml → Craft state-file handoff via XDG_STATE_HOME**: getsentry/publish's \`publish.yml\` writes the publish-state file to \`$GITHUB\_WORKSPACE/.craft-state/craft/publish-state-\<owner>-\<repo>-\<sha1(container\_cwd)\[:12]>-\<version>.json\` and sets \`XDG\_STATE\_HOME=/github/workspace/.craft-state\` on the docker step. Craft reads from \`$XDG_STATE_HOME/craft/publish-state-\*.json\`. The container_cwd is \`/github/workspace/\_\_repo\_\_\` (root) or \`/github/workspace/\_\_repo\_\_/\<subpath>\` (monorepo) — bash case statement handles both. Outside \`\_\_repo\_\_/\` means repo contents cannot pre-populate (security). Previous dual-write compat removed in getsentry/publish#7892 after Craft 2.26.0 shipped with the new-location reader.
-
-<!-- lore:019cb31a-14ce-7892-b22a-0327cfcebc13 -->
-
-- **Registry target: repo_url auto-derived from git remote, not user-configurable**: \`repo_url\` in registry manifests is always set by Craft as \`https://github.com/${owner}/${repo}\`. Resolution: (1) explicit \`github: { owner, repo }\` in \`.craft.yml\` (rare), (2) fallback: auto-detect from git \`origin\` remote URL via \`git-url-parse\` library (\`git.ts:194-217\`, \`config.ts:286-316\`). Works with HTTPS and SSH remote URLs. Always overwritten on every publish — existing manifest values are replaced (\`registry.ts:417-418\`). Result is cached globally with \`Object.freeze\`. If remote isn't \`github.com\` and no explicit config exists, throws \`ConfigurationError\`. Most repos need no configuration — the git origin remote is sufficient.
-
-<!-- lore:019cb31a-14c8-7ba9-b1c4-81b2e8bf7e85 -->
-
-- **Registry target: urlTemplate generates artifact download URLs in manifest**: \`urlTemplate\` in the registry target config generates download URLs for release artifacts in the registry manifest's \`files\` field. Uses Mustache rendering with variables \`{{version}}\`, \`{{file}}\`, \`{{revision}}\`. Primarily useful for apps (standalone binaries) and CDN-hosted assets — SDK packages published to public registries (npm, PyPI, gem) typically don't need it. If neither \`urlTemplate\` nor \`checksums\` is configured, Craft skips adding file data entirely (warns at \`registry.ts:341-349\`). Real-world pattern: \`https://downloads.sentry-cdn.com/\<product>/{{version}}/{{file}}\`.
+- **getsentry/craft has two independent pnpm projects: root and docs**: The getsentry/craft repo contains two independent pnpm projects with separate lockfiles: (1) root — \`package.json\` + \`pnpm-lock.yaml\` (6215 lines), \`@sentry/craft\` v2.27.0-dev.0, Node 22.12.0, pnpm 10.27.0 via Volta; (2) docs — \`docs/package.json\` + \`docs/pnpm-lock.yaml\` (4367 lines), \`craft-docs\` v1.0.0 private, Astro/Starlight-based. Dependabot alerts and pnpm overrides must be applied to the correct project — a vulnerability in root's lockfile is NOT fixed by adding an override to docs and vice versa.
 
 ### Gotcha
-
-<!-- lore:019df837-43e4-7a80-8e4b-9954a15c1aaa -->
-
-- **action.yml/changelog-preview.yml: shell injection via unquoted GitHub context vars**: action.yml/changelog-preview.yml: shell injection via unquoted GitHub context vars: GitHub context variables in bash scripts (\`${{ inputs.x }}\`, \`${{ github.event.y }}\`) are vulnerable to shell injection if unquoted. Fix: move to \`env:\` block at step level, then reference as \`$ENV\_VAR\`. Example: \`${{ inputs.merge\_target }}\` → \`env: { MERGE_TARGET: ${{ inputs.merge\_target }} }\` then use \`$MERGE_TARGET\`. Don't use escaped quotes — they embed literal chars. Affects action.yml and changelog-preview.yml.
-
-<!-- lore:019d8634-1a57-7ca9-985f-915388690fda -->
-
-- **actions/create-github-app-token v3 deprecated app-id input**: \*\*actions/create-github-app-token v3 required + app-id deprecated\*\*: v3 is needed for Node.js 24 runners (v2 uses Node 20, deprecated). v3 also deprecated the \`app-id\` input in favor of \`client-id\`. When the input references a variable named \`\*\_APP_ID\`, the variable value may already be a client ID (check \`vars.SENTRY_INTERNAL_APP_ID\` vs \`vars.SENTRY_RELEASE_BOT_CLIENT_ID\`). Replace both the action version and the input name. Affects all workflow files using the action.
-
-<!-- lore:019db6da-30c3-77d6-af97-f86304ab754a -->
-
-- **Allowlist cutting GITHUB\_\* breaks user release scripts**: PR #794's release-command env allowlist was too tight — it stripped all \`GITHUB\_\*\` except \`GITHUB_TOKEN\`, breaking user scripts that read GHA context vars like \`GITHUB_RUN_ID\`, \`GITHUB_REPOSITORY\`, \`GITHUB_SHA\` (sentry-cocoa's bump.sh failed on \`unbound variable GITHUB_RUN_ID\`). Fix in #807: extend \`buildReleaseCommandEnv\` to forward any \`process.env\` key starting with \`GITHUB\_\` or \`RUNNER\_\` by prefix. Safe because \`publish.yml\` only sets \`GITHUB_TOKEN\` itself under that namespace — all other secrets use unrelated prefixes (\`NPM_TOKEN\`, \`CRATES_IO_TOKEN\`, \`AWS_SECRET_ACCESS_KEY\`, etc.). Prefix allowlist does not expand credential-leak surface.
-
-<!-- lore:019dba19-0440-799a-bdf1-859349759724 -->
-
-- **Astro 6 upgrade requires @astrojs/starlight ≥0.38.0 in getsentry/craft docs**: The \`docs/\` workspace uses \`@astrojs/starlight\` which pins Astro peer versions. Starlight 0.37.x requires \`astro ^5.5.0\`; 0.38.0 is the first version supporting Astro v6. Bumping only \`astro\` to 6.x while leaving Starlight at 0.37.x builds past install but fails at \`astro build\` with \`options.starlightConfig.markdown.processedDirs is not iterable\`. Always bump both in lockstep. Additionally, Astro 6 removed legacy content-collections backwards-compat: \`docs/src/content/config.ts\` must move to \`docs/src/content.config.ts\` and each collection needs a \`loader\` (use \`docsLoader()\` from \`@astrojs/starlight/loaders\` alongside \`docsSchema()\` from \`@astrojs/starlight/schema\`). Dependabot PRs that only bump \`astro\` will fail \`Build Docs\` + \`Docs Preview\` until both changes are applied.
-
-<!-- lore:019daf66-fef3-7f51-a7f2-07276b8d300e -->
-
-- **auto-approve race: can fire before ci-pending.yml adds its label**: \*\*Resolved in getsentry/publish PR #7881\*\*: Eliminated the race by restructuring the label flow — \`ci-pending\` is now added by \`waiting-for-ci\` in \`publish.yml\` only AFTER \`accepted\` is present, not by a separate \`ci-pending.yml\` on \`issues:opened\`. The \`ci-pending.yml\` workflow was deleted. New flow: craft creates issue → (auto-approve or human) adds \`accepted\` → \`waiting-for-ci\` job adds \`ci-pending\`, comments, and triggers the poller → poller swaps to \`ci-ready\` when CI passes → \`publish.yml\` fires. The publish gate also requires \`label == accepted || label == ci-ready\`, so publish can never fire from the initial \`accepted\` label event alone — it must wait for the poller's \`ci-ready\` transition. This closes the race regardless of label ordering.
-
-<!-- lore:019df871-87d5-739a-bd83-82b92aae8d8a -->
-
-- **Bash array expansion required for safe shell argument passing in actions**: GitHub Actions bash scripts must use bash arrays to safely pass user-controlled arguments to executables. String concatenation with escaped quotes (e.g., \`CRAFT_ARGS="--config-from \\"$VAR\\""\`) embeds literal quote characters in the argument, causing the downstream command to receive \`"value"\` instead of \`value\`. Use arrays instead: \`CRAFT\_ARGS=(--config-from "$VAR")\` then expand with \`"${CRAFT_ARGS\[@]}"\`. Handles spaces, special chars, and ensures correct quoting at shell expansion time. Applied in action.yml PR #811 for \`craft prepare\` invocation.
-
-<!-- lore:019db1ee-c08c-739e-879e-d958e5d9f1a1 -->
-
-- **bun pm pack reads workspace versions from bun.lock, not package.json**: \`bun pm pack\` rewrites \`workspace:\*\` specifiers to concrete versions at pack time, reading them from \`bun.lock\` — NOT from the workspace \`package.json\`. If craft bumps package.json but leaves bun.lock stale, published tarballs point at old versions (ETARGET on install). Fix in \`NpmTarget.patchBunLock\` (src/targets/npm.ts): regex-patch bun.lock per workspace path-key. CRITICAL regex gotcha: use \`\[^{}]\*?\` (not \`\[\s\S]\*?\`) to bound the match to the workspace's own block — \`\[\s\S]\*?\` walks past a versionless workspace's closing \`}\` and silently rewrites the NEXT workspace's version. Normalize \`\\\` → \`/\` for Windows; escape regex chars (reuse \`escapeRegex\` from \`src/utils/filters.ts\`, don't duplicate). Only call when \`isWorkspace\` is true — otherwise non-workspace bun repos get a spurious 'lockfile out of sync' warning. Idempotent; uses \`safeFs.writeFileSync\`.
-
-<!-- lore:019d9acf-8039-7fc0-b677-83fe5ea32a20 -->
-
-- **CI poller needs release-bot token for private repo CI status checks**: The \`getsentry/publish\` CI poller's cross-repo API calls (commit status, check suites, git refs) require the \`sentry-release-bot\` app token with \`owner: getsentry\` scope — not the \`sentry-internal-app\` token. The internal app isn't installed on all getsentry repos (e.g. \`sentry-xbox\`, \`sentry-playstation\`, \`sentry-switch\`, \`service-registry\`), causing 404s on all CI status API calls. Combined with the \`gh api --jq\` stdout error leak, this silently leaves issues stuck in \`ci-pending\` indefinitely. Fix (PR #7843): added a separate \`release-bot-token\` step and a \`gh_api_release\` helper that uses \`GH_TOKEN="$RELEASE_TOKEN"\` for all cross-repo calls.
-
-<!-- lore:019e5017-0332-73e6-ba3b-b000f529ce0a -->
-
-- **CocoaPods transient error patterns: 'timeout' and 'cdn:' are too broad**: Trap: adding \`'timeout'\` and \`'cdn:'\` to \`COCOAPODS_TRANSIENT_ERROR_PATTERNS\` looks comprehensive but both are too broad. \`'timeout'\` matches permanent errors; \`'cdn:'\` matches permanent CDN errors. Fix: remove both — use \`'timed out'\`, \`'etimedout'\`, \`'504 gateway timeout'\`, \`'cdn.cocoapods.org'\`, and \`'trunk.cocoapods.org'\` instead. Real CocoaPods errors say \`CDN: trunk.cocoapods.org: timeout\` — the domain is \`trunk.cocoapods.org\`, not \`cdn.cocoapods.org\`, so BOTH patterns are needed. Additionally: 'already published' errors (\`'has already been pushed'\`) must be caught inside the retry body and treated as success. Test isolation: use \`vi.resetAllMocks()\` not \`vi.clearAllMocks()\` — \`clearAllMocks\` only clears call history, not implementations; persistent \`mockResolvedValue\` from one test leaks into the next.
-
-<!-- lore:019db0c1-fb98-755c-bd6b-22134bd6d852 -->
-
-- **Craft .craft-publish-\<version>.json state file is unauthenticated**: Craft .craft-publish-\<version>.json state file is unauthenticated: The publish state file was \`.craft-publish-\<version>.json\` in cwd, writable by any earlier CI step → silent target-skip → pipeline manipulation. Fixed in PR #797 (v2.26.0): moved to \`$XDG_STATE_HOME/craft/publish-state-\<owner>-\<repo>-\<sha1(cwd)\[:12]>-\<version>.json\` via \`src/utils/publishState.ts\`. \`XDG_STATE_HOME=/github/workspace/.craft-state\` set on docker step (outside \`\_\_repo\_\_/\` so repo can't pre-populate). Fallback when GH config unresolved: \`publish-state-\<sha256(cwd)\[:16]>-\<version>.json\`.
-
-<!-- lore:019db09e-aca8-7a81-b2f7-e117be50e02a -->
-
-- **Craft .craft.env file reading removed — security hazard via LD_PRELOAD**: Craft .craft.env file reading removed — security hazard via LD_PRELOAD: Craft used to hydrate \`process.env\` from \`$HOME/.craft.env\` and \`\<config-dir>/.craft.env\`, allowing attacker PRs to inject \`LD_PRELOAD=./preload.so\` for RCE with full secret access. Removed entirely. \`src/utils/env.ts\` now only exports \`warnIfCraftEnvFileExists()\` (startup warning) and \`checkEnvForPrerequisite\`. Consumers must set env vars via shell/CI.
-
-<!-- lore:019db0c1-fb90-7507-900b-896619ea120f -->
-
-- **Craft .craft.yml discovery walks up from cwd — ancestor configs auto-load**: Craft .craft.yml discovery walks up from cwd — ancestor configs auto-load: \`src/config.ts:findConfigFile()\` walks upward up to 1024 dirs looking for \`.craft.yml\`. Any stray \`.craft.yml\` in an ancestor (including \`$HOME\`) loads unconditionally and executes \`preReleaseCommand\`. No \`--config\` flag exists. Hardening: restrict discovery to git worktree root, optionally require git tracking, add \`--config \<path>\` flag to disable the walk.
-
-<!-- lore:019ca05d-1ee2-759e-8a57-596470be9a3a -->
-
-- **Craft changelog: commits without PRs were forced into leftovers regardless of category match**: In \`src/utils/changelog.ts\`, the leftovers guard at the categorization step had \`if (!categoryTitle || !raw.pr)\` — the \`|| !raw.pr\` condition forced ALL commits without associated PRs into the "Other" leftovers section, even when they matched a category via \`commit_patterns\` or labels. This meant direct pushes (no PR) like \`feat(auth): add SSO\` would correctly contribute to version bump calculation (which runs before the leftovers check) but would appear under "Other" in the changelog instead of their matched category. Fix: remove \`|| !raw.pr\` so only \`!categoryTitle\` controls leftover placement. The downstream rendering already handles PR-less commits gracefully — \`createPREntriesFromRaw\` uses \`raw.pr ?? ''\`, and \`formatChangelogEntry\` falls back to commit-hash links when \`prNumber\` is falsy (empty string).
-
-<!-- lore:019db0c1-fb9f-719c-a903-14dc258a8cdd -->
-
-- **Craft commitOnGitRepository uses execSync with string-interpolated tar path**: Craft commitOnGitRepository uses execSync with string-interpolated tar path: Previously ran \`childProcess.execSync(\\\`tar -zxvf ${archivePath}${stripComponentsArg}\\\`)\` — shell string concatenation vulnerable to injection. Fixed in PR #799: replaced with \`tar.x({ file: archivePath, cwd: directory, strip: stripComponents })\` from \`node-tar\` dep. No shell, no interpolation.
 
 <!-- lore:019db190-ac2d-73a8-9464-c884feaba7a3 -->
 
 - **Craft docs/src/content/docs/configuration.md duplicates DEFAULT_RELEASE_CONFIG**: The \`Default Configuration\` YAML snippet in \`docs/src/content/docs/configuration.md\` (~lines 230-257) enumerates the default changelog categories verbatim and must be kept in sync with \`DEFAULT_RELEASE_CONFIG\` in \`src/utils/changelog.ts\`. When adding/removing/reordering categories in code, update this doc snippet in the same PR — otherwise users copy-pasting to customize get a silently-outdated config. No automated check exists. Related: \[\[019db138-9e4d-79f5-bf25-7379510c2b45]].
 
-<!-- lore:019db0c1-fb94-73b0-aeb6-513d4cb2a79b -->
+<!-- lore:019ef3df-197a-78d1-9e2f-6df912e8f4fe -->
 
-- **Craft GPG TOCTOU: private key written to fixed /tmp path**: Craft GPG TOCTOU: private key written to fixed /tmp path: Craft GPG key import previously wrote \`GPG_PRIVATE_KEY\` to \`path.join(tmpdir(), 'private-key.asc')\` — predictable world-readable path vulnerable to TOCTOU via symlink races. Fixed in PR #798: \`src/utils/gpg.ts\` now pipes the key via stdin to \`gpg --batch --import\` using \`spawnProcess()\`. Key never touches disk.
-
-<!-- lore:019d9a8f-c76e-7716-b1ca-7546635fecc0 -->
-
-- **Craft postReleaseCommand env vars pollute shared bump-version scripts**: Craft postReleaseCommand env vars pollute shared bump-version scripts: \`runPostReleaseCommand\` set \`CRAFT_NEW_VERSION=\<released-version>\` in subprocess env. If post-release script calls shared \`bump-version.sh\` that reads \`NEW_VERSION="${CRAFT\_NEW\_VERSION:-${2:-}}"\`, env var takes precedence over positional arg, causing version to stay at already-current release → no diff → no commit. Fixed in \`publish.ts:563-564\`: use \`CRAFT_RELEASED_VERSION\` instead (prepare.ts correctly uses \`CRAFT_NEW_VERSION\`).
-
-<!-- lore:019db0c1-fb82-79d6-9485-77f5dcc3e924 -->
-
-- **Craft scripts/bump-version.sh and scripts/post-release.sh auto-run from cwd**: Craft scripts/bump-version.sh and scripts/post-release.sh auto-run from cwd: \`prepare.ts\` and \`publish.ts\` silently auto-execute \`scripts/bump-version.sh\` / \`scripts/post-release.sh\` when no explicit \`preReleaseCommand\`/\`postReleaseCommand\` in \`.craft.yml\`. A PR that merely adds one of these files gets executed on next \`craft prepare\`/\`publish\` with allowlisted release env (includes \`GITHUB_TOKEN\`). Hardening: require explicit opt-in in \`.craft.yml\`; drop file-exists fallback.
-
-<!-- lore:019db1d0-fefd-7f99-bb76-bb957dc96c38 -->
-
-- **docker://getsentry/craft:latest tag lag vs release completion**: The \`docker://getsentry/craft:latest\` tag on DockerHub advances AFTER the GitHub release completes — there's a gap of minutes between \`release/X.Y.Z\` merging and \`:latest\` pointing to the new digest. Publish runs that trigger during this window pull the PREVIOUS version. Verify the digest mapping with \`gh api /repos/getsentry/craft/.../\` or DockerHub's tags API before assuming a publish run used the newly-released Craft. The \`image.yml\` workflow on master produces this tag; check its completion timestamp against the publish run's \`docker pull\` timestamp.
-
-<!-- lore:019c9ba5-515b-70c8-bc1a-1221f6858b42 -->
-
-- **Edit tool triggers Prettier reformatting on the entire file**: When using the Edit tool to make a targeted change to a file in a repo with Prettier configured, the tool may reformat the entire file (e.g., aligning markdown table columns, changing quote styles). This causes the git diff to show cosmetic changes far beyond the intended edit. To keep commits clean: either accept the Prettier reformatting as a net improvement (if the file passes \`prettier --check\`), or use \`git checkout -- \<file>\` to restore the original and re-apply the change via bash/sed for surgical precision. In this codebase, Prettier is configured (\`.prettierrc.yml\`) but the lint CI workflow does NOT run \`prettier --check\`, only ESLint and typecheck.
-
-<!-- lore:019c9f57-aa0c-7a2a-8a10-911b13b48fc0 -->
-
-- **ESM modules prevent vi.spyOn of child_process.spawnSync — use test subclass pattern**: ESM modules prevent vi.spyOn of child_process.spawnSync — use test subclass pattern: In ESM (Vitest or Bun), you cannot \`vi.spyOn\` exports from Node built-in modules — throws 'Module namespace is not configurable'. Workaround: create a test subclass that overrides the method and injects controllable values, or use module-level \`vi.mock()\` (affects all tests in file).
-
-<!-- lore:019d4479-fd93-7328-a4b5-f9405e4aad8b -->
-
-- **GitHub App tokens expire after 1 hour — breaks long-running CI publishes**: GitHub App installation tokens expire after 1 hour (non-configurable). For publish jobs exceeding this (e.g., sentry-native's ~1h 23m symbol upload), the token expires before Craft's post-publish \`git push\` for the release branch merge. Git fails with \`could not read Username for 'https://github.com': No such device or address\` — which looks like a credential config issue but is actually token expiration. No code change in Craft alone can fix this — the \`GITHUB_TOKEN\` env var, git \`http.extraheader\`, and Octokit all use the same expired token. The real fix requires the CI workflow (\`getsentry/publish\`) to generate a fresh token after the Docker container exits, before the merge step.
-
-<!-- lore:019e5017-032b-7313-8928-32717f13a6c7 -->
-
-- **GitHub getReleaseByTag returns 404 for draft releases — cannot detect leftover drafts**: Trap: \`repos.getReleaseByTag()\` returns 404 for draft releases — drafts have no published tag. So \`getReleaseByTag\` will never return a draft, making leftover-draft detection dead code. Fix: use \`repos.listReleases({ per_page: 100 })\` (drafts appear in list responses for repo admins) and filter by tag name. In \`src/targets/github.ts\`, the recovery flow is: catch 422 from \`createDraftRelease\` → call \`findDraftReleasesByTag(tag)\` → delete each draft → if deletion fails, re-throw (don't retry with a live draft still present) → retry \`createDraftRelease\`. The \`existingRelease.draft === true\` branch via \`getReleaseByTag\` is unreachable and was replaced by this 422-recovery pattern.
+- **getsentry/craft: tar is a pinned devDep (no caret) — must bump the pin directly, not via override**: Trap: \`tar\` looks like a transitive dep that should be fixed via \`pnpm.overrides\`, because most security fixes use overrides. Fix: \`tar@7.5.11\` is a direct devDependency pinned without a range operator at \`package.json:65\` — bump the pin directly to \`7.5.16\` and run \`pnpm install\`. An override would be redundant and confusing. Vulnerable range: \`<= 7.5.15\` (GHSA-vmf3-w455-68vh, Alerts #180/#181). Confirmed tar@7.5.16 exists on npm. pnpm-lock.yaml line 6007 resolves tar@7.5.11.
 
 <!-- lore:019c9ee7-f55f-7697-b9b4-e7b9c93e9858 -->
 
 - **Lore tool seeds generic entries unrelated to the project — clean before committing**: The opencode-lore tool (https://github.com/BYK/opencode-lore) can seed AGENTS.md with generic/template lore entries that are unrelated to the actual project. These are identifiable by: (1) shared UUID prefix like \`019c9aa1-\*\` suggesting batch creation, (2) content referencing technologies not in the codebase (e.g., React useState, Kubernetes helm charts, TypeScript strict mode boilerplate in a Node CLI project). These mislead AI assistants about the project's tech stack. Always review lore-managed sections in AGENTS.md before committing and remove entries that don't apply to the actual codebase. Cursor BugBot will flag these as "Irrelevant lore entries."
 
-<!-- lore:019db1ee-c081-7071-b851-23bfbc888bd1 -->
-
-- **npm version --workspaces fails on workspace:\* deps but still bumps files**: \`npm version \<v> --workspaces --include-workspace-root\` on a monorepo with \`"workspace:\*"\` deps writes the new version to every package.json (including private workspaces — npm bumps those too), then exits non-zero with \`EUNSUPPORTEDPROTOCOL\` validating dep URLs (npm/cli#8845). Craft's \`NpmTarget.bumpVersion\` treats the exit code as failure. Fix: on spawn failure, post-check observable state — read every package.json (public AND private) and if all show \`version === newVersion\`, warn and proceed. Do NOT skip private packages in the post-check — that's a false loosening since npm actually bumps them. Genuine failures (bad version, perm errors) still throw because files weren't bumped. Apply same per-package post-check in \`bumpWorkspacePackagesIndividually\`. Guard with \`isDryRun()\` since \`spawnProcess\` no-ops in dry-run.
-
-<!-- lore:019c9be1-33d1-7b6e-b107-ae7ad42a4ea4 -->
-
-- **pnpm overrides with >= can cross major versions — use ^ to constrain**: pnpm overrides gotchas: (1) \`>=\` crosses major versions — use \`^\` to constrain within same major. (2) Version-range selectors don't reliably force re-resolution of compatible transitive deps; use blanket overrides when safe. (3) Overrides become stale — audit with \`pnpm why \<pkg>\` after dependency changes. (4) Never manually resolve pnpm-lock.yaml conflicts — \`git checkout --theirs\` then \`pnpm install\` to regenerate deterministically.
-
-<!-- lore:019c9eb7-a640-776a-929d-89120f81733a -->
-
-- **pnpm-lock.yaml merge conflicts: regenerate don't manually merge**: pnpm gotchas: (1) Lock file conflicts: never manually resolve — \`git checkout --theirs pnpm-lock.yaml\` then \`pnpm install\` to regenerate. \`git stash pop\` after merge can re-conflict; drop the stash and re-run instead. (2) Overrides: \`>=\` crosses major versions — use \`^\` to stay in-major. Version-range selectors don't reliably force re-resolution of compatible transitive deps; use blanket overrides when all consumers are on same major. (3) Overrides go stale on tree changes — audit with \`pnpm why\` and remove orphans.
-
-<!-- lore:019d4479-fd9a-7a97-931f-8f9a18e5752e -->
-
-- **prepare-dry-run e2e tests fail without EDITOR in dumb terminals**: The 7 tests in \`src/\_\_tests\_\_/prepare-dry-run.e2e.test.ts\` fail in environments where \`TERM=dumb\` and \`EDITOR\` is unset (e.g., inside agent shells or minimal CI containers). The error is \`Terminal is dumb, but EDITOR unset\` from git commit. This is a pre-existing environment issue, not a code defect. These tests pass in normal CI (Node.js 20/22 runners) where terminal capabilities are available.
-
 <!-- lore:019c9be1-33db-7bba-bb0a-297d5de6edb7 -->
 
 - **prepare-dry-run e2e tests require EDITOR env var for git commit**: The 6 tests in \`src/\_\_tests\_\_/prepare-dry-run.e2e.test.ts\` fail in environments where \`EDITOR\` is unset and the terminal is non-interactive (e.g., headless CI agents, worktrees). The error is \`Terminal is dumb, but EDITOR unset\` from git refusing to commit without a message editor. These are environment-dependent failures, not code bugs. They pass in environments with \`EDITOR=vi\` or similar set.
 
-<!-- lore:019daf66-fee9-7897-86e9-69d4c4e0c582 -->
-
-- **Publish issue title monorepo suffix breaks owner/repo parsing**: Craft titles like \`publish: getsentry/relay/py@0.9.26\` have a subdirectory path suffix. Naive \`sed 's/^publish: \\(.\*\\)@.\*/\1/p'\` extracts \`getsentry/relay/py\` — causes 404 on every GitHub API call (\`repos/getsentry/relay/py/...\` isn't a valid repo). Fix: match only first two path segments: \`sed -n 's|^publish: \\(\[^/]\*/\[^/@]\*\\).\*@.\*|\1|p'\`. Applies to any workflow parsing publish issue titles (ci-poller.yml, auto-approve.yml, craft-action.yml's request-publish step).
-
-<!-- lore:019db1ee-c097-7368-b790-eb49552aa1b2 -->
-
-- **spawnProcess no-ops in dry-run — breaks post-check logic**: \`src/utils/system.ts\` \`spawnProcess\` returns \`undefined\` immediately in dry-run mode (unless \`enableInDryRunMode\` or worktree mode is set) — it never actually spawns the child. Any logic that relies on observable side effects (files written, state changed) after a spawn will see unchanged state in dry-run. Example trap: post-checking package.json \`version\` after \`npm version\` to detect successful-but-errored bumps would incorrectly trigger fallback paths in dry-run because the spawn is skipped and files stay stale. Mitigation: guard post-check / fallback logic with \`isDryRun()\` and short-circuit to the existing dry-run success behavior. File writes don't have this problem if routed through \`safeFs.writeFileSync\` which handles dry-run natively.
-
-<!-- lore:019db141-686d-7689-a23e-f48c6a04a3fa -->
-
-- **system.ts → env.ts import creates circular dep via config.ts**: system.ts → env.ts import creates circular dep via config.ts: Importing \`env.ts\` from \`src/utils/system.ts\` creates circular dep: system.ts → env.ts → config.ts → artifact_providers/github.ts → system.ts. Symptom: \`BaseArtifactProvider\` is \`undefined\` at class-extension time. Fix: put helpers shared between system.ts and env.ts in leaf module with no other imports (e.g. \`src/utils/dynamicLinkerEnv.ts\`). Don't import config/env-heavy modules from system.ts.
-
-<!-- lore:019e5068-804c-7d50-82b8-e6a4f4d04198 -->
-
-- **vi.clearAllMocks() does not reset mock implementations — use vi.resetAllMocks()**: Trap: \`vi.clearAllMocks()\` in \`beforeEach\` looks like a clean slate but only clears call history/counts — it does NOT reset implementations set via \`mockResolvedValue()\` (without \`Once\`). A persistent \`mockResolvedValue(undefined)\` from test A leaks into test B, causing the mock to return \`undefined\` instead of the \`Once\` values queued in test B. Symptom: tests pass in isolation but fail when run together. Fix: use \`vi.resetAllMocks()\` instead — it clears both call history AND implementations. Then re-apply any default mock implementations in \`beforeEach\` after the reset call.
-
 ### Pattern
-
-<!-- lore:019c9ba5-515c-7131-a1e6-10f93443d0e2 -->
-
-- **AGENTS.md lore section: only include project-relevant entries**: The \`\<!-- lore-managed section -->\` in AGENTS.md is auto-maintained by the lore tool and can accumulate cross-project entries (React, Kubernetes, etc.) that are irrelevant to the Craft codebase. When committing AGENTS.md changes, review the lore section and strip entries that don't pertain to this repo. Only project-specific patterns (like the \`publish_repo: self\` sentinel) should be included.
-
-<!-- lore:019d867b-7617-77ff-a3e3-25f9e7548b29 -->
-
-- **CI poller variable gate with dedicated app token in getsentry/publish**: \*\*CI poller variable gate with dedicated app token in getsentry/publish\*\*: The \`ci-poller.yml\` cron uses repo variable \`CI_POLLER_HAS_PENDING\` as a fast gate — \`'true'\` runs, otherwise skips. \`workflow_dispatch\` bypasses the gate. \*\*Self-dispatch for fast re-checking\*\*: when pending issues remain, the poller dispatches itself (up to 60 attempts, ~30 min cap) for ~30-60s intervals instead of relying on unreliable cron. \*\*Two tokens required\*\*: (1) \`sentry-release-bot\` (\`SENTRY_RELEASE_BOT_CLIENT_ID\`/\`SENTRY_RELEASE_BOT_PRIVATE_KEY\` with \`owner: getsentry\`) for cross-repo API calls (CI status, check suites, git refs) since sentry-internal-app isn't installed on all repos. (2) \`CI_POLLER_APP\` token for writing repo variables. \`gh issue list/edit/comment\` uses sentry-internal-app token so label changes trigger \`publish.yml\`. Key: cleanup steps use \`if: always()\`; disable steps guard on \`steps.poller-token.outcome == 'success'\`.
 
 <!-- lore:019c9bb9-a79b-71e0-9f71-d94e77119b4b -->
 
 - **CLI UX: auto-correct common user mistakes with stderr warnings instead of hard errors**: CLI UX: auto-correct common user mistakes with stderr warnings instead of hard errors. Safe when: (1) input is already invalid, (2) no ambiguity in correction, (3) warning goes to stderr (doesn't interfere with JSON/stdout). Normalize inputs at command level before passing to pure parsing functions. The \`gh\` CLI is the UX model.
 
-<!-- lore:019daf66-5dbc-729e-89a3-a35ec63707bf -->
-
-- **Craft action.yml opt-in ci_ready input + signal-ready composite action**: In getsentry/craft, the \`ci_ready: 'true'\` input on \`action.yml\` makes \`craft prepare\` add a \`ci-pending\` label at issue creation (atomic with \`gh issue create --label\`), opting the repo into event-driven publishing. A separate composite action \`signal-ready/action.yml\` lets target repo CI send a \`repository_dispatch\` event of type \`ci-ready\` with \`{repo, version, sha}\` payload to the publish repo when CI passes. The publish repo's \`ci-ready.yml\` handler finds the issue by exact title match (\`publish: {repo}@{version}\`), verifies \`ci-pending\` is present, swaps labels. Auth: the dispatch sender needs a token with write access to the publish repo (sentry-release-bot app token, not \`GITHUB_TOKEN\`).
-
-<!-- lore:019d4479-fd97-764e-a7ec-0d32360b0f16 -->
-
-- **Craft Docker container auth: credentials come from volume-mounted git config**: When Craft runs inside Docker in CI (via \`getsentry/craft:latest\`), git authentication comes from \`actions/checkout\`'s \`http.extraheader\` in the local \`.git/config\`, which is volume-mounted into the container at \`/github/workspace\`. The container sets \`HOME=/root\`, so global git config from the host runner isn't available. The \`GITHUB_TOKEN\` env var is passed separately. Craft's \`handleReleaseBranch()\` doesn't set up its own auth — it relies on whatever git config is present. Other targets (registry, commitOnGitRepository) explicitly inject tokens into clone URLs via \`GitHubRemote.getRemoteStringWithAuth()\` or URL manipulation.
-
 <!-- lore:019c9f57-aa11-74f6-9532-7c8a45fe12a5 -->
 
 - **Craft npm target OIDC detection via CI environment variables**: The \`isOidcEnvironment()\` helper in \`src/targets/npm.ts\` detects OIDC capability by checking CI-specific env vars that npm itself uses for OIDC token exchange: - \*\*GitHub Actions:\*\* \`ACTIONS_ID_TOKEN_REQUEST_URL\` AND \`ACTIONS_ID_TOKEN_REQUEST_TOKEN\` (both present when \`id-token: write\` permission is set) - \*\*GitLab CI/CD:\*\* \`NPM_ID_TOKEN\` (present when \`id_tokens\` with \`aud: "npm:registry.npmjs.org"\` is configured) This auto-detection means zero config changes for the common case. The explicit \`oidc: true\` config is only needed to force OIDC when \`NPM_TOKEN\` is also set (e.g., migration period).
-
-<!-- lore:019db213-4205-7445-94a0-235778777da9 -->
-
-- **Craft PR review workflow: subagent self-review + bot-finding loop before merge**: Before merging non-trivial Craft PRs: (1) dispatch a subagent for objective critical review — it catches silent-corruption bugs human review glosses over (e.g. regex boundary issues); (2) verify each finding with a minimal reproducer before fixing; (3) add regression tests and verify they fail when the fix is reverted; (4) after push, wait for \`Cursor Bugbot\` and \`Seer Code Review\` checks (both appear as CheckRuns on the PR) — \`NEUTRAL\` conclusion means non-blocking findings posted as review comments; (5) reply to each bot comment via \`gh api repos/.../pulls/comments/{id}/replies\` and resolve threads via GraphQL \`resolveReviewThread\`. Branch protection requires review approval; repo admins can use \`gh pr merge --squash --admin\` to bypass for self-reviewed fixes. Format check (prettier) is part of the Lint workflow — run \`pnpm format\` before pushing.
 
 <!-- lore:019cbe02-ce99-7e34-af5d-3a28c43a7cd4 -->
 
 - **Craft PR workflow: branch from master, cherry-pick, git notes for plans**: Branch naming convention is \`{user}/{type}/{description}\` (e.g., \`byk/fix/...\`, \`feat/...\`). When working from a feature branch worktree, create fix branches from master: \`git checkout -b fix/name --track origin/master\`, then \`git cherry-pick \<commit>\`. Commit title conventions follow conventional commits: \`fix:\`, \`feat:\`, \`refactor:\`, \`meta:\`, \`docs:\`. For implementation plans, attach as git notes via \`git notes add -m "..."\` and push with \`git push origin refs/notes/commits\`. Create draft PRs with \`gh pr create --draft\`.
 
-<!-- lore:019c9b36-8f9d-71c9-a43a-d2715aa249d0 -->
+<!-- lore:019c9eb7-a633-78aa-aaeb-8ddca3719975 -->
 
-- **Craft publish_repo 'self' sentinel resolves to GITHUB_REPOSITORY at runtime**: The composite action's \`publish_repo\` input supports a special sentinel value \`"self"\` which resolves to \`$GITHUB_REPOSITORY\` at runtime in the bash script of the 'Request publish' step. This allows repos to create publish request issues in themselves rather than in a separate \`{owner}/publish\` repo. The resolution happens in bash (not in the GitHub Actions expression) because the expression layer sets \`PUBLISH_REPO\` via \`inputs.publish_repo || format('{0}/publish', github.repository_owner)\` — the string \`"self"\` passes through as-is and gets resolved to the actual repo name in the shell. Useful for personal/small repos where the default GITHUB_TOKEN already has write access to the repo itself.
+- **Craft publish_repo 'self' sentinel resolves to GITHUB_REPOSITORY at runtime**: The Craft composite action's \`publish_repo\` input supports a special sentinel value \`"self"\` which resolves to \`$GITHUB_REPOSITORY\` at runtime in the bash script of the 'Request publish' step. This allows repos to create publish request issues in themselves rather than in a separate \`{owner}/publish\` repo. The resolution happens in bash (not in the GitHub Actions expression) because the expression layer sets \`PUBLISH_REPO\` via \`inputs.publish_repo || format('{0}/publish', github.repository_owner)\` — the string \`"self"\` passes through as-is and gets resolved to the actual repo name in the shell. Useful for personal/small repos where the default GITHUB_TOKEN already has write access to the repo itself.
 
 <!-- lore:019c9fa3-fcfe-7b07-8351-90944df38ca0 -->
 
 - **Craft uses home-grown SemVer utils — don't add semver package for version comparisons**: Despite \`semver\` being a dependency (used in \`src/utils/autoVersion.ts\` for \`semver.inc()\`), the codebase has its own \`SemVer\` interface and utilities in \`src/utils/version.ts\`: \`parseVersion()\`, \`versionGreaterOrEqualThan()\`, \`isPreviewRelease()\`, etc. These are used throughout the codebase (npm target, publish tag logic, etc.). When adding version comparison logic, use these existing utilities rather than introducing new custom comparison functions or reaching for the \`semver\` package. Example: the OIDC minimum npm version check was initially implemented with 3 separate constants and a custom comparison helper, then refactored to a single \`SemVer\` constant + \`versionGreaterOrEqualThan()\`.
 
-<!-- lore:019db1ee-c093-7663-8c7d-37c07fda211b -->
-
-- **Craft workspace discovery supports npm/yarn/pnpm uniformly**: \`src/utils/workspaces.ts\` \`discoverWorkspaces(rootDir)\` returns \`{type: 'npm'|'yarn'|'pnpm'|'none', packages: WorkspacePackage\[]}\`. Tries pnpm-workspace.yaml first (more specific), then package.json \`workspaces\` field (array or \`{packages: \[]}\` object form). npm vs yarn is distinguished by presence of \`yarn.lock\`. Each \`WorkspacePackage\` carries \`name\`, absolute \`location\`, \`private\`, \`hasPublicAccess\` (publishConfig.access === 'public'), and \`workspaceDependencies\` (deps that reference other workspace packages by name — across dependencies/peer/optional, not dev). \`NpmTarget.expand\` uses this to auto-generate per-package target configs, filters private packages, validates public→private deps, and topologically sorts via \`topologicalSortPackages\` (depth-based, detects cycles). Artifact filenames generated via \`packageNameToArtifactPattern\` or a user \`artifactTemplate\` with \`{{name}}\`/\`{{simpleName}}\`/\`{{version}}\`.
-
 <!-- lore:019db190-ac1e-7acb-bcc5-54730cdf4ec4 -->
 
 - **Craft: split unrelated work into separate PRs off master**: When a feature or fix is logically independent from existing work on the current branch, don't append it to that branch. Create a new branch off master (\`git fetch origin master && git checkout -b \<branch> origin/master\`), stash changes, pop on the new branch, commit, push with \`-u\`, open PR. This keeps PRs self-contained, independently reviewable, and revertable. Applies even when the current branch name thematically overlaps (e.g., a branch named \`fix/dependabot-security-alerts\` is not the right home for a feature adding \`security:\` prefix recognition).
 
-<!-- lore:019d8c2f-ddaf-72f0-96db-44dd54bd56b8 -->
+<!-- lore:019ef3df-1990-791d-9e1d-0cb9b6daff27 -->
 
-- **Craft/Publish release flow: prepare then accept publish issue**: Craft's release flow is two-phase: (1) Run \`release.yml\` GitHub Action with version "auto" — this runs \`craft prepare\`, auto-determines version from commits, creates the \`release/X.Y.Z\` branch, and opens a publish issue on \`getsentry/publish\` repo (e.g. \`publish: getsentry/craft@2.25.3\`). (2) Add the \`accepted\` label to that publish issue to trigger the actual publish pipeline. Do NOT manually create release branches — always use the workflow. The publish issue URL is emitted in the release job logs as a \`::notice::Created publish request:\` line. The publish repo is configured via \`PUBLISH_REPO\` (defaults to \`getsentry/publish\`).
-
-<!-- lore:019daf66-fed6-7031-9a7c-b94791a71647 -->
-
-- **getsentry/publish: label-based state machine for publish gating**: getsentry/publish label state machine (post-PR #7881 + retry-race fix): \`accepted\` (human/auto-approve, added first), \`ci-pending\` (added by \`waiting-for-ci\` in publish.yml AFTER \`accepted\`), \`ci-ready\` (added by poller when CI passes), \`ci-failed\` (added by poller on failure, also removes \`accepted\`). \*\*Publish gate fires ONLY on \`ci-ready\` label event\*\* — not \`accepted\` — to prevent race where \`publish\` and \`waiting-for-ci\` run in parallel on the same \`labeled: accepted\` event when \`ci-ready\` is stale from a previous failed publish. \`waiting-for-ci\` job (on \`accepted\` labeled, when \`ci-pending\` or \`ci-failed\` present): removes \`ci-failed\` AND \`ci-ready\` (critical: stale \`ci-ready\` must be cleared so poller's re-add generates a fresh \`labeled\` event), adds \`ci-pending\`, comments, triggers poller. Concurrency group uses \`github.event.issue.title\` to lock on repo@version.
-
-<!-- lore:019daf66-feec-78eb-a2a0-4e14f3b76453 -->
-
-- **GitHub App token scoping for cross-repo CI status checks**: When a workflow in repo A needs to call APIs on repo B, \`secrets.GITHUB_TOKEN\` won't work (scoped to repo A only). Use \`actions/create-github-app-token@v3\` with \`owner: \<org>\` to get a token with access to all org repos (app must be installed org-wide). In \`getsentry/publish\`, the CI poller uses TWO tokens: \`sentry-release-bot\` (installed on all getsentry repos) for cross-repo CI status calls, and \`sentry-internal-app\` for label/comment operations on the publish repo itself. Separate tokens because some repos don't have sentry-internal-app installed.
-
-<!-- lore:019db141-6871-79b9-8a4d-25a803b4419e -->
-
-- **Split independent security fixes into separate PRs**: User preference: when tackling multiple independent security hardening items, open one PR per item rather than a single combined PR. Each PR self-contained, independently reviewable, and revertable, with no ordering dependency. Branch naming: \`security/\<short-description>\`. Examples from this session: .craft.env / GPG stdin / node-tar / subprocess env sanitization / action pinning / publish-state move → separate PRs (#794, #797-#801) on 4+ branches off master. Companion PRs that coordinate across repos (e.g. Craft #797 + publish #7886 dual-write + publish #7892 legacy-drop) are also split by repo and sequenced deliberately.
-
-<!-- lore:019db1d0-fef2-73d3-b17e-54512b7cb837 -->
-
-- **Synthetic end-to-end test for Craft binary behavior without Docker**: Synthetic end-to-end test for Craft binary behavior without Docker: Download bundled binary from release (\`gh release download \<tag> -p 'craft'\`), create minimal git repo with \`.craft.yml\` (need \`statusProvider.name: github\`), commit+tag, then run with \`CRAFT_LOG_LEVEL=Debug GITHUB_TOKEN=... craft publish --no-status-check --no-merge \<ver>\`. Pre-seed state files using \`sha1(cwd)\[:12]\` (differs from container's \`/github/workspace/\_\_repo\_\_\` hash). Log lines like \`Found publish state file, resuming from there...\` prove the read path works without production runs.
-
-<!-- lore:019daf66-5dc3-7a5c-b169-be468d2ff29c -->
-
-- **Use release-bot token for cross-repo API calls in getsentry org workflows**: The \`sentry-internal-app\` is NOT installed on all getsentry repos (e.g. \`sentry-xbox\`, \`sentry-playstation\`, \`sentry-switch\`, \`service-registry\`). Using its token for cross-repo API calls like \`gh api repos/{other-repo}/commits/...\` returns 404 "Not Found" — looks like a missing resource but is actually a missing installation. Use \`sentry-release-bot\` instead: configure with \`client-id: ${{ vars.SENTRY\_RELEASE\_BOT\_CLIENT\_ID }}\`, \`private-key: ${{ secrets.SENTRY\_RELEASE\_BOT\_PRIVATE\_KEY }}\`, and \`owner: getsentry\` to get a token with access to all org repos. Pattern in getsentry/publish CI poller: generate both tokens, use internal-app for publish-repo label changes, release-bot for cross-repo \`repos/{repo}/commits/{sha}/status\` and \`/check-runs\` API calls.
+- **getsentry/craft: form-data has two transitive copies requiring separate overrides**: Two copies of \`form-data\` in root \`pnpm-lock.yaml\` via different chains: (1) \`form-data@4.0.4\` (High, GHSA-hmw2-7cc7-3qxx, Alert #178): \`@types/node-fetch@2.6.13\` (package.json:30) → \`form-data@4.0.4\` (lockfile lines 5359/4714). Fix: \`"form-data@>=4": "^4.0.6"\` in pnpm.overrides. (2) \`form-data@2.5.5\` (High, Alert #179): \`@google-cloud/storage@7.18.0\` (package.json:16) → \`retry-request@7.0.2\` (line 5861) → \`@types/request@2.48.13\` (line 5863) → \`form-data@2.5.5\` (line 5350). Fix: \`"form-data@<3": "^2.5.6"\` in pnpm.overrides. Both overrides needed; one alone leaves the other copy vulnerable. form-data@4.0.6 and @2.5.6 confirmed on npm.
 
 ### Preference
 
-<!-- lore:019e4b53-6c40-7c67-a656-f489077b34b2 -->
+<!-- lore:019ef3dc-4266-7415-abb1-3dd7af028186 -->
 
-- **Always explore codebase deeply before planning implementation**: When approaching a problem in the codebase, the user consistently requests thorough exploration first — reading full source files, searching for references, and answering specific diagnostic questions (e.g., when/where state is persisted, what rollback logic exists, how errors propagate) — before any implementation plan is created. The user wants the assistant to understand the existing code deeply and answer targeted questions about behavior, not jump straight to solutions. This applies especially to multi-file flows involving state management, error handling, and retry/rollback logic.
+- **Always gather deep dependency chain context before proposing fixes**: When investigating vulnerabilities or dependency issues, Burak Yigit Kaya systematically traces the full transitive dependency chain — identifying lockfile line numbers for each package, which packages pull them in, and which version ranges are affected — before proposing any fix. He reads raw lockfile lines, cross-references multiple lockfiles (e.g., root vs. docs/), and documents every intermediate dependency. When proposing fixes, he expects solutions that account for the complete chain (e.g., pnpm overrides targeting the correct ancestor). Do not suggest fixes without first confirming the full dependency path and all affected copies of a package. Applied in getsentry/craft Dependabot analysis: traced form-data through @google-cloud/storage → retry-request → @types/request → form-data@2.5.5.
 
-<!-- lore:019e5174-03a9-7db3-8b1e-cd8abeb7086e -->
+<!-- lore:019ef3e1-e4c1-78ac-bd12-055563b614a5 -->
 
-- **Always fix Dependabot security alerts by adding/bumping pnpm overrides rather than direct dependency changes**: When addressing Dependabot vulnerability alerts, the user consistently resolves them by adding or bumping entries in the \`pnpm.overrides\` section of \`package.json\` (root or docs/), then regenerating the lockfile. The user investigates the full dependency chain to find the vulnerable transitive package, identifies the patched version, and applies the override at the appropriate level (root vs docs sub-project). The user expects a written plan before execution, approves it, then verifies with a build and test run. Direct changes to the vulnerable package's parent dependency are avoided in favor of pnpm overrides.
-
-<!-- lore:019e51ae-cc65-7576-9e9b-6bba6aa927f9 -->
-
-- **Always fix Dependabot/security alerts via pnpm overrides and verify with lockfile regeneration**: When addressing Dependabot or GitHub security alerts, the user consistently follows this workflow: (1) investigate the vulnerable transitive dependency chain, (2) write a plan file to \`.opencode/plans/\`, (3) add or bump a \`pnpm.overrides\` entry in the relevant \`package.json\` (root or \`docs/\`), (4) regenerate the lockfile via \`pnpm install\`, (5) verify the fix with \`pnpm why \<package>\`, and (6) run tests and build to confirm no regressions. Pre-existing test failures (e.g., \`prepare-dry-run.e2e.test.ts\`) are noted but not treated as blockers. The user approves the plan before execution begins.
-
-<!-- lore:019e5172-079a-7177-a937-8babc45d43dd -->
-
-- **Always fix open Dependabot/security alerts by bumping overrides and regenerating lockfiles**: When the user asks to fix GitHub security reports, they expect: (1) query open Dependabot alerts via \`gh api\`, (2) write a plan file to \`.opencode/plans/\` summarizing the required version bumps, (3) await approval before executing, (4) apply fixes by bumping \`pnpm.overrides\` in the appropriate \`package.json\` (root or \`docs/\`), (5) regenerate the affected \`pnpm-lock.yaml\`, and (6) verify with a build/test run. Fixes are scoped to the minimal affected lockfile (root vs docs). All alerts must be resolved; fixed alerts are skipped. The pattern applies to both root and \`docs/\` sub-project vulnerabilities.
-
-<!-- lore:019e5074-679e-7867-859a-a72ef73be24c -->
-
-- **Always maintain a prioritized task list across sessions and resume from it at session start**: The user consistently tracks work as an explicit numbered task list with priority levels (HIGH/MEDIUM) and statuses (pending/in_progress/completed). At the start of each session, the active task list is loaded and the highest-priority in-progress or pending item is picked up immediately. Tasks are marked completed as they finish, and the list is updated in real time as work progresses. The assistant should always acknowledge the current task list state at session start, work through items in priority order, and keep statuses current throughout the session.
-
-<!-- lore:019e507a-5b07-793c-921f-9e99a31b2059 -->
-
-- **Always raise timing thresholds generously to account for CI overhead**: When test timing assertions fail or are too tight, the user consistently raises thresholds generously rather than minimally. They account for CI process spawn overhead (~200ms), use relative scaling (e.g., \`baseline \* 1.5 + 1000\`) instead of fixed deltas, raise absolute caps significantly (e.g., 1500ms → 2000ms, 225ms → 500ms), and rename tests to reflect the new threshold. The pattern applies to any timing-sensitive test assertion. Always prefer generous buffers that scale with the baseline measurement rather than tight fixed values.
-
-<!-- lore:019e504b-3379-7ab3-9569-33af7ee2ebf8 -->
-
-- **Always request thorough self-review before merging a PR**: After completing implementation work and pushing commits, the user consistently asks for a thorough self-review of both the code changes and the PR description before merging. This applies even after CI passes. The user values objectivity and notes that subagent/independent review may yield better results than the same agent that wrote the code. When performing this review, check: correctness of logic, edge cases, code style/formatting (including Prettier compliance), test coverage, PR description accuracy, and any pre-existing issues that should be called out but not conflated with the current changes. Also verify that test mocks are realistic — unrealistic mocks (e.g. mocking \`getReleaseByTag\` to return a draft) can mask real bugs.
-
-<!-- lore:019e513e-9526-7507-ae06-ed73ea3bf22a -->
-
-- **Always squash-merge PRs when force merge fails due to repository restrictions**: When attempting to force-merge or use admin merge flags and GitHub rejects the operation (e.g., 'merge commits not allowed'), the user falls back to squash-merge as the standard merge strategy. This applies consistently on the getsentry/craft repository. When merging PRs, default to squash-merge (\`--squash\`) rather than attempting regular merge commits or force merges. Do not attempt \`--auto\` combined with \`--admin\`; use \`--admin\` alone or squash-merge directly. The user expects the merge to complete successfully without manual intervention after CI passes.
-
-<!-- lore:019e5065-4c66-7099-9ae9-29784969470c -->
-
-- **Always verify test counts and assertions match actual implementation reality**: When reviewing PRs or completed work, the user carefully cross-checks claimed test counts against actual \`it()\`/\`test()\` blocks in the code, and verifies that test mocks reflect realistic API behavior. The user flags discrepancies (e.g., '14 new tests' vs actual 10) and identifies tests with unrealistic mocks that mask real bugs (e.g., mocking \`getReleaseByTag\` to return a draft when the GitHub API returns 404 for drafts). When reviewing, always count actual test blocks, verify mock setups reflect documented API behavior, and flag any test that passes due to an unrealistic mock rather than correct implementation logic.
-
-<!-- lore:019e4b4b-a3dc-7709-b74f-6ce4a4a3e546 -->
-
-- **Always write a plan file before executing multi-step changes**: Before implementing any non-trivial set of changes, the user expects a detailed plan to be written (to \`.opencode/plans/\<id>.md\`) and presented for review. The user then explicitly approves the plan before execution begins. This applies to both security/dependency fixes and feature/resilience work. The plan should include: what files change, what specific lines/methods are affected, why each change is needed, and a summary table of line counts. Do not start implementing until the user says to proceed.
-
-<!-- lore:019e5045-40ae-798b-bf3f-bc4da414568e -->
-
-- **Always write plans to \`.opencode/plans/\` before executing multi-step tasks**: When tackling multi-step implementation tasks, the user expects a written plan saved to \`.opencode/plans/\` before execution begins. Plans should include: task breakdown with status tracking, specific file paths and line numbers, implementation details (constants, method signatures, patterns to follow), and rationale for design decisions. The user reviews and approves the plan before work starts. During execution, task statuses are updated (pending → in_progress → completed) and snapshots are taken. This applies to any non-trivial change involving multiple files or coordinated edits.
-
-<!-- lore:019db09e-acb5-733a-9527-b80fe9f32b0d -->
-
-- **CHANGELOG.md is auto-managed — do not edit manually**: Craft's CHANGELOG.md is auto-generated from PR descriptions by the release pipeline. Do NOT add entries manually, even for breaking changes. The user will reject such edits. Describe breaking changes in the PR body instead; the auto-managed process surfaces them in the changelog.
+- **Always verify npm package existence before recommending version bumps**: When analyzing dependency vulnerabilities and recommending fixes, the user consistently confirms that the target patched version actually exists on npm before finalizing the recommendation. This applies to both direct dependency bumps (e.g., tar@7.5.16) and override targets (e.g., form-data@4.0.6, form-data@2.5.6). Always check npm registry availability for the exact recommended version as part of the fix analysis, and explicitly note the confirmation (e.g., 'Confirmed X@Y.Z exists on npm') alongside the fix action.
 
 <!-- lore:019db190-ac29-7350-ba2f-a4471600c753 -->
 
 - **Do not commit lore-daemon AGENTS.md churn in feature PRs**: AGENTS.md is managed by the opencode-lore daemon and frequently shows unrelated diffs (new entries, reorderings, deletions) from background reconciliation. These MUST NOT ship in feature/fix PRs. Before committing, \`git restore AGENTS.md\` to drop unrelated lore churn and let the daemon reconcile separately. If a new lore entry is genuinely written for the current PR, keep only that single entry and drop the rest. See \[\[019c9ee7-f55f-7697-b9b4-e7b9c93e9858]] for related lore-tool issues.
-
-<!-- lore:019db141-6874-76d9-9f8e-c5c6152e25e0 -->
-
-- **Pin only third-party GitHub Actions — skip GitHub/Sentry owned**: User scope for \`uses:\` SHA-pinning in \`.github/workflows/\*.yml\`: pin ONLY non-GitHub, non-Sentry actions. Skip \`actions/\*\` (GitHub-owned), \`getsentry/\*\` (Sentry-owned), local \`./\` and local reusable workflows. As of PR #801, pinned third-parties are \`pnpm/action-setup\` and \`rossjrw/pr-preview-action\`. Include a \`# vX.Y.Z\` trailing comment next to each SHA for reviewer readability. Resolve SHAs via \`git ls-remote\` + \`^{}\` deref for annotated tags.

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.3",
-    "astro": "^6.1.10",
+    "astro": "^6.4.8",
     "sharp": "^0.33.5"
   },
   "pnpm": {
@@ -19,7 +19,8 @@
       "rollup": "^4.59.0",
       "svgo": "^4.0.1",
       "smol-toml": "^1.6.1",
-      "defu": "^6.1.5"
+      "defu": "^6.1.5",
+      "vite": "^7.3.5"
     }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   svgo: ^4.0.1
   smol-toml: ^1.6.1
   defu: ^6.1.5
+  vite: ^7.3.5
 
 importers:
 
@@ -18,10 +19,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.38.3
-        version: 0.38.3(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.2))
+        version: 0.38.3(astro@6.4.8(@types/node@25.0.3)(rollup@4.62.2))
       astro:
-        specifier: ^6.1.10
-        version: 6.3.3(@types/node@25.0.3)(rollup@4.60.2)
+        specifier: ^6.4.8
+        version: 6.4.8(@types/node@25.0.3)(rollup@4.62.2)
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
@@ -31,14 +32,14 @@ packages:
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
 
+  '@astrojs/internal-helpers@0.10.0':
+    resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
+
   '@astrojs/internal-helpers@0.8.0':
     resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
 
   '@astrojs/internal-helpers@0.9.0':
     resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
-
-  '@astrojs/internal-helpers@0.9.1':
-    resolution: {integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==}
 
   '@astrojs/markdown-remark@7.1.0':
     resolution: {integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==}
@@ -46,8 +47,8 @@ packages:
   '@astrojs/markdown-remark@7.1.1':
     resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
 
-  '@astrojs/markdown-remark@7.1.2':
-    resolution: {integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==}
+  '@astrojs/markdown-remark@7.2.0':
+    resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
   '@astrojs/mdx@5.0.4':
     resolution: {integrity: sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==}
@@ -577,128 +578,128 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
-    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.2':
-    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
-    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.2':
-    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
-    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
-    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
-    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
-    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
-    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
-    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
-    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
-    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
-    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
-    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
-    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
-    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
-    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
-    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
-    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
-    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
-    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
-    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
-    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
 
@@ -760,6 +761,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -795,6 +799,9 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@ungap/structured-clone@1.3.2':
+    resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -832,8 +839,8 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@6.3.3:
-    resolution: {integrity: sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g==}
+  astro@6.4.8:
+    resolution: {integrity: sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -1435,6 +1442,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -1526,12 +1538,19 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -1621,8 +1640,8 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
-  rollup@4.60.2:
-    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1844,8 +1863,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1887,7 +1906,7 @@ packages:
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       vite:
         optional: true
@@ -1920,15 +1939,22 @@ snapshots:
 
   '@astrojs/compiler@4.0.0': {}
 
+  '@astrojs/internal-helpers@0.10.0':
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.1.1
+      picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
+      smol-toml: 1.6.1
+      unified: 11.0.5
+
   '@astrojs/internal-helpers@0.8.0':
     dependencies:
       picomatch: 4.0.4
 
   '@astrojs/internal-helpers@0.9.0':
-    dependencies:
-      picomatch: 4.0.4
-
-  '@astrojs/internal-helpers@0.9.1':
     dependencies:
       picomatch: 4.0.4
 
@@ -1984,14 +2010,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/markdown-remark@7.1.2':
+  '@astrojs/markdown-remark@7.2.0':
     dependencies:
-      '@astrojs/internal-helpers': 0.9.1
+      '@astrojs/internal-helpers': 0.10.0
       '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -1999,9 +2024,6 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.0.2
-      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -2010,12 +2032,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.4(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.2))':
+  '@astrojs/mdx@5.0.4(astro@6.4.8(@types/node@25.0.3)(rollup@4.62.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.3.3(@types/node@25.0.3)(rollup@4.60.2)
+      astro: 6.4.8(@types/node@25.0.3)(rollup@4.62.2)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2043,17 +2065,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.3(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.2))':
+  '@astrojs/starlight@0.38.3(astro@6.4.8(@types/node@25.0.3)(rollup@4.62.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.4(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.2))
+      '@astrojs/mdx': 5.0.4(astro@6.4.8(@types/node@25.0.3)(rollup@4.62.2))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.3.3(@types/node@25.0.3)(rollup@4.60.2)
-      astro-expressive-code: 0.41.6(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.2))
+      astro: 6.4.8(@types/node@25.0.3)(rollup@4.62.2)
+      astro-expressive-code: 0.41.6(astro@6.4.8(@types/node@25.0.3)(rollup@4.62.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -2457,87 +2479,87 @@ snapshots:
   '@pagefind/windows-x64@1.4.0':
     optional: true
 
-  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
+  '@rollup/pluginutils@5.3.0(rollup@4.62.2)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.60.2
+      rollup: 4.62.2
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.2':
+  '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
+  '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.2':
+  '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
+  '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
+  '@rollup/rollup-linux-x64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
+  '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
+  '@rollup/rollup-openharmony-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
   '@shikijs/core@3.23.0':
@@ -2621,6 +2643,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -2657,6 +2681,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@ungap/structured-clone@1.3.2': {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2678,21 +2704,21 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.6(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.2)):
+  astro-expressive-code@0.41.6(astro@6.4.8(@types/node@25.0.3)(rollup@4.62.2)):
     dependencies:
-      astro: 6.3.3(@types/node@25.0.3)(rollup@4.60.2)
+      astro: 6.4.8(@types/node@25.0.3)(rollup@4.62.2)
       rehype-expressive-code: 0.41.6
 
-  astro@6.3.3(@types/node@25.0.3)(rollup@4.60.2):
+  astro@6.4.8(@types/node@25.0.3)(rollup@4.62.2):
     dependencies:
       '@astrojs/compiler': 4.0.0
-      '@astrojs/internal-helpers': 0.9.1
-      '@astrojs/markdown-remark': 7.1.2
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-remark': 7.2.0
       '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.2.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
       aria-query: 5.3.2
       axobject-query: 4.1.0
       ci-info: 4.4.0
@@ -2735,8 +2761,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@25.0.3)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@25.0.3))
+      vite: 7.3.5(@types/node@25.0.3)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@25.0.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -3127,7 +3153,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.2
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -3217,7 +3243,7 @@ snapshots:
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -3781,6 +3807,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.15: {}
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
@@ -3884,9 +3912,17 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
+
+  property-information@7.2.0: {}
 
   radix3@1.1.2: {}
 
@@ -4057,35 +4093,35 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  rollup@4.60.2:
+  rollup@4.62.2:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.2
-      '@rollup/rollup-android-arm64': 4.60.2
-      '@rollup/rollup-darwin-arm64': 4.60.2
-      '@rollup/rollup-darwin-x64': 4.60.2
-      '@rollup/rollup-freebsd-arm64': 4.60.2
-      '@rollup/rollup-freebsd-x64': 4.60.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
-      '@rollup/rollup-linux-arm64-gnu': 4.60.2
-      '@rollup/rollup-linux-arm64-musl': 4.60.2
-      '@rollup/rollup-linux-loong64-gnu': 4.60.2
-      '@rollup/rollup-linux-loong64-musl': 4.60.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
-      '@rollup/rollup-linux-ppc64-musl': 4.60.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
-      '@rollup/rollup-linux-riscv64-musl': 4.60.2
-      '@rollup/rollup-linux-s390x-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-musl': 4.60.2
-      '@rollup/rollup-openbsd-x64': 4.60.2
-      '@rollup/rollup-openharmony-arm64': 4.60.2
-      '@rollup/rollup-win32-arm64-msvc': 4.60.2
-      '@rollup/rollup-win32-ia32-msvc': 4.60.2
-      '@rollup/rollup-win32-x64-gnu': 4.60.2
-      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
   sax@1.6.0: {}
@@ -4336,21 +4372,21 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.2(@types/node@25.0.3):
+  vite@7.3.5(@types/node@25.0.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.2
+      postcss: 8.5.15
+      rollup: 4.62.2
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.0.3
       fsevents: 2.3.3
 
-  vitefu@1.1.3(vite@7.3.2(@types/node@25.0.3)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@25.0.3)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.0.3)
+      vite: 7.3.5(@types/node@25.0.3)
 
   web-namespaces@2.0.1: {}
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-formatter-github-annotations": "^0.1.0",
-    "node-stream-zip": "^1.15.0",
     "fast-xml-parser": "^5.8.0",
     "git-url-parse": "^16.1.0",
     "glob": "^11.0.0",
@@ -54,6 +53,7 @@
     "mustache": "3.0.1",
     "nock": "^13.2.4",
     "node-fetch": "^2.6.1",
+    "node-stream-zip": "^1.15.0",
     "ora": "5.4.0",
     "prettier": "^3.4.2",
     "prompts": "2.4.1",
@@ -62,11 +62,12 @@
     "source-map-support": "^0.5.20",
     "split": "1.0.1",
     "string-length": "3.1.0",
-    "tar": "7.5.11",
+    "tar": "7.5.16",
     "tmp": "^0.2.6",
     "tslib": "^2.8.1",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2",
+    "vite": "^7.3.5",
     "vitest": "^4.1.0",
     "yargs": "^18",
     "zod": "^3.24.1"
@@ -109,7 +110,10 @@
       "flatted": "^3.4.2",
       "picomatch@<3": "^2.3.2",
       "uuid": "^14.0.0",
-      "@tootallnate/once": "^2.0.1"
+      "@tootallnate/once": "^2.0.1",
+      "form-data@>=4": "^4.0.6",
+      "form-data@<3": "^2.5.6",
+      "vite": "^7.3.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ overrides:
   picomatch@<3: ^2.3.2
   uuid: ^14.0.0
   '@tootallnate/once': ^2.0.1
+  form-data@>=4: ^4.0.6
+  form-data@<3: ^2.5.6
+  vite: ^7.3.5
 
 importers:
 
@@ -189,8 +192,8 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       tar:
-        specifier: 7.5.11
-        version: 7.5.11
+        specifier: 7.5.16
+        version: 7.5.16
       tmp:
         specifier: ^0.2.6
         version: 0.2.7
@@ -203,9 +206,12 @@ importers:
       typescript-eslint:
         specifier: ^8.18.2
         version: 8.50.1(eslint@9.39.2)(typescript@5.9.3)
+      vite:
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@22.19.1)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0))
       yargs:
         specifier: ^18
         version: 18.0.0
@@ -1119,79 +1125,66 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -1688,7 +1681,7 @@ packages:
     resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2133,12 +2126,12 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@2.5.5:
-    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+  form-data@2.5.6:
+    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
     engines: {node: '>= 0.12'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded-parse@2.1.2:
@@ -2243,8 +2236,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   html-entities@2.6.0:
@@ -2792,8 +2785,8 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  tar@7.5.11:
-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   teeny-request@9.0.0:
@@ -2888,8 +2881,8 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2944,7 +2937,7 @@ packages:
       '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -4733,7 +4726,7 @@ snapshots:
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 22.19.1
-      form-data: 4.0.4
+      form-data: 4.0.6
 
   '@types/node@22.19.1':
     dependencies:
@@ -4767,7 +4760,7 @@ snapshots:
       '@types/caseless': 0.12.5
       '@types/node': 22.19.1
       '@types/tough-cookie': 4.0.5
-      form-data: 2.5.5
+      form-data: 2.5.6
 
   '@types/semver@7.7.1': {}
 
@@ -4892,13 +4885,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@22.19.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5171,7 +5164,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -5369,21 +5362,21 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@2.5.5:
+  form-data@2.5.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
       safe-buffer: 5.2.1
 
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   forwarded-parse@2.1.2: {}
@@ -5431,7 +5424,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -5511,7 +5504,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -6026,7 +6019,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tar@7.5.11:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -6127,7 +6120,7 @@ snapshots:
 
   uuid@14.0.0: {}
 
-  vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0):
+  vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6140,10 +6133,10 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -6160,7 +6153,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@22.19.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@22.19.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary

Resolves **10 open Dependabot alerts** across 5 CVEs and dismisses 2 low-severity esbuild alerts as tolerable risk.

### Alerts Fixed

| Alert(s) | Package | Severity | CVE | Fix |
|----------|---------|----------|-----|-----|
| #180, #181 | `tar` | Medium | GHSA-vmf3-w455-68vh | Bump direct pin `7.5.11` -> `7.5.16` |
| #178, #179 | `form-data` | High | GHSA-hmw2-7cc7-3qxx | `pnpm.overrides` for `4.0.6` (v4) and `2.5.6` (v2) |
| #172, #176 | `vite` (root) | High + Medium | GHSA-fx2h-pf6j-xcff, GHSA-v6wh-96g9-6wx3 | Add as direct devDep `^7.3.5` + override |
| #173, #177 | `vite` (docs) | High + Medium | same | `pnpm.overrides` in docs |
| #174, #175 | `astro` | High + Medium | GHSA-2pvr-wf23-7pc7, GHSA-jrpj-wcv7-9fh9 | `pnpm update` -> `6.4.8` |

### Alerts Dismissed (tolerable_risk)

| Alert(s) | Package | Severity | Reason |
|----------|---------|----------|--------|
| #167, #168 | `esbuild` | Low | GHSA-g7r4-m6w7-qqqr - Windows dev-server only vulnerability. Craft is a CLI tool, docs is a static site. Transitive dep of `vite@7.3.5` which pins `esbuild@^0.27.0` - cannot fix without vite 8 major bump. |

## Changes

### Root project (`package.json`)
- `tar`: `7.5.11` -> `7.5.16` (direct pin bump)
- `vite`: added as devDependency at `^7.3.5` (was only transitive via vitest)
- `pnpm.overrides`: added `form-data@>=4: ^4.0.6`, `form-data@<3: ^2.5.6`, `vite: ^7.3.5`

### Docs project (`docs/package.json`)
- `astro`: resolved `5.16.11` -> `6.4.8` (specifier `^6.1.10` allowed it)
- `@astrojs/starlight`: resolved `0.37.3` -> `0.38.3`
- `pnpm.overrides`: added `vite: ^7.3.5`

## Verification

- `pnpm build` - passed
- `pnpm test` - 1025 passed, 1 skipped
- `pnpm lint` - 0 errors
- `pnpm docs:build` - 27 pages built successfully