### PR TITLE
feat(aws-lambda-layer): Add CompatibleArchitectures and per-region failure improvements

### DIFF
--- a/docs/src/content/docs/targets/aws-lambda-layer.md
+++ b/docs/src/content/docs/targets/aws-lambda-layer.md
@@ -11,6 +11,7 @@ Creates a new public Lambda layer in each available AWS region and updates the S
 |--------|-------------|
 | `layerName` | Name of the Lambda layer. Supports template variables (see below) |
 | `compatibleRuntimes` | List of runtime configurations |
+| `compatibleArchitectures` | Optional list of instruction set architectures (`x86_64`, `arm64`) |
 | `license` | Layer license |
 | `linkPrereleases` | Publish layers for preview/pre-release versions. Default: `false` |
 | `includeNames` | Must filter to exactly one artifact |
@@ -42,6 +43,9 @@ compatibleRuntimes:
     versions:
       - nodejs10.x
       - nodejs12.x
+compatibleArchitectures:
+  - x86_64
+  - arm64
 ```
 
 ## Environment Variables
@@ -65,6 +69,9 @@ targets:
         versions:
           - nodejs10.x
           - nodejs12.x
+    compatibleArchitectures:
+      - x86_64
+      - arm64
     license: MIT
 ```
 

--- a/docs/src/content/docs/targets/aws-lambda-layer.md
+++ b/docs/src/content/docs/targets/aws-lambda-layer.md
@@ -67,8 +67,8 @@ targets:
     compatibleRuntimes:
       - name: node
         versions:
-          - nodejs10.x
-          - nodejs12.x
+          - nodejs22.x
+          - nodejs24.x
     compatibleArchitectures:
       - x86_64
       - arm64

--- a/src/targets/__tests__/awsLambda.test.ts
+++ b/src/targets/__tests__/awsLambda.test.ts
@@ -31,6 +31,7 @@ function setTestingProjectConfig(awsTarget: AwsLambdaLayerTarget) {
       versions: ['nodejs10.x', 'nodejs12.x'],
     },
   ];
+  awsTarget.config.compatibleArchitectures = ['x86_64', 'arm64'];
   awsTarget.config.license = 'MIT';
 }
 
