### PR TITLE
build: upgrade to Node 24.18.0 (LTS Krypton)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.23.1-bookworm-slim AS builder
+FROM node:24.18.0-bookworm-slim AS builder
 
 WORKDIR /usr/local/lib
 
@@ -17,7 +17,7 @@ RUN \
   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/lib/node_modules/.bin" \
   pnpm build
 
-FROM node:22.23.1-bookworm
+FROM node:24.18.0-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
   DOTNET_CLI_TELEMETRY_OPTOUT=1 \

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/is-ci": "^2.0.0",
     "@types/js-yaml": "^4.0.5",
     "@types/mkdirp": "^1.0.0",
-    "@types/node": "^22.10.1",
+    "@types/node": "^24.0.0",
     "@types/node-fetch": "^2.5.10",
     "@types/ora": "^1.3.4",
     "@types/prompts": "^2.0.11",
@@ -90,7 +90,7 @@
     "docs:build": "cd docs && pnpm build"
   },
   "volta": {
-    "node": "22.23.1",
+    "node": "24.18.0",
     "pnpm": "10.27.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.2
       '@types/node':
-        specifier: ^22.10.1
-        version: 22.19.1
+        specifier: ^24.0.0
+        version: 24.13.2
       '@types/node-fetch':
         specifier: ^2.5.10
         version: 2.6.13
@@ -208,10 +208,10 @@ importers:
         version: 8.50.1(eslint@9.39.2)(typescript@5.9.3)
       vite:
         specifier: ^7.3.5
-        version: 7.3.5(@types/node@22.19.1)(tsx@4.21.0)
+        version: 7.3.5(@types/node@24.13.2)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(vite@7.3.5(@types/node@24.13.2)(tsx@4.21.0))
       yargs:
         specifier: ^18
         version: 18.0.0
@@ -1569,8 +1569,8 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
-  '@types/node@22.19.1':
-    resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/ora@1.3.5':
     resolution: {integrity: sha512-CZe3oXbO1XylJT1feg+/aCzNt6tfR4XO+IkLetc85O/yaZRw271cZtS8LL/2mknd+PoR5IKAjFLzo4KWZXxung==}
@@ -2856,8 +2856,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -4676,7 +4676,7 @@ snapshots:
 
   '@types/aws4@1.11.6':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
 
   '@types/caseless@0.12.5': {}
 
@@ -4693,7 +4693,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
 
   '@types/deep-eql@4.0.2': {}
 
@@ -4717,24 +4717,24 @@ snapshots:
 
   '@types/mkdirp@1.0.2':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
       form-data: 4.0.6
 
-  '@types/node@22.19.1':
+  '@types/node@24.13.2':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.18.2
 
   '@types/ora@1.3.5':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
 
   '@types/parse-path@7.1.0':
     dependencies:
@@ -4746,19 +4746,19 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
       kleur: 3.0.3
 
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.6
 
@@ -4769,11 +4769,11 @@ snapshots:
   '@types/tar@4.0.5':
     dependencies:
       '@types/minipass': 3.3.5
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
 
   '@types/tmp@0.0.33': {}
 
@@ -4885,13 +4885,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@24.13.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@22.19.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -6095,7 +6095,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.18.2: {}
 
   universal-user-agent@7.0.3: {}
 
@@ -6120,7 +6120,7 @@ snapshots:
 
   uuid@14.0.0: {}
 
-  vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0):
+  vite@7.3.5(@types/node@24.13.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6129,14 +6129,14 @@ snapshots:
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(vite@7.3.5(@types/node@24.13.2)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@22.19.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.13.2)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -6153,11 +6153,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@22.19.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 22.19.1
+      '@types/node': 24.13.2
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## What

Upgrade craft's Docker base images and Volta toolchain from **Node 22.23.1** to **Node 24.18.0** (current LTS, "Krypton"), and bump `@types/node` to `^24`.

## Why

Our recent hotfix (#837) pinned to **22.23.1** to escape the `ERR_STREAM_PREMATURE_CLOSE` regression that 22.23.0 introduced (the CVE-2026-48931 fix added a public `'data'` listener to idle `http.Agent` sockets, which made `node-fetch@2` report false premature-close errors on GCS auth calls).

**24.18.0 carries the same fix** ([nodejs/node#64004](https://github.com/nodejs/node/pull/64004), backported to both 22.x and 24.x), so it's free of the regression *and* moves us onto the latest LTS major.

## ⚠️ Do not merge yet — blocked on Docker image

The official `node:24.18.0-bookworm` images are **not published yet**. As of opening this PR:

- `node:24.18.0-bookworm` / `-bookworm-slim` → **404** on Docker Hub
- The only Node 24 image currently available is `24.17.0` — the *broken* release
- docker-node PR [nodejs/docker-node#2546](https://github.com/nodejs/docker-node/pull/2546) ("feat: Node.js 24.18.0") is open and will publish the images once merged + built

The `image` CI check will fail until those base images are live. **Hold merge** until `node:24.18.0-bookworm` is pullable, then re-run the image build.

## Verification (local, on Node 24.18.0)

- ✅ `pnpm typecheck`
- ✅ `pnpm build` + binary runs (`craft --version`)
- ✅ `pnpm test` — 1025 passed, 1 skipped (57 files)

Lockfile diff is limited to `@types/node` 22.19.1 → 24.13.2; `lockfileVersion` unchanged.
