### PR TITLE
fix(crates): Ignore dev dependencies when ordering packages

### DIFF
--- a/src/targets/__tests__/crates.test.ts
+++ b/src/targets/__tests__/crates.test.ts
@@ -76,4 +76,27 @@ describe('getPublishOrder', () => {
     const sortedPackages = [p2, p1];
     expect(target.getPublishOrder(packages)).toEqual(sortedPackages);
   });
+
+  test('excludes versioned dev dependencies when noDevDeps is false', () => {
+    const targetWithoutNoDevDeps = new CratesTarget(
+      {
+        name: 'crates',
+        noDevDeps: false,
+      },
+      new NoneArtifactProvider(),
+      { owner: 'getsentry', repo: 'craft' },
+    );
+    const packages = ['p1', 'p2'].map(cratePackageFactory);
+    const [p1, p2] = packages;
+
+    p1.dependencies = [cratePackageToDependency(p2)];
+    p2.dependencies = [
+      makeDev({
+        ...cratePackageToDependency(p1),
+        req: '^1.0.0',
+      }),
+    ];
+
+    expect(targetWithoutNoDevDeps.getPublishOrder(packages)).toEqual([p2, p1]);
+  });
 });

--- a/src/targets/crates.ts
+++ b/src/targets/crates.ts
@@ -238,14 +238,10 @@ export class CratesTarget extends BaseTarget {
     const ordered: CratePackage[] = [];
 
     const isWorkspaceDependency = (dep: CrateDependency) => {
-      // Optionally exclude dev dependencies from dependency resolution. When
-      // this flag is provided, these usually lead to circular dependencies.
-      // Path-only dependencies are designated by `req = *`, and are not being
-      // validated by cargo on publish.
-      if (
-        dep.kind === 'dev' &&
-        (dep.req === '*' || this.cratesConfig.noDevDeps)
-      ) {
+      // Dev dependencies are not required to publish a crate, regardless of
+      // whether noDevDeps removes them from the package. They must not affect
+      // publication order, including path-only and versioned dependencies.
+      if (dep.kind === 'dev') {
         return false;
       }
 


### PR DESCRIPTION
Cargo dev-dependencies are not required to publish a crate, but the publish-order graph previously treated versioned dev-dependencies as workspace edges when `noDevDeps` was false. A valid graph such as sentry -> sentry-core with the reverse edge used only for doctests was therefore reported as circular. This failure [can be observed here](https://github.com/getsentry/publish/actions/runs/30360035005/job/90277265724).

Ignore all dev-dependencies while calculating publish order, independently of `noDevDeps`. Keep `noDevDeps` responsible only for selecting cargo-hack publish behavior, and add regression coverage for the default configuration with a versioned dev-dependency.

Closes #856
