### PR TITLE
fix(vercel): pass prebuilt output directory

### DIFF
--- a/src/targets/__tests__/vercel.test.ts
+++ b/src/targets/__tests__/vercel.test.ts
@@ -205,6 +205,7 @@ describe('publish', () => {
     expect(clientOptions.token).toBe(DEFAULT_SECRET_VALUE);
     expect(clientOptions.path).toBe(TMP_DIR);
     expect(clientOptions.prebuilt).toBe(true);
+    expect(clientOptions.vercelOutputDir).toBe(`${TMP_DIR}/.vercel/output`);
     expect(clientOptions.skipAutoDetectionConfirmation).toBe(true);
     expect(deploymentOptions.target).toBe('production');
     expect(deploymentOptions.meta.release).toBe(version);
@@ -219,6 +220,7 @@ describe('publish', () => {
 
     const [clientOptions] = (createDeployment as any).mock.calls[0];
     expect(clientOptions.prebuilt).toBe(false);
+    expect(clientOptions.vercelOutputDir).toBeUndefined();
   });
 
   test('does not forward org/project IDs when unset', async () => {

--- a/src/targets/__tests__/vercel.test.ts
+++ b/src/targets/__tests__/vercel.test.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { join } from 'path';
 
 import { createDeployment } from '@vercel/client';
 
@@ -205,7 +206,9 @@ describe('publish', () => {
     expect(clientOptions.token).toBe(DEFAULT_SECRET_VALUE);
     expect(clientOptions.path).toBe(TMP_DIR);
     expect(clientOptions.prebuilt).toBe(true);
-    expect(clientOptions.vercelOutputDir).toBe(`${TMP_DIR}/.vercel/output`);
+    expect(clientOptions.vercelOutputDir).toBe(
+      join(TMP_DIR, '.vercel', 'output'),
+    );
     expect(clientOptions.skipAutoDetectionConfirmation).toBe(true);
     expect(deploymentOptions.target).toBe('production');
     expect(deploymentOptions.meta.release).toBe(version);

--- a/src/targets/vercel.ts
+++ b/src/targets/vercel.ts
@@ -182,6 +182,9 @@ export class VercelTarget extends BaseTarget {
         token: this.vercelConfig.VERCEL_TOKEN,
         path: deployDir,
         prebuilt: this.vercelConfig.prebuilt,
+        vercelOutputDir: this.vercelConfig.prebuilt
+          ? join(deployDir, '.vercel', 'output')
+          : undefined,
         teamId: this.vercelConfig.orgId,
         skipAutoDetectionConfirmation: true,
       },


### PR DESCRIPTION
## Summary

- pass `.vercel/output` as `vercelOutputDir` for prebuilt deployments
- omit the option for source deployments
- add regression assertions for both paths

`@vercel/client` requires `vercelOutputDir` whenever `prebuilt` is true.

## Verification

- `pnpm exec vitest run src/targets/__tests__/vercel.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm exec prettier --check src/targets/vercel.ts src/targets/__tests__/vercel.test.ts`