### PR TITLE
fix: pin Node to 22.23.1 to avoid node-fetch premature-close regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS builder
+FROM node:22.23.1-bookworm-slim AS builder
 
 WORKDIR /usr/local/lib
 
@@ -17,7 +17,7 @@ RUN \
   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/lib/node_modules/.bin" \
   pnpm build
 
-FROM node:22-bookworm
+FROM node:22.23.1-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
   DOTNET_CLI_TELEMETRY_OPTOUT=1 \

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "docs:build": "cd docs && pnpm build"
   },
   "volta": {
-    "node": "22.12.0",
+    "node": "22.23.1",
     "pnpm": "10.27.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

GCS publishing started failing (e.g. [sentry-native 0.15.2 publish run](https://github.com/getsentry/publish/actions/runs/28084819405/job/83148110750)) with:

```
Invalid response body while trying to fetch https://www.googleapis.com/oauth2/v4/token: Premature close
code: ERR_STREAM_PREMATURE_CLOSE
```

The failing request reported **`x-goog-api-client: gl-node/22.23.0`**.

## Root cause

- **Node 22.23.0** (2026-06-17) shipped the security fix for **CVE-2026-48931** ("response queue poisoning in `http.Agent`"), which attaches a public `'data'` listener to idle keep-alive Agent sockets.
- **node-fetch@2** inspects `socket.listenerCount('data') > 0` while closing a response and throws a false-positive `ERR_STREAM_PREMATURE_CLOSE` on reused pooled sockets — see [nodejs/node#63989](https://github.com/nodejs/node/issues/63989).
- craft reaches this path via `@google-cloud/storage` → `google-auth-library` → `gaxios@6` → `node-fetch@2` during the GCS OAuth token fetch.
- The `Dockerfile` used the **floating** `node:22-bookworm` base images, which silently advanced to the bad 22.23.0 — so this broke with **no change to craft's code or deps**.

## Fix

Pin the Dockerfile base images and the Volta `node` to **22.23.1** (2026-06-22), the patched release that backports [nodejs/node#64004](https://github.com/nodejs/node/pull/64004). Pinning the exact version also closes the unguarded base-image float that caused the incident (there is no Dependabot/Renovate for Docker in this repo).

## Why tests didn't catch it

Environmental regression, not a code defect: introduced by the base-image float, and the test suite mocks all network I/O with `nock`, so the real node-fetch@2 keep-alive path never executes in CI.

## Follow-ups (not in this PR)

- Consider adding a Dependabot `docker` ecosystem entry so the now-pinned base image gets automated bump PRs.