### PR TITLE
fix(cloudflare): default to worker, optional account id, infer prod branch

### DIFF
--- a/docs/src/content/docs/targets/cloudflare.md
+++ b/docs/src/content/docs/targets/cloudflare.md
@@ -3,28 +3,42 @@ title: Cloudflare
 description: Deploy static sites or Workers to Cloudflare
 ---
 
-Deploys a release artifact to Cloudflare, either as a [Cloudflare Pages](https://developers.cloudflare.com/pages/) site or as a [Cloudflare Worker](https://developers.cloudflare.com/workers/) with static assets.
+Deploys a release artifact to Cloudflare, either as a [Cloudflare Worker](https://developers.cloudflare.com/workers/) (optionally with static assets) or as a [Cloudflare Pages](https://developers.cloudflare.com/pages/) site.
 
 The target extracts a ZIP artifact and shells out to the [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) CLI to perform the deployment. `wrangler` is bundled in the Craft Docker image.
+
+:::note
+`deployType` defaults to `worker`. Cloudflare is steering new projects to Workers (with static assets) and positioning Pages as legacy, so Workers is the forward-looking default. Pages remains fully supported via `deployType: pages`.
+:::
 
 ## Configuration
 
 | Option | Description |
 |--------|-------------|
-| `deployType` | `pages` (default) or `worker`. |
+| `deployType` | `worker` (default) or `pages`. |
 | `projectName` | Cloudflare Pages project name. **Required** when `deployType` is `pages`. |
-| `productionBranch` | The Pages project's production branch name. Passed to `wrangler pages deploy --branch` so a release always targets the **production** environment. Default: `main`. This is the Cloudflare environment selector, not your git release branch. |
+| `productionBranch` | The Pages project's production branch name. Optional — when omitted, Craft reads it from the Cloudflare API so the release lands on production. See [Production deployments](#production-deployments-pages). Only used for `deployType: pages`. |
 | `wranglerCliPath` | Path to the `wrangler` binary. Default: `wrangler` (or the `WRANGLER_BIN` env var). |
 | `workingDir` | Subdirectory within the extracted artifact to deploy from. For `worker` deploys this is where the `wrangler.toml` lives. |
 
 ## Environment Variables
 
-| Name | Description |
-|------|-------------|
-| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with permission to deploy Pages/Workers. |
-| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID. |
+| Name | Required | Description |
+|------|----------|-------------|
+| `CLOUDFLARE_API_TOKEN` | Yes | Cloudflare API token with permission to deploy (Account → Cloudflare Pages → Edit, or the equivalent Workers permissions). Passed to `wrangler` via the environment, never on the command line. |
+| `CLOUDFLARE_ACCOUNT_ID` | No | Cloudflare account ID. This is an identifier, not a secret. When unset, `wrangler` auto-discovers it for single-account tokens; set it explicitly if your token can access multiple accounts. |
 
-Both are required. They are passed to `wrangler` via the environment, never on the command line.
+:::note
+Cloudflare deployments authenticate with an API token — there is no OIDC/keyless option in `wrangler`, so provide `CLOUDFLARE_API_TOKEN` as a CI secret.
+:::
+
+## Production deployments (Pages)
+
+`wrangler pages deploy --branch <X>` deploys to **production** only when `<X>` exactly matches the project's server-side production branch; any other value silently produces a *preview* deployment (this is not an error). To make releases reliably land on production, Craft resolves the production branch as follows:
+
+1. If `productionBranch` is set in the config, it is used verbatim.
+2. Otherwise, if the account ID is known, Craft reads the project's production branch from the Cloudflare API (`GET /accounts/{id}/pages/projects/{name}`) — the same call `wrangler` makes internally, so it needs no token scope beyond deploying.
+3. If neither is available, Craft omits `--branch`; a bare deploy from Craft's temporary (non-git) directory defaults to production.
 
 ## Default Behavior
 
@@ -36,16 +50,6 @@ By default, this target:
 
 ## Example
 
-Cloudflare Pages (static site):
-
-```yaml
-targets:
-  - name: cloudflare
-    deployType: pages
-    projectName: my-docs-site
-    productionBranch: main
-```
-
 Cloudflare Worker (with a `wrangler.toml` in the artifact):
 
 ```yaml
@@ -55,8 +59,18 @@ targets:
     workingDir: worker
 ```
 
+Cloudflare Pages (static site):
+
+```yaml
+targets:
+  - name: cloudflare
+    deployType: pages
+    projectName: my-docs-site
+    # productionBranch is optional; inferred from the API when omitted.
+```
+
 ## Workflow
 
-1. Create a `cloudflare.zip` artifact in your CI workflow (e.g. the built static site, or your Worker plus `wrangler.toml`).
+1. Create a `cloudflare.zip` artifact in your CI workflow (e.g. your Worker plus `wrangler.toml`, or the built static site for Pages).
 2. Configure the target in `.craft.yml`.
-3. Set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in your environment.
+3. Set `CLOUDFLARE_API_TOKEN` in your environment (and `CLOUDFLARE_ACCOUNT_ID` if your token can access multiple accounts).

--- a/src/targets/__tests__/cloudflare.test.ts
+++ b/src/targets/__tests__/cloudflare.test.ts
@@ -7,6 +7,7 @@ import { isDryRun } from '../../utils/helpers';
 
 const TMP_DIR = '/tmp/craft-cloudflare-test';
 const DEFAULT_SECRET_VALUE = 'secret_value';
+const ACCOUNT_ID = 'acc_1234';
 
 vi.mock('../../utils/helpers');
 
@@ -53,57 +54,76 @@ function createCloudflareTarget(
   );
 }
 
+/** Mocks global.fetch to return a Pages project with the given production branch. */
+function mockFetchProductionBranch(branch: string): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ result: { production_branch: branch } }),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
 beforeEach(() => {
   setTargetSecretsInEnv();
   delete process.env.WRANGLER_BIN;
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
   (isDryRun as any).mockReturnValue(false);
 });
 
 afterEach(() => {
   removeTargetSecretsFromEnv();
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('cloudflare target configuration', () => {
-  test('exports the expected secrets', () => {
+  test('exports the expected secrets (only the API token is a secret)', () => {
     expect(targetSecrets).toContain('CLOUDFLARE_API_TOKEN');
-    expect(targetSecrets).toContain('CLOUDFLARE_ACCOUNT_ID');
+    expect(targetSecrets).not.toContain('CLOUDFLARE_ACCOUNT_ID');
   });
 
-  test('enforces required secrets', () => {
+  test('enforces the required API token secret', () => {
     removeTargetSecretsFromEnv();
 
     expect(() =>
-      createCloudflareTarget({ projectName: 'my-project' }),
+      createCloudflareTarget({ deployType: 'worker' }),
     ).toThrowErrorMatchingInlineSnapshot(
       `[Error: Required value(s) CLOUDFLARE_API_TOKEN not found in configuration files or the environment. See the documentation for more details.]`,
     );
-
-    process.env.CLOUDFLARE_API_TOKEN = DEFAULT_SECRET_VALUE;
-    expect(() =>
-      createCloudflareTarget({ projectName: 'my-project' }),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Required value(s) CLOUDFLARE_ACCOUNT_ID not found in configuration files or the environment. See the documentation for more details.]`,
-    );
   });
 
-  test('applies default options (pages)', () => {
-    const target = createCloudflareTarget({ projectName: 'my-project' });
+  test('does not require CLOUDFLARE_ACCOUNT_ID', () => {
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    expect(() => createCloudflareTarget({ deployType: 'worker' })).not.toThrow();
+  });
+
+  test('applies default options (worker)', () => {
+    const target = createCloudflareTarget({});
 
     expect(target.cloudflareConfig).toStrictEqual({
       CLOUDFLARE_API_TOKEN: DEFAULT_SECRET_VALUE,
-      CLOUDFLARE_ACCOUNT_ID: DEFAULT_SECRET_VALUE,
-      deployType: 'pages',
-      projectName: 'my-project',
-      productionBranch: 'main',
+      deployType: 'worker',
+      projectName: undefined,
+      productionBranch: undefined,
       wranglerCliPath: 'wrangler',
       workingDir: undefined,
+      accountId: undefined,
     });
+  });
+
+  test('picks up CLOUDFLARE_ACCOUNT_ID from env when set', () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const target = createCloudflareTarget({});
+    expect(target.cloudflareConfig.accountId).toBe(ACCOUNT_ID);
   });
 
   test('allows overriding default options', () => {
     const target = createCloudflareTarget({
-      deployType: 'worker',
+      deployType: 'pages',
       projectName: 'my-project',
       productionBranch: 'production',
       wranglerCliPath: '/custom/wrangler',
@@ -112,18 +132,18 @@ describe('cloudflare target configuration', () => {
 
     expect(target.cloudflareConfig).toStrictEqual({
       CLOUDFLARE_API_TOKEN: DEFAULT_SECRET_VALUE,
-      CLOUDFLARE_ACCOUNT_ID: DEFAULT_SECRET_VALUE,
-      deployType: 'worker',
+      deployType: 'pages',
       projectName: 'my-project',
       productionBranch: 'production',
       wranglerCliPath: '/custom/wrangler',
       workingDir: 'subdir',
+      accountId: undefined,
     });
   });
 
   test('resolves wrangler path from WRANGLER_BIN env', () => {
     process.env.WRANGLER_BIN = '/env/wrangler';
-    const target = createCloudflareTarget({ projectName: 'my-project' });
+    const target = createCloudflareTarget({});
     expect(target.cloudflareConfig.wranglerCliPath).toBe('/env/wrangler');
   });
 
@@ -150,19 +170,23 @@ describe('cloudflare target configuration', () => {
   });
 
   test('checks wrangler is present in the constructor', () => {
-    createCloudflareTarget({ projectName: 'my-project' });
+    createCloudflareTarget({});
     expect(system.checkExecutableIsPresent).toHaveBeenCalledWith('wrangler');
   });
 
   test('rejects config values that look like env-var expansions', () => {
     expect(() =>
-      createCloudflareTarget({ projectName: '${CLOUDFLARE_API_TOKEN}' }),
+      createCloudflareTarget({
+        deployType: 'pages',
+        projectName: '${CLOUDFLARE_API_TOKEN}',
+      }),
     ).toThrowErrorMatchingInlineSnapshot(
       `[Error: [cloudflare] "projectName" must not be an environment-variable expansion (got "\${CLOUDFLARE_API_TOKEN}")]`,
     );
 
     expect(() =>
       createCloudflareTarget({
+        deployType: 'pages',
         projectName: 'ok',
         workingDir: '${CLOUDFLARE_ACCOUNT_ID}',
       }),
@@ -182,8 +206,12 @@ describe('publish', () => {
     );
   }
 
-  test('deploys a pages project with production branch and provenance', async () => {
-    const target = createCloudflareTarget({ projectName: 'my-project' });
+  test('deploys a pages project with the configured production branch and provenance', async () => {
+    const target = createCloudflareTarget({
+      deployType: 'pages',
+      projectName: 'my-project',
+      productionBranch: 'main',
+    });
     stubArtifacts(target, [artifact]);
 
     await target.publish(version, revision);
@@ -211,14 +239,62 @@ describe('publish', () => {
       '--commit-dirty',
       'false',
     ]);
-    // Secrets must be in env, not argv
+    // Secret must be in env, not argv
     expect(options.env.CLOUDFLARE_API_TOKEN).toBe(DEFAULT_SECRET_VALUE);
-    expect(options.env.CLOUDFLARE_ACCOUNT_ID).toBe(DEFAULT_SECRET_VALUE);
     expect(args).not.toContain(DEFAULT_SECRET_VALUE);
   });
 
-  test('uses the configured production branch', async () => {
+  test('does not forward CLOUDFLARE_ACCOUNT_ID when unset', async () => {
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    const target = createCloudflareTarget({ deployType: 'worker' });
+    stubArtifacts(target, [artifact]);
+
+    await target.publish(version, revision);
+
+    const [, , options] = (system.spawnProcess as any).mock.calls[0];
+    expect('CLOUDFLARE_ACCOUNT_ID' in options.env).toBe(false);
+  });
+
+  test('forwards CLOUDFLARE_ACCOUNT_ID when set', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const target = createCloudflareTarget({ deployType: 'worker' });
+    stubArtifacts(target, [artifact]);
+
+    await target.publish(version, revision);
+
+    const [, , options] = (system.spawnProcess as any).mock.calls[0];
+    expect(options.env.CLOUDFLARE_ACCOUNT_ID).toBe(ACCOUNT_ID);
+  });
+
+  test('infers the production branch from the API when not configured', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const fetchMock = mockFetchProductionBranch('trunk');
     const target = createCloudflareTarget({
+      deployType: 'pages',
+      projectName: 'my-project',
+    });
+    stubArtifacts(target, [artifact]);
+
+    await target.publish(version, revision);
+
+    // Correct API endpoint + auth header
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/pages/projects/my-project`,
+    );
+    expect(init.headers.Authorization).toBe(`Bearer ${DEFAULT_SECRET_VALUE}`);
+
+    const [, args] = (system.spawnProcess as any).mock.calls[0];
+    expect(args[args.indexOf('--branch') + 1]).toBe('trunk');
+  });
+
+  test('does not call the API when productionBranch is configured', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const target = createCloudflareTarget({
+      deployType: 'pages',
       projectName: 'my-project',
       productionBranch: 'release',
     });
@@ -226,9 +302,87 @@ describe('publish', () => {
 
     await target.publish(version, revision);
 
+    expect(fetchMock).not.toHaveBeenCalled();
     const [, args] = (system.spawnProcess as any).mock.calls[0];
-    expect(args).toContain('--branch');
     expect(args[args.indexOf('--branch') + 1]).toBe('release');
+  });
+
+  test('omits --branch when the branch cannot be resolved (no account id)', async () => {
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const target = createCloudflareTarget({
+      deployType: 'pages',
+      projectName: 'my-project',
+    });
+    stubArtifacts(target, [artifact]);
+
+    await target.publish(version, revision);
+
+    // No account id → cannot address the API → no fetch, no --branch
+    expect(fetchMock).not.toHaveBeenCalled();
+    const [, args] = (system.spawnProcess as any).mock.calls[0];
+    expect(args).not.toContain('--branch');
+  });
+
+  test('omits --branch when the API call fails', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    const target = createCloudflareTarget({
+      deployType: 'pages',
+      projectName: 'my-project',
+    });
+    stubArtifacts(target, [artifact]);
+
+    await target.publish(version, revision);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, args] = (system.spawnProcess as any).mock.calls[0];
+    expect(args).not.toContain('--branch');
+  });
+
+  test('hard-fails when the Pages project is not found (404)', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    const target = createCloudflareTarget({
+      deployType: 'pages',
+      projectName: 'missing-project',
+    });
+    stubArtifacts(target, [artifact]);
+
+    await expect(target.publish(version, revision)).rejects.toThrow(
+      /Pages project "missing-project" not found/,
+    );
+    expect(system.spawnProcess).not.toHaveBeenCalled();
+  });
+
+  test('ignores an API-sourced branch that looks like an env expansion', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    mockFetchProductionBranch('${CLOUDFLARE_API_TOKEN}');
+    const target = createCloudflareTarget({
+      deployType: 'pages',
+      projectName: 'my-project',
+    });
+    stubArtifacts(target, [artifact]);
+
+    await target.publish(version, revision);
+
+    const [, args] = (system.spawnProcess as any).mock.calls[0];
+    // The suspicious value must never reach argv.
+    expect(args).not.toContain('--branch');
+    expect(args).not.toContain('${CLOUDFLARE_API_TOKEN}');
   });
 
   test('deploys a worker using the local wrangler.toml', async () => {
@@ -244,9 +398,23 @@ describe('publish', () => {
     expect(options.env.CLOUDFLARE_API_TOKEN).toBe(DEFAULT_SECRET_VALUE);
   });
 
+  test('worker deploy never calls the Pages API', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const target = createCloudflareTarget({ deployType: 'worker' });
+    stubArtifacts(target, [artifact]);
+
+    await target.publish(version, revision);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test('deploys from workingDir subdirectory when configured', async () => {
     const target = createCloudflareTarget({
+      deployType: 'pages',
       projectName: 'my-project',
+      productionBranch: 'main',
       workingDir: 'dist',
     });
     stubArtifacts(target, [artifact]);
@@ -260,7 +428,7 @@ describe('publish', () => {
   });
 
   test('reports an error and does not deploy when no artifacts found', async () => {
-    const target = createCloudflareTarget({ projectName: 'my-project' });
+    const target = createCloudflareTarget({ deployType: 'worker' });
     stubArtifacts(target, []);
 
     await expect(target.publish(version, revision)).rejects.toThrow(
@@ -270,7 +438,7 @@ describe('publish', () => {
   });
 
   test('reports an error when more than one artifact found', async () => {
-    const target = createCloudflareTarget({ projectName: 'my-project' });
+    const target = createCloudflareTarget({ deployType: 'worker' });
     stubArtifacts(target, [artifact, artifact]);
 
     await expect(target.publish(version, revision)).rejects.toThrow(
@@ -279,15 +447,23 @@ describe('publish', () => {
     expect(system.spawnProcess).not.toHaveBeenCalled();
   });
 
-  test('does not deploy in dry-run mode (including worktree mode)', async () => {
+  test('does not deploy or hit the API in dry-run mode (including worktree mode)', async () => {
     (isDryRun as any).mockReturnValue(true);
-    const target = createCloudflareTarget({ projectName: 'my-project' });
+    process.env.CLOUDFLARE_ACCOUNT_ID = ACCOUNT_ID;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const target = createCloudflareTarget({
+      deployType: 'pages',
+      projectName: 'my-project',
+    });
     stubArtifacts(target, [artifact]);
 
     await target.publish(version, revision);
 
-    // Artifact is still extracted (local, safe), but the remote deploy is skipped
+    // Artifact is still extracted (local, safe), but the remote deploy AND the
+    // production-branch API call are both skipped.
     expect(system.extractZipArchiveWithFlattening).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(system.spawnProcess).not.toHaveBeenCalled();
   });
 });

--- a/src/targets/__tests__/cloudflare.test.ts
+++ b/src/targets/__tests__/cloudflare.test.ts
@@ -98,7 +98,9 @@ describe('cloudflare target configuration', () => {
 
   test('does not require CLOUDFLARE_ACCOUNT_ID', () => {
     delete process.env.CLOUDFLARE_ACCOUNT_ID;
-    expect(() => createCloudflareTarget({ deployType: 'worker' })).not.toThrow();
+    expect(() =>
+      createCloudflareTarget({ deployType: 'worker' }),
+    ).not.toThrow();
   });
 
   test('applies default options (worker)', () => {

--- a/src/targets/cloudflare.ts
+++ b/src/targets/cloudflare.ts
@@ -22,14 +22,34 @@ import { BaseArtifactProvider } from '../artifact_providers/base';
 /**
  * Secrets required to authenticate with the Cloudflare API.
  *
+ * Only the API token is a true secret. The account ID is an identifier, not a
+ * credential, and is handled separately (see `CLOUDFLARE_ACCOUNT_ID` below):
+ * it is optional and, when set, forwarded to wrangler; otherwise wrangler
+ * auto-discovers it for single-account tokens.
+ *
  * Exported so tests (and documentation tooling) can reference the canonical
  * list of environment variables this target consumes.
  */
-export const targetSecrets = [
-  'CLOUDFLARE_API_TOKEN',
-  'CLOUDFLARE_ACCOUNT_ID',
-] as const;
+export const targetSecrets = ['CLOUDFLARE_API_TOKEN'] as const;
 type SecretsType = (typeof targetSecrets)[number];
+
+/**
+ * Optional, non-secret account identifier forwarded to wrangler when present.
+ * When unset, wrangler auto-discovers the account for single-account tokens.
+ */
+const ACCOUNT_ID_ENV_VAR = 'CLOUDFLARE_ACCOUNT_ID';
+
+/** Base URL of the Cloudflare REST API. */
+const CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+/**
+ * Matches a string that is exactly an environment-variable expansion, e.g.
+ * `${CLOUDFLARE_API_TOKEN}`. `spawnProcess` expands args of this exact form
+ * against the environment (which includes the API token), so any value flowing
+ * into wrangler argv must be rejected if it matches — whether it comes from
+ * config or from the Cloudflare API.
+ */
+const ENV_EXPANSION_REGEX = /^\$\{.*\}$/;
 
 /** Wrangler executable configuration */
 const WRANGLER_CONFIG = {
@@ -45,11 +65,14 @@ type CloudflareDeployType = 'pages' | 'worker';
 /** Valid deploy types */
 const DEPLOY_TYPES: readonly CloudflareDeployType[] = ['pages', 'worker'];
 
-/** Default deploy type when none is configured */
-const DEFAULT_DEPLOY_TYPE: CloudflareDeployType = 'pages';
-
-/** Default production branch passed to `wrangler pages deploy --branch` */
-const DEFAULT_PRODUCTION_BRANCH = 'main';
+/**
+ * Default deploy type when none is configured.
+ *
+ * Defaults to "worker": Cloudflare is steering new projects to Workers (with
+ * static assets) and positioning Pages as legacy, so Workers is the
+ * forward-looking default. Pages remains fully supported via `deployType: pages`.
+ */
+const DEFAULT_DEPLOY_TYPE: CloudflareDeployType = 'worker';
 
 /**
  * Regex for the Cloudflare deploy archive.
@@ -70,21 +93,30 @@ interface CloudflareConfigFields extends Record<string, unknown> {
 
 /** Target options for "cloudflare" */
 export interface CloudflareTargetConfig {
-  /** How to deploy: "pages" (default) or "worker" */
+  /** How to deploy: "worker" (default) or "pages" */
   deployType: CloudflareDeployType;
   /** Cloudflare Pages project name (required for `deployType: pages`) */
   projectName?: string;
   /**
    * The Cloudflare Pages project's production branch name. Passed to
-   * `wrangler pages deploy --branch` so a release publish always targets the
-   * production environment. This is the Cloudflare environment selector, NOT
-   * craft's git release branch.
+   * `wrangler pages deploy --branch`, which does an exact-string match against
+   * the project's server-side production branch: a match deploys to
+   * production, anything else silently deploys to *preview*. When omitted, the
+   * target reads the project's production branch from the Cloudflare API so a
+   * release always lands on production. This is the Cloudflare environment
+   * selector, NOT craft's git release branch.
    */
-  productionBranch: string;
+  productionBranch?: string;
   /** Resolved path/name of the wrangler binary */
   wranglerCliPath: string;
   /** Subdirectory within the extracted artifact to deploy from */
   workingDir?: string;
+  /**
+   * Optional Cloudflare account ID (an identifier, not a secret). Forwarded to
+   * wrangler when set; otherwise wrangler auto-discovers it for single-account
+   * tokens.
+   */
+  accountId?: string;
 }
 
 /**
@@ -99,8 +131,9 @@ export type CloudflareTargetFullConfig = CloudflareTargetConfig &
  * Shells out to the `wrangler` CLI (the reference implementation of the
  * Cloudflare deploy protocols). Two deploy modes are supported via the
  * `deployType` option:
+ *   - "worker" (default) → `wrangler deploy` (using a `wrangler.toml` in the
+ *     artifact)
  *   - "pages"  → `wrangler pages deploy <dir> --project-name <name> ...`
- *   - "worker" → `wrangler deploy` (using a `wrangler.toml` in the artifact)
  */
 export class CloudflareTarget extends BaseTarget {
   /** Target name */
@@ -153,7 +186,7 @@ export class CloudflareTarget extends BaseTarget {
       productionBranch: config.productionBranch,
       workingDir: config.workingDir,
     })) {
-      if (typeof value === 'string' && /^\$\{.*\}$/.test(value)) {
+      if (typeof value === 'string' && ENV_EXPANSION_REGEX.test(value)) {
         throw new ConfigurationError(
           `[cloudflare] "${key}" must not be an environment-variable ` +
             `expansion (got "${value}")`,
@@ -168,9 +201,13 @@ export class CloudflareTarget extends BaseTarget {
     return {
       deployType,
       projectName: config.projectName,
-      productionBranch: config.productionBranch || DEFAULT_PRODUCTION_BRANCH,
+      // No default: when unset we infer the project's production branch from
+      // the Cloudflare API at publish time (see resolveProductionBranch).
+      productionBranch: config.productionBranch,
       wranglerCliPath,
       workingDir: config.workingDir,
+      // Optional, non-secret identifier. Forwarded to wrangler when present.
+      accountId: process.env[ACCOUNT_ID_ENV_VAR] || undefined,
       ...this.getTargetSecrets(),
     };
   }
@@ -199,35 +236,143 @@ export class CloudflareTarget extends BaseTarget {
    * @param deployDir The directory to deploy from
    * @param version The version being released
    * @param revision The git commit SHA being published
+   * @param productionBranch The resolved Pages production branch, or undefined
+   *   to let wrangler decide (a bare deploy from the non-git temp dir defaults
+   *   to production)
    */
   private getWranglerArgs(
     deployDir: string,
     version: string,
     revision: string,
+    productionBranch?: string,
   ): string[] {
     if (this.cloudflareConfig.deployType === 'worker') {
       // Worker deploys use the local wrangler.toml; run with cwd=deployDir.
       return ['deploy'];
     }
 
-    // Pages deploy. `--branch <productionBranch>` forces a production
-    // deployment; the commit-* flags attach release provenance and prevent
-    // wrangler from inferring (wrong) git state from the temp directory.
-    return [
+    // Pages deploy. `wrangler pages deploy --branch <X>` deploys to production
+    // only when <X> exactly matches the project's server-side production
+    // branch; any other value silently produces a *preview* deployment. We
+    // therefore pass the resolved production branch (from config or the API)
+    // so a release reliably lands on production. The commit-* flags attach
+    // release provenance and stop wrangler from inferring (wrong) git state
+    // from the temp directory. If we couldn't resolve the branch we omit
+    // `--branch`: a bare deploy from the non-git temp dir defaults to
+    // production anyway.
+    const args = [
       'pages',
       'deploy',
       deployDir,
       '--project-name',
       this.cloudflareConfig.projectName as string,
-      '--branch',
-      this.cloudflareConfig.productionBranch,
+    ];
+    if (productionBranch) {
+      args.push('--branch', productionBranch);
+    }
+    args.push(
       '--commit-hash',
       revision,
       '--commit-message',
       `Release ${version}`,
       '--commit-dirty',
       'false',
-    ];
+    );
+    return args;
+  }
+
+  /**
+   * Resolves the Pages production branch for a `pages` deploy.
+   *
+   * Uses the configured `productionBranch` when set. Otherwise, if the account
+   * ID is known, reads the project's production branch from the Cloudflare API
+   * (`GET /accounts/{id}/pages/projects/{name}`) — the same call wrangler makes
+   * internally, so it needs no token scope beyond deploying. Returns undefined
+   * if it can't be resolved (caller then omits `--branch`).
+   */
+  private async resolveProductionBranch(): Promise<string | undefined> {
+    if (this.cloudflareConfig.productionBranch) {
+      return this.cloudflareConfig.productionBranch;
+    }
+
+    const accountId = this.cloudflareConfig.accountId;
+    const projectName = this.cloudflareConfig.projectName;
+    if (!accountId || !projectName) {
+      // Without an account ID we can't address the API. Let wrangler handle
+      // it (bare deploy from the non-git temp dir defaults to production).
+      this.logger.debug(
+        'Cloudflare: production branch not configured and account ID ' +
+          'unavailable; omitting --branch (wrangler defaults to production).',
+      );
+      return undefined;
+    }
+
+    const url =
+      `${CLOUDFLARE_API_BASE}/accounts/${encodeURIComponent(accountId)}` +
+      `/pages/projects/${encodeURIComponent(projectName)}`;
+
+    let response: Response;
+    let body: { result?: { production_branch?: string } };
+    try {
+      response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${this.cloudflareConfig.CLOUDFLARE_API_TOKEN}`,
+        },
+      });
+      // A 404 means the account/project pair is wrong -- a real
+      // misconfiguration that would otherwise be masked by the soft fallback.
+      // Handle it after the try so reportError's throw is not swallowed here.
+      if (response.status !== 404 && !response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      body =
+        response.status === 404
+          ? {}
+          : ((await response.json()) as {
+              result?: { production_branch?: string };
+            });
+    } catch (err) {
+      // Transient/network/parse failure: warn and fall back (omitting --branch
+      // still lands on production for a bare non-git deploy).
+      this.logger.warn(
+        `Cloudflare: failed to read the project's production branch ` +
+          `(${err instanceof Error ? err.message : String(err)}); omitting ` +
+          '--branch (wrangler defaults to production).',
+      );
+      return undefined;
+    }
+
+    if (response.status === 404) {
+      // Fail loudly instead of deploying to the wrong place.
+      reportError(
+        `[cloudflare] Pages project "${projectName}" not found for the ` +
+          'configured account. Check "projectName" and CLOUDFLARE_ACCOUNT_ID.',
+      );
+      return undefined;
+    }
+
+    const branch = body.result?.production_branch;
+    if (branch && ENV_EXPANSION_REGEX.test(branch)) {
+      // Defense-in-depth: never let an API-sourced value that looks like an
+      // env expansion reach wrangler argv (spawnProcess would expand it
+      // against the environment, which holds the API token).
+      this.logger.warn(
+        `Cloudflare: ignoring suspicious production branch "${branch}" ` +
+          'from the API; omitting --branch (wrangler defaults to production).',
+      );
+      return undefined;
+    }
+    if (branch) {
+      this.logger.debug(
+        `Cloudflare: inferred production branch "${branch}" from the API.`,
+      );
+      return branch;
+    }
+    this.logger.warn(
+      'Cloudflare: API response did not include a production branch; ' +
+        'omitting --branch (wrangler defaults to production).',
+    );
+    return undefined;
   }
 
   /**
@@ -266,24 +411,47 @@ export class CloudflareTarget extends BaseTarget {
           ? join(directory, this.cloudflareConfig.workingDir)
           : directory;
 
-        const args = this.getWranglerArgs(deployDir, version, revision);
-
         // A Cloudflare deploy is a remote, irreversible operation with no local
         // isolation. Unlike git/fs operations, it must NEVER run in dry-run
         // mode -- including worktree mode, where spawnProcess would otherwise
-        // execute the command for real. Guard explicitly here.
+        // execute the command for real. Guard explicitly here, before any
+        // network calls (production-branch inference also hits the API).
         if (isDryRun()) {
+          const args = this.getWranglerArgs(
+            deployDir,
+            version,
+            revision,
+            this.cloudflareConfig.productionBranch,
+          );
           logDryRun(
             `${this.cloudflareConfig.wranglerCliPath} ${args.join(' ')}`,
           );
           return;
         }
 
-        const env = {
+        // For Pages, resolve the production branch (config or API) so the
+        // deploy reliably lands on production instead of a silent preview.
+        const productionBranch =
+          this.cloudflareConfig.deployType === 'pages'
+            ? await this.resolveProductionBranch()
+            : undefined;
+
+        const args = this.getWranglerArgs(
+          deployDir,
+          version,
+          revision,
+          productionBranch,
+        );
+
+        const env: NodeJS.ProcessEnv = {
           ...process.env,
           CLOUDFLARE_API_TOKEN: this.cloudflareConfig.CLOUDFLARE_API_TOKEN,
-          CLOUDFLARE_ACCOUNT_ID: this.cloudflareConfig.CLOUDFLARE_ACCOUNT_ID,
         };
+        // Account ID is an optional identifier: forward it only when set,
+        // otherwise let wrangler auto-discover it for single-account tokens.
+        if (this.cloudflareConfig.accountId) {
+          env.CLOUDFLARE_ACCOUNT_ID = this.cloudflareConfig.accountId;
+        }
 
         this.logger.info(
           `Deploying to Cloudflare (${this.cloudflareConfig.deployType})...`,


### PR DESCRIPTION
## Summary

Follow-up to #843 addressing the review comments left on the cloudflare docs. Three behavior changes + docs/tests.

### 1. Default `deployType: worker` (was `pages`)
Cloudflare is steering new projects to Workers (with static assets) and positioning Pages as legacy, so `worker` is the forward-looking default. Pages remains fully supported via `deployType: pages`.

### 2. `CLOUDFLARE_ACCOUNT_ID` is now optional (not a secret)
The account ID is an **identifier, not a credential**. Only `CLOUDFLARE_API_TOKEN` is a required secret now. The account ID is read from the environment and forwarded to `wrangler` **only when set**; otherwise `wrangler` auto-discovers it for single-account tokens (confirmed against wrangler v4 behavior).

### 3. `productionBranch` auto-inferred for Pages
`wrangler pages deploy --branch <X>` deploys to production **only** when `<X>` exactly matches the project's server-side production branch — any other value silently produces a *preview* deploy. Previously we defaulted to `main`, which is a guess. Now:

1. If `productionBranch` is configured → used verbatim.
2. Else, if the account ID is known → read the project's `production_branch` from `GET /accounts/{id}/pages/projects/{name}` (the same call wrangler makes internally, so **no extra token scope** — Pages:Edit covers it).
3. Else → omit `--branch` (a bare deploy from the non-git temp dir defaults to production).

A **404** (wrong project/account) fails loudly rather than masking a misconfig; transient/network errors fall back to omitting `--branch`.

## Safety

- **Dry-run makes zero network calls**: the `isDryRun()` guard runs *before* both the inference `fetch()` and `spawnProcess`.
- **No token leakage**: token is env-only (never argv), and error messages don't carry it.
- **Defense-in-depth**: API-sourced branch values are also checked against the `${VAR}` env-expansion guard before reaching argv.
- No new dependency — raw global `fetch` (Node 24.18.0 baseline).

## Testing

- `pnpm test` — full suite green (1052 passed). 27 cloudflare tests covering: worker default, account-id optional/forwarded-when-set, branch inference (correct URL + `Bearer` auth header), config-branch-skips-API, 404 hard-fail, API-failure/no-account-id fallbacks, suspicious-branch guard, worker-never-calls-API, and dry-run-makes-no-fetch.
- `tsc` / `pnpm lint` clean. Docs build clean.

## Review

Adversarial subagent review: dry-run zero-network-call invariant verified by code walk; no token leak; no CRITICAL/MAJOR issues. Findings MINOR-1 (guard the API-sourced branch) and MINOR-3 (hard-fail on 404) were addressed in this PR.

Addresses review comments on #843 (productionBranch default, account-id-not-a-secret, auto-discovery/inference).

🤖 Generated with [opencode](https://opencode.ai)