### PR TITLE
feat(vercel): allow project ID in target config

### DIFF
--- a/docs/src/content/docs/targets/vercel.md
+++ b/docs/src/content/docs/targets/vercel.md
@@ -61,4 +61,4 @@ targets:
 
 1. Build the site in CI (e.g. `vercel build`) and create a `vercel.zip` artifact containing the prebuilt `.vercel/output` (or the source when `prebuilt: false`).
 2. Configure the target in `.craft.yml`.
-3. Set `VERCEL_TOKEN` in your environment and `VERCEL_ORG_ID` for the team. Set `projectId` in `.craft.yml`, or set `VERCEL_PROJECT_ID` when the shared publish environment must override the repository config.
+3. Set `VERCEL_TOKEN` in your environment. Set `orgId` and `projectId` in `.craft.yml`, or set `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` when the shared publish environment must override the repository config.

--- a/docs/src/content/docs/targets/vercel.md
+++ b/docs/src/content/docs/targets/vercel.md
@@ -13,6 +13,7 @@ The target extracts a ZIP artifact and deploys it via the Vercel deploy API (usi
 |--------|-------------|
 | `prebuilt` | Whether the artifact contains a prebuilt `.vercel/output` (the result of `vercel build`). When `true` (default), the artifact's prebuilt `.vercel/output` is uploaded and the remote build step is skipped. Set to `false` to have Vercel build from source. |
 | `workingDir` | Subdirectory within the extracted artifact to deploy from. |
+| `orgId` | Vercel organization/team ID. Use this for a repository-specific team; `VERCEL_ORG_ID` overrides it when set. |
 | `projectId` | Vercel project ID. Use this for a repository-specific project; `VERCEL_PROJECT_ID` overrides it when set. |
 
 ## Environment Variables
@@ -42,6 +43,7 @@ The version being released is attached to the deployment as metadata (`release=<
 ```yaml
 targets:
   - name: vercel
+    orgId: team_example
     projectId: prj_example
     # prebuilt defaults to true: the docs site is built in CI and this
     # target only promotes the prebuilt output to production.

--- a/docs/src/content/docs/targets/vercel.md
+++ b/docs/src/content/docs/targets/vercel.md
@@ -13,6 +13,7 @@ The target extracts a ZIP artifact and deploys it via the Vercel deploy API (usi
 |--------|-------------|
 | `prebuilt` | Whether the artifact contains a prebuilt `.vercel/output` (the result of `vercel build`). When `true` (default), the artifact's prebuilt `.vercel/output` is uploaded and the remote build step is skipped. Set to `false` to have Vercel build from source. |
 | `workingDir` | Subdirectory within the extracted artifact to deploy from. |
+| `projectId` | Vercel project ID. Use this for a repository-specific project; `VERCEL_PROJECT_ID` overrides it when set. |
 
 ## Environment Variables
 
@@ -41,6 +42,7 @@ The version being released is attached to the deployment as metadata (`release=<
 ```yaml
 targets:
   - name: vercel
+    projectId: prj_example
     # prebuilt defaults to true: the docs site is built in CI and this
     # target only promotes the prebuilt output to production.
 ```
@@ -57,4 +59,4 @@ targets:
 
 1. Build the site in CI (e.g. `vercel build`) and create a `vercel.zip` artifact containing the prebuilt `.vercel/output` (or the source when `prebuilt: false`).
 2. Configure the target in `.craft.yml`.
-3. Set `VERCEL_TOKEN` in your environment, plus `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` so the deploy targets the right project.
+3. Set `VERCEL_TOKEN` in your environment and `VERCEL_ORG_ID` for the team. Set `projectId` in `.craft.yml`, or set `VERCEL_PROJECT_ID` when the shared publish environment must override the repository config.

--- a/src/targets/__tests__/vercel.test.ts
+++ b/src/targets/__tests__/vercel.test.ts
@@ -137,12 +137,26 @@ describe('vercel target configuration', () => {
     expect(target.vercelConfig.projectId).toBe(PROJECT_ID);
   });
 
+  test('picks up orgId from target config', () => {
+    const target = createVercelTarget({ orgId: ORG_ID });
+
+    expect(target.vercelConfig.orgId).toBe(ORG_ID);
+  });
+
   test('prefers VERCEL_PROJECT_ID over target config', () => {
     const envProjectId = 'prj_from_env';
     process.env.VERCEL_PROJECT_ID = envProjectId;
     const target = createVercelTarget({ projectId: PROJECT_ID });
 
     expect(target.vercelConfig.projectId).toBe(envProjectId);
+  });
+
+  test('prefers VERCEL_ORG_ID over target config', () => {
+    const envOrgId = 'org_from_env';
+    process.env.VERCEL_ORG_ID = envOrgId;
+    const target = createVercelTarget({ orgId: ORG_ID });
+
+    expect(target.vercelConfig.orgId).toBe(envOrgId);
   });
 
   test('allows overriding default options', () => {

--- a/src/targets/__tests__/vercel.test.ts
+++ b/src/targets/__tests__/vercel.test.ts
@@ -131,6 +131,20 @@ describe('vercel target configuration', () => {
     expect(target.vercelConfig.projectId).toBe(PROJECT_ID);
   });
 
+  test('picks up projectId from target config', () => {
+    const target = createVercelTarget({ projectId: PROJECT_ID });
+
+    expect(target.vercelConfig.projectId).toBe(PROJECT_ID);
+  });
+
+  test('prefers VERCEL_PROJECT_ID over target config', () => {
+    const envProjectId = 'prj_from_env';
+    process.env.VERCEL_PROJECT_ID = envProjectId;
+    const target = createVercelTarget({ projectId: PROJECT_ID });
+
+    expect(target.vercelConfig.projectId).toBe(envProjectId);
+  });
+
   test('allows overriding default options', () => {
     const target = createVercelTarget({
       prebuilt: false,

--- a/src/targets/vercel.ts
+++ b/src/targets/vercel.ts
@@ -51,6 +51,7 @@ const DEFAULT_DEPLOY_ARCHIVE_REGEX = /^(?:.+-)?vercel\.zip$/;
 interface VercelConfigFields extends Record<string, unknown> {
   prebuilt?: boolean;
   workingDir?: string;
+  projectId?: string;
 }
 
 /** Target options for "vercel" */
@@ -122,7 +123,10 @@ export class VercelTarget extends BaseTarget {
       workingDir: config.workingDir,
       // Optional, non-secret identifiers. Forwarded to the deploy when present.
       orgId: process.env[ORG_ID_ENV_VAR] || undefined,
-      projectId: process.env[PROJECT_ID_ENV_VAR] || undefined,
+      // An environment variable overrides the target config so shared publish
+      // infrastructure can select a project without changing the repository.
+      projectId:
+        process.env[PROJECT_ID_ENV_VAR] || config.projectId || undefined,
       ...this.getTargetSecrets(),
     };
   }

--- a/src/targets/vercel.ts
+++ b/src/targets/vercel.ts
@@ -51,6 +51,7 @@ const DEFAULT_DEPLOY_ARCHIVE_REGEX = /^(?:.+-)?vercel\.zip$/;
 interface VercelConfigFields extends Record<string, unknown> {
   prebuilt?: boolean;
   workingDir?: string;
+  orgId?: string;
   projectId?: string;
 }
 
@@ -122,7 +123,9 @@ export class VercelTarget extends BaseTarget {
       prebuilt: config.prebuilt ?? true,
       workingDir: config.workingDir,
       // Optional, non-secret identifiers. Forwarded to the deploy when present.
-      orgId: process.env[ORG_ID_ENV_VAR] || undefined,
+      // Environment variables override target config for shared publish
+      // infrastructure.
+      orgId: process.env[ORG_ID_ENV_VAR] || config.orgId || undefined,
       // An environment variable overrides the target config so shared publish
       // infrastructure can select a project without changing the repository.
       projectId:


### PR DESCRIPTION
## Summary

- allow the `vercel` target to configure `projectId` in `.craft.yml`
- keep `VERCEL_PROJECT_ID` as an environment override for shared publish infrastructure
- add regression tests and document the precedence

## Verification

- `pnpm exec vitest run src/targets/__tests__/vercel.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm exec prettier --check src/targets/vercel.ts src/targets/__tests__/vercel.test.ts docs/src/content/docs/targets/vercel.md`