@@ -80,6 +81,7 @@ describe('project config parameters', () => {
   function clearConfig(awsTarget: AwsLambdaLayerTarget): void {
     delete awsTarget.config.layerName;
     delete awsTarget.config.compatibleRuntimes;
+    delete awsTarget.config.compatibleArchitectures;
     delete awsTarget.config.license;
   }
 

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -348,17 +348,26 @@ export class AwsLambdaLayerTarget extends BaseTarget {
         });
 
         // Common data specific to all the layers in the current runtime.
-        const runtimeData = {
+        const runtimeData: {
+          canonical: string;
+          sdk_version: string;
+          account_number: string;
+          layer_name: string;
+          regions: { region: string; version: string }[];
+          compatible_runtimes: string[];
+          compatible_architectures?: string[];
+        } = {
           canonical: layerManager.getCanonicalName(),
           sdk_version: version,
           account_number: getAccountFromArn(publishedLayers[0].arn),
           layer_name: resolvedLayerName,
           regions: regionsVersions,
           compatible_runtimes: runtime.versions,
-          ...(compatibleArchitectures?.length
-            ? { compatible_architectures: compatibleArchitectures }
-            : {}),
         };
+
+        if (compatibleArchitectures?.length) {
+          runtimeData.compatible_architectures = compatibleArchitectures;
+        }
 
         const baseFilepath = path.posix.join(
           runtimeBaseDir,

--- a/src/targets/awsLambdaLayer.ts
+++ b/src/targets/awsLambdaLayer.ts
@@ -42,6 +42,7 @@ interface AwsLambdaTargetConfig {
 interface AwsLambdaTargetYamlConfig extends Record<string, unknown> {
   linkPrereleases?: boolean;
   compatibleRuntimes?: CompatibleRuntime[];
+  compatibleArchitectures?: string[];
   license?: string;
 }
 
@@ -290,6 +291,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
     this.logger.debug(`Resolved layer name: ${resolvedLayerName}`);
 
     const config = this.config as TypedTargetConfig<AwsLambdaTargetYamlConfig>;
+    const compatibleArchitectures = config.compatibleArchitectures;
     await Promise.all(
       config.compatibleRuntimes!.map(async (runtime: CompatibleRuntime) => {
         this.logger.debug(`Publishing runtime ${runtime.name}...`);
@@ -300,6 +302,7 @@ export class AwsLambdaLayerTarget extends BaseTarget {
           artifactBuffer,
           awsRegions,
           version,
+          compatibleArchitectures,
         );
 
         let publishedLayers = [];
@@ -351,6 +354,10 @@ export class AwsLambdaLayerTarget extends BaseTarget {
           account_number: getAccountFromArn(publishedLayers[0].arn),
           layer_name: resolvedLayerName,
           regions: regionsVersions,
+          compatible_runtimes: runtime.versions,
+          ...(compatibleArchitectures?.length
+            ? { compatible_architectures: compatibleArchitectures }
+            : {}),
         };
 
         const baseFilepath = path.posix.join(

--- a/src/utils/__tests__/awsLambdaLayerManager.test.ts
+++ b/src/utils/__tests__/awsLambdaLayerManager.test.ts
@@ -1,20 +1,57 @@
 import { vi } from 'vitest';
 import * as awsManager from '../awsLambdaLayerManager';
 
-vi.mock('../../logger');
+const {
+  mockState,
+  mockLambdaConstructor,
+  mockPublishLayerVersion,
+  mockAddLayerVersionPermission,
+  mockLoggerError,
+  mockCaptureException,
+} = vi.hoisted(() => ({
+  mockState: { failRegion: undefined as string | undefined },
+  mockLambdaConstructor: vi.fn(),
+  mockPublishLayerVersion: vi.fn(),
+  mockAddLayerVersionPermission: vi.fn().mockResolvedValue({}),
+  mockLoggerError: vi.fn(),
+  mockCaptureException: vi.fn(),
+}));
 
-const mockPublishLayerVersion = vi.fn().mockResolvedValue({
+vi.mock('../../logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  },
+}));
+
+vi.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+const SUCCESSFUL_LAYER = {
   LayerVersionArn: 'arn:aws:lambda:test-region:123456789:layer:test-layer:1',
   Version: 1,
-});
-const mockAddLayerVersionPermission = vi.fn().mockResolvedValue({});
+};
 
 vi.mock('@aws-sdk/client-lambda', () => ({
-  Lambda: vi.fn().mockImplementation(function (this: any) {
-    this.publishLayerVersion = mockPublishLayerVersion;
+  Lambda: vi.fn().mockImplementation(function (
+    this: any,
+    config: { region: string; maxAttempts: number },
+  ) {
+    mockLambdaConstructor(config);
+    this.publishLayerVersion = async (...args: unknown[]) => {
+      mockPublishLayerVersion(...args);
+      if (mockState.failRegion && config.region === mockState.failRegion) {
+        throw new Error('AccessDeniedException');
+      }
+      return SUCCESSFUL_LAYER;
+    };
     this.addLayerVersionPermission = mockAddLayerVersionPermission;
   }),
   Runtime: {},
+  Architecture: {},
 }));
 
 const CANONICAL_SEPARATOR = ':';
@@ -23,9 +60,12 @@ const COMPATIBLE_RUNTIME_DATA = {
   name: 'test runtime',
   versions: ['test version 1', 'test version 2'],
 };
+const COMPATIBLE_ARCHITECTURES = ['x86_64', 'arm64'];
 const AWS_TEST_REGIONS = ['test aws region 1', 'test aws region 2'];
 
-function getTestAwsLambdaLayerManager(): awsManager.AwsLambdaLayerManager {
+function getTestAwsLambdaLayerManager(
+  architectures?: string[],
+): awsManager.AwsLambdaLayerManager {
   return new awsManager.AwsLambdaLayerManager(
     COMPATIBLE_RUNTIME_DATA,
     'test layer name',
@@ -33,6 +73,7 @@ function getTestAwsLambdaLayerManager(): awsManager.AwsLambdaLayerManager {
     Buffer.alloc(0),
     AWS_TEST_REGIONS,
     '0.0.0',
+    architectures,
   );
 }
 
@@ -56,17 +97,59 @@ describe('utils', () => {
 });
 
 describe('layer publishing', () => {
+  beforeEach(() => {
+    mockState.failRegion = undefined;
+    mockLambdaConstructor.mockClear();
+    mockPublishLayerVersion.mockClear();
+    mockAddLayerVersionPermission.mockClear();
+    mockLoggerError.mockClear();
+    mockCaptureException.mockClear();
+  });
+
   test('publish to single region', async () => {
     const regionTest = 'region-test';
     const manager = getTestAwsLambdaLayerManager();
     const publishedLayer = await manager.publishLayerToRegion(regionTest);
     expect(publishedLayer.region).toStrictEqual(regionTest);
+    expect(mockLambdaConstructor).toHaveBeenCalledWith({
+      region: regionTest,
+      maxAttempts: 3,
+    });
+    expect(mockPublishLayerVersion).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        CompatibleArchitectures: expect.anything(),
+      }),
+    );
+  });
+
+  test('publish with compatible architectures', async () => {
+    const manager = getTestAwsLambdaLayerManager(COMPATIBLE_ARCHITECTURES);
+    await manager.publishLayerToRegion('region-test');
+    expect(mockPublishLayerVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        CompatibleRuntimes: COMPATIBLE_RUNTIME_DATA.versions,
+        CompatibleArchitectures: COMPATIBLE_ARCHITECTURES,
+      }),
+    );
   });
 
   test('publish to all regions', async () => {
     const manager = getTestAwsLambdaLayerManager();
-    const pubishedLayers = await manager.publishToAllRegions();
-    const publishedRegions = pubishedLayers.map(layer => layer.region);
-    expect(publishedRegions).toStrictEqual(AWS_TEST_REGIONS);
+    const publishedLayers = await manager.publishToAllRegions();
+    expect(publishedLayers.map(layer => layer.region)).toStrictEqual(
+      AWS_TEST_REGIONS,
+    );
+  });
+
+  test('failed region does not block other regions', async () => {
+    mockState.failRegion = AWS_TEST_REGIONS[1];
+    const manager = getTestAwsLambdaLayerManager();
+    const publishedLayers = await manager.publishToAllRegions();
+
+    expect(publishedLayers.map(layer => layer.region)).toStrictEqual([
+      AWS_TEST_REGIONS[0],
+    ]);
+    expect(mockLoggerError).toHaveBeenCalled();
+    expect(mockCaptureException).toHaveBeenCalled();
   });
 });

--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -91,9 +91,9 @@ export class AwsLambdaLayerManager {
       CompatibleRuntimes: this.runtime.versions as Runtime[],
       ...(this.compatibleArchitectures?.length
         ? {
-          CompatibleArchitectures: this
-            .compatibleArchitectures as Architecture[],
-        }
+            CompatibleArchitectures: this
+              .compatibleArchitectures as Architecture[],
+          }
         : {}),
       LicenseInfo: this.license,
       Description: `Sentry AWS Serverless SDK v${this.sdkVersion}`,

--- a/src/utils/awsLambdaLayerManager.ts
+++ b/src/utils/awsLambdaLayerManager.ts
@@ -1,7 +1,8 @@
 import { XMLParser } from 'fast-xml-parser';
 import aws4 from 'aws4';
 import fetch from 'node-fetch';
-import { Lambda, Runtime } from '@aws-sdk/client-lambda';
+import { Architecture, Lambda, Runtime } from '@aws-sdk/client-lambda';
+import { captureException } from '@sentry/node';
 import { logger } from '../logger';
 
 /** Prefix of the canonical name. */
@@ -10,6 +11,8 @@ const RUNTIME_CANONICAL_PREFIX = 'aws-layer:';
 const ARN_SEPARATOR = ':';
 /** Index (0-based) of the account number in the ARN. */
 const ARN_ACCOUNT_INDEX = 4;
+/** Total AWS SDK attempts per operation, including the initial request. */
+const AWS_MAX_ATTEMPTS = 3;
 
 /**
  * Info for a runtime.
@@ -35,6 +38,8 @@ interface PublishedLayer {
 export class AwsLambdaLayerManager {
   /** Compatible runtimes with the new layer.  */
   private runtime: CompatibleRuntime;
+  /** Compatible architectures with the new layer. */
+  private compatibleArchitectures?: string[];
   /** Regions to publish the layer to. */
   private awsRegions: string[] = [];
   /** Name of the layer to be published. */
@@ -55,6 +60,7 @@ export class AwsLambdaLayerManager {
     artifactBuffer: Buffer,
     awsRegions: string[],
     sdkVersion: string,
+    compatibleArchitectures?: string[],
   ) {
     this.runtime = runtime;
     this.layerName = layerName;
@@ -62,6 +68,7 @@ export class AwsLambdaLayerManager {
     this.artifactBuffer = artifactBuffer;
     this.awsRegions = awsRegions;
     this.sdkVersion = sdkVersion;
+    this.compatibleArchitectures = compatibleArchitectures;
   }
 
   /**
@@ -71,13 +78,23 @@ export class AwsLambdaLayerManager {
    */
   public async publishLayerToRegion(region: string): Promise<PublishedLayer> {
     logger.debug(`Publishing layer to ${region}...`);
-    const lambda = new Lambda({ region: region });
+    // Let the AWS SDK retry transient failures with exponential backoff.
+    const lambda = new Lambda({
+      region,
+      maxAttempts: AWS_MAX_ATTEMPTS,
+    });
     const publishedLayer = await lambda.publishLayerVersion({
       Content: {
         ZipFile: this.artifactBuffer,
       },
       LayerName: this.layerName,
       CompatibleRuntimes: this.runtime.versions as Runtime[],
+      ...(this.compatibleArchitectures?.length
+        ? {
+          CompatibleArchitectures: this
+            .compatibleArchitectures as Architecture[],
+        }
+        : {}),
       LicenseInfo: this.license,
       Description: `Sentry AWS Serverless SDK v${this.sdkVersion}`,
     });
@@ -103,26 +120,57 @@ export class AwsLambdaLayerManager {
 
   /**
    * Publishes new AWS Lambda layers to all the regions.
-   *
-   * @returns Array of the published layers.
+   * Failed regions are reported, but do not block the release.
+   * @returns Array of the successfully published layers.
    */
   public async publishToAllRegions(): Promise<PublishedLayer[]> {
-    const publishedLayers = await Promise.all(
-      this.awsRegions.map(async region => {
+    type RegionResult =
+      | { region: string; layer: PublishedLayer }
+      | { region: string; error: Error };
+
+    const results: RegionResult[] = await Promise.all(
+      this.awsRegions.map(async (region): Promise<RegionResult> => {
         try {
-          return await this.publishLayerToRegion(region);
+          const layer = await this.publishLayerToRegion(region);
+          return { region, layer: layer };
         } catch (error) {
-          logger.warn(
-            'Something went wrong with AWS trying to publish to region ' +
-              `${region}: ${error.message}`,
-          );
-          return undefined;
+          return {
+            region,
+            error: error instanceof Error ? error : new Error(String(error)),
+          };
         }
       }),
     );
-    return publishedLayers.filter(layer => {
-      return layer !== undefined;
-    }) as PublishedLayer[];
+
+    const failed = results.filter(
+      (result): result is { region: string; error: Error } => 'error' in result,
+    );
+    if (failed.length) {
+      const summary =
+        `Layer published with ${failed.length} failed region(s) for ` +
+        `${this.runtime.name}: ${failed.map(f => f.region).join(', ')}`;
+      logger.error(summary);
+      for (const { region, error } of failed) {
+        logger.error(`  ${region}: ${error.message}`);
+      }
+      captureException(new Error(summary), {
+        extra: {
+          runtime: this.runtime.name,
+          sdkVersion: this.sdkVersion,
+          failedRegions: failed.map(f => ({
+            region: f.region,
+            message: f.error.message,
+          })),
+        },
+      });
+    }
+
+    return results
+      .filter(
+        (result): result is { region: string; layer: PublishedLayer } =>
+          'layer' in result,
+      )
+      .map(result => result.layer);
   }
 
   /**


### PR DESCRIPTION
- Introduce `compatibleArchitectures` parameter allowing specification of supported instruction set architectures (`x86_64`, `arm64`).
- Updated tests to cover scenarios involving new parameter.
- Make per-region publishing failure more prominent; perform 2 additional requests after initial one fails

Refs: #860